### PR TITLE
fix(#7323): guard miner_alerts env casts against malformed input

### DIFF
--- a/tests/test_miner_alerts.py
+++ b/tests/test_miner_alerts.py
@@ -313,3 +313,81 @@ def test_fetch_helpers_parse_success_and_errors(miner_alerts_module, monkeypatch
     )
     assert miner_alerts_module.fetch_miners() == []
     assert miner_alerts_module.fetch_balance("miner-a") is None
+
+
+# Regression tests for issue #7323: env-var casts must not crash at import time.
+@pytest.fixture()
+def miner_alerts_safe_module(tmp_path, monkeypatch):
+    """Load a fresh copy of miner_alerts with the given env-var state.
+
+    The script lives at ``tools/miner_alerts/miner_alerts.py`` without an
+    ``__init__`` file, so we load it via ``spec_from_file_location`` (the same
+    pattern used by the ``miner_alerts_module`` fixture above).
+    """
+    fake_dotenv = types.SimpleNamespace(load_dotenv=lambda: None)
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "tools"
+        / "miner_alerts"
+        / "miner_alerts.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "miner_alerts_for_safe_tests", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_safe_int_falls_back_on_malformed_input(miner_alerts_safe_module):
+    safe_int = miner_alerts_safe_module._safe_int
+
+    assert safe_int("123", 999) == 123
+    assert safe_int("-7", 999) == -7
+    assert safe_int("", 999) == 999
+    assert safe_int(None, 999) == 999
+    assert safe_int("not-a-number", 999) == 999
+    # int() rejects non-integer numeric strings — fall back to default.
+    assert safe_int("12.5", 999) == 999
+
+
+def test_safe_float_falls_back_on_malformed_input(miner_alerts_safe_module):
+    safe_float = miner_alerts_safe_module._safe_float
+
+    assert safe_float("10.0", 99.0) == 10.0
+    assert safe_float("-2.5", 99.0) == -2.5
+    assert safe_float("", 99.0) == 99.0
+    assert safe_float(None, 99.0) == 99.0
+    assert safe_float("banana", 99.0) == 99.0
+
+
+def test_module_imports_with_malformed_numeric_env_vars(
+    monkeypatch,
+):
+    """Issue #7323: misconfigured numeric env vars must not crash import."""
+    monkeypatch.setenv("POLL_INTERVAL", "two-minutes")
+    monkeypatch.setenv("OFFLINE_THRESHOLD", "")
+    monkeypatch.setenv("LARGE_TRANSFER_THRESHOLD", "high")
+    monkeypatch.setenv("SMTP_PORT", "  ")
+
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "tools"
+        / "miner_alerts"
+        / "miner_alerts.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "miner_alerts_safe_import_7323", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    # The import must succeed even when env values are malformed.
+    spec.loader.exec_module(module)
+
+    assert module.POLL_INTERVAL == 120
+    assert module.OFFLINE_THRESHOLD == 600
+    assert module.LARGE_TRANSFER_THRESHOLD == 10.0
+    assert module.SMTP_PORT == 587

--- a/tools/miner_alerts/miner_alerts.py
+++ b/tools/miner_alerts/miner_alerts.py
@@ -40,16 +40,43 @@ load_dotenv()
 RUSTCHAIN_API = os.getenv("RUSTCHAIN_API", "https://rustchain.org")
 VERIFY_SSL = os.getenv("RUSTCHAIN_VERIFY_SSL", "false").lower() == "true"
 
+
+def _safe_int(val, default: int) -> int:
+    """Cast *val* to int, returning *default* on malformed input.
+
+    Module-level numeric env casts previously crashed at import time with a
+    bare ``ValueError`` when the env var was empty or non-numeric (see #7323).
+    Falling back to the documented default keeps the daemon loadable and
+    matches the existing safe-parse pattern used by the Prometheus exporter.
+    """
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_float(val, default: float) -> float:
+    """Cast *val* to float, returning *default* on malformed input.
+
+    Same rationale as :func:`_safe_int` — keeps the daemon importable when
+    numeric env vars are misconfigured.
+    """
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return default
+
+
 # Polling intervals (seconds)
-POLL_INTERVAL = int(os.getenv("POLL_INTERVAL", "120"))  # 2 minutes default
-OFFLINE_THRESHOLD = int(os.getenv("OFFLINE_THRESHOLD", "600"))  # 10 min no attestation
+POLL_INTERVAL = _safe_int(os.getenv("POLL_INTERVAL", "120"), 120)  # 2 minutes default
+OFFLINE_THRESHOLD = _safe_int(os.getenv("OFFLINE_THRESHOLD", "600"), 600)  # 10 min no attestation
 
 # Large transfer threshold (RTC)
-LARGE_TRANSFER_THRESHOLD = float(os.getenv("LARGE_TRANSFER_THRESHOLD", "10.0"))
+LARGE_TRANSFER_THRESHOLD = _safe_float(os.getenv("LARGE_TRANSFER_THRESHOLD", "10.0"), 10.0)
 
 # SMTP configuration
 SMTP_HOST = os.getenv("SMTP_HOST", "smtp.gmail.com")
-SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
+SMTP_PORT = _safe_int(os.getenv("SMTP_PORT", "587"), 587)
 SMTP_USER = os.getenv("SMTP_USER", "")
 SMTP_PASS = os.getenv("SMTP_PASS", "")
 SMTP_FROM = os.getenv("SMTP_FROM", "")


### PR DESCRIPTION
## Summary

`tools/miner_alerts/miner_alerts.py` parses `POLL_INTERVAL`, `OFFLINE_THRESHOLD`, `LARGE_TRANSFER_THRESHOLD`, and `SMTP_PORT` as `int` / `float` at module import time. A typo in any of those env vars raises `ValueError` on import, preventing the alerting daemon from starting at all — even though the script already ships sane defaults for each value.

This PR wraps the four casts with `_safe_int` / `_safe_float` helpers that fall back to the documented default on `TypeError` / `ValueError`. The pattern mirrors what already ships in `tools/prometheus/rustchain_exporter.py` (see #7321 / PR #7529).

## Changes

- `tools/miner_alerts/miner_alerts.py`
  - Add `_safe_int(val, default)` and `_safe_float(val, default)` helpers with docstrings referencing the issue.
  - Wrap `POLL_INTERVAL`, `OFFLINE_THRESHOLD`, `SMTP_PORT` with `_safe_int`.
  - Wrap `LARGE_TRANSFER_THRESHOLD` with `_safe_float`.
  - Net: +31 / −4 lines.
- `tests/test_miner_alerts.py`
  - Add `miner_alerts_safe_module` fixture (same `spec_from_file_location` pattern already used in the file).
  - `test_safe_int_falls_back_on_malformed_input` — covers valid int, negative, empty string, `None`, non-numeric, and `"12.5"` (which `int()` rejects in strict mode).
  - `test_safe_float_falls_back_on_malformed_input` — covers valid float, negative, empty, `None`, `"banana"`.
  - `test_module_imports_with_malformed_numeric_env_vars` — end-to-end check: sets every numeric env var to garbage and asserts the module imports cleanly with the documented defaults (`120`, `600`, `10.0`, `587`).
  - Net: +78 / 0 lines.

## Why this approach

- **Smallest possible blast radius** — only the four problematic lines are wrapped; nothing else in `miner_alerts.py` changes.
- **Reuses a proven pattern** — `tools/prometheus/rustchain_exporter.py` already uses an equivalent `_safe_int` helper (PR #7529, issue #7321). Following the same convention keeps the tooling layer consistent and gives the next contributor a familiar shape to extend.
- **No behavior change for valid configs** — happy-path values cast to the same result as before; only the failure mode shifts from "daemon refuses to start" to "daemon logs default and continues".
- **Default-as-second-arg** keeps the fallback value visible at the call site, matching the style of PR #7529.

## Testing

```
$ python3 -m pytest tests/test_miner_alerts.py tests/test_miner_alerts_db.py -v
============================= test session starts ==============================
collected 14 items

tests/test_miner_alerts.py::test_alert_db_subscription_lifecycle_and_filters PASSED
tests/test_miner_alerts.py::test_alert_db_updates_state_and_recent_alerts PASSED
tests/test_miner_alerts.py::test_send_alert_delivers_enabled_channels_and_logs_history PASSED
tests/test_miner_alerts.py::test_alert_templates_respect_cooldowns_and_format_messages PASSED
tests/test_miner_alerts.py::test_fetch_helpers_parse_success_and_errors PASSED
tests/test_miner_alerts.py::test_safe_int_falls_back_on_malformed_input PASSED
tests/test_miner_alerts.py::test_safe_float_falls_back_on_malformed_input PASSED
tests/test_miner_alerts.py::test_module_imports_with_malformed_numeric_env_vars PASSED
tests/test_miner_alerts_db.py::test_add_subscription_requires_email_or_phone PASSED
tests/test_miner_alerts_db.py::test_add_subscription_upserts_and_filters_by_alert_type PASSED
tests/test_miner_alerts_db.py::test_add_subscription_upserts_phone_only_subscription PASSED
tests/test_miner_alerts_db.py::test_remove_subscription_deactivates_without_deleting PASSED
tests/test_miner_alerts_db.py::test_update_miner_state_inserts_then_tracks_balance_change PASSED
tests/test_miner_alerts_db.py::test_recent_alert_exists_honors_success_and_cooldown PASSED

============================== 14 passed in 0.19s ==============================
```

## Manual verification

Before the fix:

```
$ POLL_INTERVAL=two-minutes python3 -c "import importlib.util; \
    spec = importlib.util.spec_from_file_location('m', 'tools/miner_alerts/miner_alerts.py'); \
    m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)"
ValueError: invalid literal for int() with base 10: 'two-minutes'
```

After the fix:

```
$ POLL_INTERVAL=two-minutes OFFLINE_THRESHOLD="" LARGE_TRANSFER_THRESHOLD=high \
  SMTP_PORT="  " python3 -c "import importlib.util; \
    spec = importlib.util.spec_from_file_location('m', 'tools/miner_alerts/miner_alerts.py'); \
    m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m); \
    print(m.POLL_INTERVAL, m.OFFLINE_THRESHOLD, m.LARGE_TRANSFER_THRESHOLD, m.SMTP_PORT)"
120 600 10.0 587
```

## Trade-offs

- A misconfigured threshold is now silent (default used) rather than failing loud. Considered: log a warning on fallback. Skipped to keep the helper dependency-free and to mirror the merged #7321 fix exactly; can be added in a follow-up if maintainers want it.
- The fallback default is duplicated at the call site (`_safe_int(os.getenv("X", "120"), 120)`). Slightly noisy but keeps each config self-documenting and matches the merged pattern.

Closes #7323