### PR TITLE
fix(#7325): guard webhook dispatcher env casts against malformed input

### DIFF
--- a/tools/webhooks/webhook_server.py
+++ b/tools/webhooks/webhook_server.py
@@ -46,11 +46,30 @@ logging.basicConfig(
 log = logging.getLogger("webhook-dispatcher")
 
 # ---------------------------------------------------------------------------
+# Safe numeric casts — guard against malformed env values at import time
+# ---------------------------------------------------------------------------
+def _safe_int(val: str, default: int) -> int:
+    """Cast *val* to int, returning *default* on malformed/empty input."""
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        return default
+
+
+def _safe_float(val: str, default: float) -> float:
+    """Cast *val* to float, returning *default* on malformed/empty input."""
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return default
+
+
+# ---------------------------------------------------------------------------
 # Constants & defaults
 # ---------------------------------------------------------------------------
 DEFAULT_NODE_URL = os.getenv("RUSTCHAIN_NODE", "http://localhost:5000")
-DEFAULT_POLL_INTERVAL = int(os.getenv("WEBHOOK_POLL_INTERVAL", "10"))
-DEFAULT_LARGE_TX_THRESHOLD = float(os.getenv("LARGE_TX_THRESHOLD", "100.0"))
+DEFAULT_POLL_INTERVAL = _safe_int(os.getenv("WEBHOOK_POLL_INTERVAL", "10"), 10)
+DEFAULT_LARGE_TX_THRESHOLD = _safe_float(os.getenv("LARGE_TX_THRESHOLD", "100.0"), 100.0)
 DEFAULT_DB_PATH = os.getenv("WEBHOOK_DB", "webhooks.db")
 MAX_ADMIN_BODY_BYTES = 1024 * 1024
 MAX_RETRIES = 5


### PR DESCRIPTION
## Summary
Hardens `tools/webhooks/webhook_server.py` so a malformed numeric env value (e.g. `WEBHOOK_POLL_INTERVAL=fast`, `LARGE_TX_THRESHOLD=huge`) no longer import-crashes the webhook dispatcher — it falls back to the existing defaults instead.

## Changes
- `tools/webhooks/webhook_server.py` (+21 / -2):
  - Add module-level `_safe_int(val, default)` and `_safe_float(val, default)` helpers that swallow `ValueError` / `TypeError` and return the provided default.
  - Replace the two module-level casts:
    - `DEFAULT_POLL_INTERVAL = int(os.getenv("WEBHOOK_POLL_INTERVAL", "10"))` → `_safe_int(..., 10)`
    - `DEFAULT_LARGE_TX_THRESHOLD = float(os.getenv("LARGE_TX_THRESHOLD", "100.0"))` → `_safe_float(..., 100.0)`
  - No behavior change for valid / unset env values; defaults remain `10s` and `100.0 RTC`.

## Why this approach
- Smallest possible diff: the existing tool already has safe defaults baked in — the cast was the only thing that prevented them from being used.
- Mirrors the same pattern maintainers accepted in the analogous tools:
  - #7321 — `tools/prometheus/rustchain_exporter.py`
  - #7323 — `tools/miner_alerts/miner_alerts.py`
- Strict scope: no CLI flags, defaults, admin routes, or runtime behavior touched. Module-level constants used elsewhere (e.g. `DEFAULT_POLL_INTERVAL` passed into the polling thread) keep their public names and types.

## Testing
```bash
# All four scenarios pass on this branch:
python3 -c "import sys; sys.path.insert(0,'tools/webhooks'); import webhook_server; \
  assert webhook_server.DEFAULT_POLL_INTERVAL == 10 and webhook_server.DEFAULT_LARGE_TX_THRESHOLD == 100.0"
# → defaults preserved

WEBHOOK_POLL_INTERVAL=fast LARGE_TX_THRESHOLD=huge python3 -c "import sys; sys.path.insert(0,'tools/webhooks'); import webhook_server"
# → import succeeds, falls back to 10 / 100.0 (this was the bug)

WEBHOOK_POLL_INTERVAL="" LARGE_TX_THRESHOLD="" python3 -c "..."
# → falls back to 10 / 100.0

WEBHOOK_POLL_INTERVAL=30 LARGE_TX_THRESHOLD=500.5 python3 -c "..."
# → override still applied (30 / 500.5)
```

Module imports cleanly in all four cases. No other call sites needed changes — the two affected constants are the only module-level `int(...)` / `float(...)` casts of `os.getenv(...)` in the file (verified via `grep -nE 'int\(os\.getenv|float\(os\.getenv'`).

## Manual verification
- `python3 -c "import sys; sys.path.insert(0,'tools/webhooks'); import webhook_server; print(webhook_server.DEFAULT_POLL_INTERVAL, webhook_server.DEFAULT_LARGE_TX_THRESHOLD)"` → `10 100.0`
- Same command with `WEBHOOK_POLL_INTERVAL=fast LARGE_TX_THRESHOLD=huge` prefixed → exits 0, prints `10 100.0` (previously raised `ValueError` at import).

## Trade-offs
- Malformed values are silently coerced to the default rather than raising. This matches the issue's expected behavior ("fall back instead of import-crashing") and the precedent set in #7321 / #7323. If louder feedback is wanted later, the helpers can be extended to emit a `logging.warning(...)` — left out here to keep the diff focused on the reported bug.

Closes #7325
