### PR TITLE
fix(#7216): harden health dashboard node and incident rendering

### DIFF
--- a/docs/network-status.html
+++ b/docs/network-status.html
@@ -232,17 +232,29 @@
 
     function renderHistory() {
       const box = document.getElementById('historyList');
-      box.innerHTML = '';
+      box.replaceChildren();
       for (const base of NODE_ENDPOINTS) {
         const row = document.createElement('div');
         row.className = 'rounded border border-slate-800 bg-slate-950 p-3';
-        row.innerHTML = `
-          <div class="flex items-center justify-between mb-2">
-            <div class="font-mono text-xs break-all">${base}</div>
-            <div class="text-xs text-slate-300">90d uptime: <span class="text-emerald-300">${uptimePct(base)}</span></div>
-          </div>
-          ${sparkline(base)}
-        `;
+        // Build with safe DOM construction — never innerHTML for untrusted fields.
+        const top = document.createElement('div');
+        top.className = 'flex items-center justify-between mb-2';
+        const urlSpan = document.createElement('div');
+        urlSpan.className = 'font-mono text-xs break-all';
+        urlSpan.textContent = base;
+        const upSpan = document.createElement('div');
+        upSpan.className = 'text-xs text-slate-300';
+        upSpan.textContent = '90d uptime: ';
+        const upVal = document.createElement('span');
+        upVal.className = 'text-emerald-300';
+        upVal.textContent = uptimePct(base);
+        upSpan.appendChild(upVal);
+        top.append(urlSpan, upSpan);
+        // The sparkline returns an <svg> string with no untrusted interpolation,
+        // so a controlled innerHTML assignment is safe here.
+        const spark = document.createElement('div');
+        spark.innerHTML = sparkline(base);
+        row.append(top, spark);
         box.appendChild(row);
       }
     }

--- a/status/index.html
+++ b/status/index.html
@@ -552,8 +552,18 @@
       }
     }
 
+    // Whitelist of allowed status values; anything else collapses to "unknown"
+    // so we never interpolate untrusted strings into class attributes.
+    const STATUS_WHITELIST = new Set(["online", "offline", "degraded", "blocked", "unknown"]);
+
+    function safeClass(value, fallback = "") {
+      return STATUS_WHITELIST.has(value) ? value : fallback;
+    }
+
     function renderNodes(results) {
-      $("node-list").innerHTML = results.map((result) => {
+      const list = $("node-list");
+      list.replaceChildren();
+      for (const result of results) {
         const status = getOnlineStatus(result);
         const health = result.health || {};
         const epoch = result.epoch || {};
@@ -566,26 +576,55 @@
           ? `${Math.floor(Number(uptime) / 3600)}h ${Math.floor((Number(uptime) % 3600) / 60)}m`
           : "unknown";
 
-        return `
-          <article class="node-card">
-            <div class="node-head">
-              <div>
-                <div class="node-title">${result.node.name}</div>
-                <div class="node-sub">${result.node.location}<br>${result.node.origin}</div>
-              </div>
-              <span class="badge ${status === "online" ? "ok" : status === "offline" ? "bad" : status === "blocked" ? "blocked" : ""}">${status}</span>
-            </div>
-            <div class="kv">
-              <div><span>Response</span><strong>${result.responseMs ? `${result.responseMs} ms` : "--"}</strong></div>
-              <div><span>Version</span><strong>${escapeHtml(version)}</strong></div>
-              <div><span>Miners</span><strong>${minerCount || "--"}</strong></div>
-              <div><span>Epoch</span><strong>${epoch.epoch ?? health.epoch ?? "--"}</strong></div>
-              <div><span>Slot</span><strong>${epoch.slot ?? "--"}</strong></div>
-              <div><span>Uptime</span><strong>${uptimeLabel}</strong></div>
-            </div>
-          </article>
-        `;
-      }).join("");
+        // Build with safe DOM construction — never innerHTML for untrusted fields.
+        const card = document.createElement("article");
+        card.className = "node-card";
+
+        const head = document.createElement("div");
+        head.className = "node-head";
+
+        const headInfo = document.createElement("div");
+        const title = document.createElement("div");
+        title.className = "node-title";
+        title.textContent = result.node.name ?? "";
+        const sub = document.createElement("div");
+        sub.className = "node-sub";
+        const loc = document.createElement("span");
+        loc.textContent = result.node.location ?? "";
+        sub.append(loc, document.createElement("br"));
+        const originSpan = document.createElement("span");
+        originSpan.textContent = result.node.origin ?? "";
+        sub.appendChild(originSpan);
+        headInfo.append(title, sub);
+
+        const badge = document.createElement("span");
+        badge.className = `badge ${safeClass(status === "online" ? "ok" : status === "offline" ? "bad" : status === "blocked" ? "blocked" : "", status === "online" ? "ok" : status === "offline" ? "bad" : "")}`;
+        badge.textContent = status;
+        head.append(headInfo, badge);
+
+        const kv = document.createElement("div");
+        kv.className = "kv";
+        const mkRow = (label, value) => {
+          const row = document.createElement("div");
+          const lbl = document.createElement("span");
+          lbl.textContent = label;
+          const strong = document.createElement("strong");
+          strong.textContent = value;
+          row.append(lbl, strong);
+          return row;
+        };
+        kv.append(
+          mkRow("Response", result.responseMs ? `${result.responseMs} ms` : "--"),
+          mkRow("Version", version),
+          mkRow("Miners", String(minerCount || "--")),
+          mkRow("Epoch", String(epoch.epoch ?? health.epoch ?? "--")),
+          mkRow("Slot", String(epoch.slot ?? "--")),
+          mkRow("Uptime", uptimeLabel)
+        );
+
+        card.append(head, kv);
+        list.appendChild(card);
+      }
     }
 
     function renderSummary(results, primaryMiners, primaryEpoch) {
@@ -632,30 +671,52 @@
 
       const rows = [...counts.entries()].sort((a, b) => b[1] - a[1]);
       const total = miners.length || 0;
+      const target = $("arch-breakdown");
+      target.replaceChildren();
       if (!rows.length) {
-        $("arch-breakdown").innerHTML = `<div class="muted">Miner architecture data is unavailable.</div>`;
+        const muted = document.createElement("div");
+        muted.className = "muted";
+        muted.textContent = "Miner architecture data is unavailable.";
+        target.appendChild(muted);
         return;
       }
 
-      $("arch-breakdown").innerHTML = rows.map(([arch, count]) => {
+      for (const [arch, count] of rows) {
         const pct = total ? Math.round((count / total) * 100) : 0;
-        return `
-          <div class="arch-row">
-            <strong>${escapeHtml(arch)}</strong>
-            <div class="track"><div class="fill" style="width:${pct}%"></div></div>
-            <span class="muted">${count}</span>
-          </div>
-        `;
-      }).join("");
+        const row = document.createElement("div");
+        row.className = "arch-row";
+        const archStrong = document.createElement("strong");
+        archStrong.textContent = arch;
+        const track = document.createElement("div");
+        track.className = "track";
+        const fill = document.createElement("div");
+        fill.className = "fill";
+        fill.style.width = `${pct}%`;
+        track.appendChild(fill);
+        const mutedCount = document.createElement("span");
+        mutedCount.className = "muted";
+        mutedCount.textContent = String(count);
+        row.append(archStrong, track, mutedCount);
+        target.appendChild(row);
+      }
     }
 
     function renderLog(results) {
-      $("fetch-log").innerHTML = results.map((result) => {
+      const target = $("fetch-log");
+      target.replaceChildren();
+      const ALLOWED = new Set(["online", "offline", "blocked", "amber"]);
+      for (const result of results) {
         const status = getOnlineStatus(result);
         const cls = status === "online" ? "green" : status === "offline" ? "red" : status === "blocked" ? "" : "amber";
         const msg = result.error || `health ok in ${result.responseMs} ms`;
-        return `<div class="log-item"><strong class="${cls}">${result.node.name}</strong>: ${escapeHtml(msg)}</div>`;
-      }).join("");
+        const item = document.createElement("div");
+        item.className = "log-item";
+        const strong = document.createElement("strong");
+        strong.className = ALLOWED.has(cls) ? cls : "";
+        strong.textContent = result.node.name ?? "";
+        item.append(strong, document.createTextNode(`: ${msg}`));
+        target.appendChild(item);
+      }
     }
 
     function escapeHtml(value) {

--- a/status/index.html
+++ b/status/index.html
@@ -554,7 +554,7 @@
 
     // Whitelist of allowed status values; anything else collapses to "unknown"
     // so we never interpolate untrusted strings into class attributes.
-    const STATUS_WHITELIST = new Set(["online", "offline", "degraded", "blocked", "unknown"]);
+    const STATUS_WHITELIST = new Set(["online", "offline", "degraded", "blocked", "unknown", "ok", "bad"]);
 
     function safeClass(value, fallback = "") {
       return STATUS_WHITELIST.has(value) ? value : fallback;

--- a/status/templates/status.html
+++ b/status/templates/status.html
@@ -82,6 +82,13 @@ function escapeHtml(value) {
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#039;');
 }
+// Whitelist of CSS class fragments safe to interpolate from server-side data.
+// Any class not in this set is dropped so an attacker cannot break out of the
+// attribute via a crafted node name, status string, or event label.
+const ALLOWED_STATUS_CLASSES = new Set(['up', 'down', 'recovered', 'unknown']);
+function safeClass(value, fallback = '') {
+  return ALLOWED_STATUS_CLASSES.has(String(value)) ? String(value) : fallback;
+}
 async function refresh() {
   try {
     const [statusRes, incRes, uptimeRes] = await Promise.all([
@@ -106,31 +113,58 @@ async function refresh() {
       const nid = node.name.toLowerCase().replace(/\s+/g, '-').replace('node-','node-');
       const nodeId = Object.keys(uptime).find(k => uptime[k].name === node.name) || '';
       const u = uptime[nodeId] || {};
+      const statusClass = safeClass(node.up ? 'up' : 'down');
       const card = document.createElement('div');
       card.className = 'node-card';
-      card.innerHTML = `
-        <div class="node-header">
-          <span class="node-name">${escapeHtml(node.name)}</span>
-          <span class="status-badge ${node.up?'up':'down'}">${node.up?'Operational':'Down'}</span>
-        </div>
-        <div class="node-stats">
-          <div><span class="stat-label">Location</span><br><span class="stat-value">${escapeHtml(node.location || '—')}</span></div>
-          <div><span class="stat-label">Response</span><br><span class="stat-value">${escapeHtml(node.response_ms || 0)}ms</span></div>
-          <div><span class="stat-label">Miners</span><br><span class="stat-value">${escapeHtml(node.active_miners || '—')}</span></div>
-          <div><span class="stat-label">Epoch</span><br><span class="stat-value">${escapeHtml(node.current_epoch || '—')}</span></div>
-          <div><span class="stat-label">Version</span><br><span class="stat-value">${escapeHtml(node.version || '—')}</span></div>
-          <div><span class="stat-label">Uptime</span><br><span class="stat-value">${escapeHtml(formatUptime(node.uptime))}</span></div>
-        </div>
-        <div class="uptime-pct">${u.uptime_pct!==undefined?escapeHtml(u.uptime_pct+'% uptime (24h)'):'—'}</div>
-        <div class="uptime-bar" id="bar-${nodeId}"></div>
-      `;
+      // Build the static skeleton with safe DOM methods, then escape dynamic text.
+      const header = document.createElement('div');
+      header.className = 'node-header';
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'node-name';
+      nameSpan.textContent = node.name ?? '';
+      const badge = document.createElement('span');
+      badge.className = `status-badge ${statusClass}`;
+      badge.textContent = node.up ? 'Operational' : 'Down';
+      header.append(nameSpan, badge);
+
+      const stats = document.createElement('div');
+      stats.className = 'node-stats';
+      const mkStat = (label, value) => {
+        const wrap = document.createElement('div');
+        const lbl = document.createElement('span');
+        lbl.className = 'stat-label';
+        lbl.textContent = label;
+        const val = document.createElement('span');
+        val.className = 'stat-value';
+        val.textContent = value;
+        wrap.append(lbl, document.createElement('br'), val);
+        return wrap;
+      };
+      stats.append(
+        mkStat('Location', node.location || '—'),
+        mkStat('Response', `${node.response_ms || 0}ms`),
+        mkStat('Miners', String(node.active_miners || '—')),
+        mkStat('Epoch', String(node.current_epoch || '—')),
+        mkStat('Version', String(node.version || '—')),
+        mkStat('Uptime', formatUptime(node.uptime))
+      );
+
+      const uptimePct = document.createElement('div');
+      uptimePct.className = 'uptime-pct';
+      uptimePct.textContent = u.uptime_pct !== undefined ? `${u.uptime_pct}% uptime (24h)` : '—';
+
+      const bar = document.createElement('div');
+      bar.className = 'uptime-bar';
+      bar.id = `bar-${nodeId}`;
+
+      card.append(header, stats, uptimePct, bar);
       container.appendChild(card);
       // Load history for uptime bar
       if (nodeId) {
         fetch('/api/history/'+nodeId).then(r=>r.json()).then(hist=>{
-          const bar = document.getElementById('bar-'+nodeId);
-          if(!bar) return;
-          // Show last 48 ticks (every 30 min summary)
+          const barEl = document.getElementById('bar-'+nodeId);
+          if(!barEl) return;
+          // Show last 48 ticks (every 30 min summary) — class names whitelisted.
           const buckets = [];
           const step = Math.max(1, Math.floor(hist.length/48));
           for(let i=0;i<hist.length;i+=step){
@@ -138,22 +172,43 @@ async function refresh() {
             const anyDown = slice.some(h=>!h.up);
             buckets.push(anyDown?'down':'up');
           }
-          bar.innerHTML = buckets.map(s=>`<div class="tick ${s}"></div>`).join('');
+          barEl.replaceChildren(...buckets.map(s => {
+            const tick = document.createElement('div');
+            tick.className = `tick ${safeClass(s)}`;
+            return tick;
+          }));
         });
       }
     }
     // Incidents
     const incEl = document.getElementById('incidents');
+    incEl.replaceChildren();
     if(incidents.length===0){
-      incEl.innerHTML='<div class="empty">No incidents recorded</div>';
+      const empty = document.createElement('div');
+      empty.className = 'empty';
+      empty.textContent = 'No incidents recorded';
+      incEl.appendChild(empty);
     } else {
-      incEl.innerHTML=incidents.slice(0,20).map(i=>`
-        <div class="incident">
-          <span><span class="event-${i.event === 'down' ? 'down' : i.event === 'recovered' ? 'recovered' : 'unknown'}">${i.event==='down'?'🔴':'🟢'} ${escapeHtml(i.node)} — ${escapeHtml(i.event)}</span>
-          ${i.detail?' · '+escapeHtml(i.detail):''}</span>
-          <span class="time">${escapeHtml(formatTime(i.time))}</span>
-        </div>
-      `).join('');
+      for (const i of incidents.slice(0,20)) {
+        const eventClass = safeClass(
+          i.event === 'down' ? 'down' : i.event === 'recovered' ? 'recovered' : 'unknown'
+        );
+        const row = document.createElement('div');
+        row.className = 'incident';
+        const left = document.createElement('span');
+        const evt = document.createElement('span');
+        evt.className = `event-${eventClass}`;
+        evt.textContent = `${i.event==='down'?'🔴':'🟢'} ${i.node ?? ''} — ${i.event ?? ''}`;
+        left.append(evt);
+        if (i.detail) {
+          left.append(document.createTextNode(` · ${i.detail}`));
+        }
+        const timeSpan = document.createElement('span');
+        timeSpan.className = 'time';
+        timeSpan.textContent = formatTime(i.time);
+        row.append(left, timeSpan);
+        incEl.appendChild(row);
+      }
     }
   } catch(e) { console.error('Refresh failed:', e); }
 }

--- a/status/test_status.py
+++ b/status/test_status.py
@@ -2,6 +2,7 @@
 """Unit tests for RustChain Multi-Node Health Dashboard."""
 
 import json
+import os
 import pytest
 from unittest.mock import patch, MagicMock
 from status_server import app, check_node, poll_all, NODES, node_status, history, incidents
@@ -197,17 +198,71 @@ class TestAPI:
         resp = client.get("/")
         html = resp.data.decode("utf-8")
 
+        # escapeHtml helper still present for legacy callers
         assert "function escapeHtml(value)" in html
-        assert "${escapeHtml(node.name)}" in html
-        assert "${escapeHtml(node.location || '—')}" in html
-        assert "${escapeHtml(node.response_ms || 0)}ms" in html
-        assert "${escapeHtml(node.version || '—')}" in html
-        assert "${escapeHtml(i.node)}" in html
-        assert "${escapeHtml(i.event)}" in html
-        assert "escapeHtml(i.detail)" in html
+        # Class-name whitelist helper to prevent attribute breakout
+        assert "function safeClass(value" in html
+        assert "ALLOWED_STATUS_CLASSES" in html
+        # No raw template interpolation of untrusted fields into innerHTML
         assert "${node.name}" not in html
-        assert "${node.version||'—'}" not in html
         assert "${i.detail?' · '+i.detail:''}" not in html
+        # Nodes must be built via safe DOM construction, not innerHTML
+        assert "card.innerHTML" not in html
+        assert "nameSpan.textContent = node.name" in html
+        assert "badge.textContent = node.up ? 'Operational' : 'Down'" in html
+        # Incident rows must be built with createElement/textContent
+        assert "evt.textContent = " in html
+        assert "incEl.innerHTML" not in html
+        # Uptime bar must use safeClass, not direct interpolation
+        assert "tick ${safeClass(s)}" in html
+
+
+class TestStaticDashboardFiles:
+    """Static-file checks for the GitHub Pages health dashboard surface.
+
+    These files are not served by the Flask app at runtime but are published
+    from the repository itself, so any unsafe interpolation in them is a
+    shipped XSS sink on the public status page.
+    """
+
+    @staticmethod
+    def _read(rel_path):
+        here = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(here, rel_path), "r", encoding="utf-8") as fh:
+            return fh.read()
+
+    def test_status_index_html_escapes_node_and_incident_fields(self):
+        html = self._read("index.html")
+
+        # Class-name whitelist helper to prevent attribute breakout
+        assert "function safeClass(value" in html
+        assert 'STATUS_WHITELIST' in html
+        # No innerHTML assignments that interpolate untrusted node fields.
+        assert "${result.node.name}" not in html
+        assert "${result.node.location}" not in html
+        assert "${result.node.origin}" not in html
+        # Untrusted fields must flow through textContent / className.
+        assert 'title.textContent = result.node.name' in html
+        assert 'loc.textContent = result.node.location' in html
+        assert 'originSpan.textContent = result.node.origin' in html
+        assert 'strong.textContent = result.node.name' in html
+        # No `result.node.X` interpolated into a class attribute.
+        assert 'class="${result.node.' not in html
+
+    def test_network_status_html_escapes_base_and_message(self):
+        # website/static/ is the canonical copy; docs/ mirrors it.
+        for rel_path in (
+            "../website/static/network-status.html",
+            "../docs/network-status.html",
+        ):
+            html = self._read(rel_path)
+
+            # No template-string innerHTML that interpolates the URL base
+            assert '<div class="font-mono text-xs break-all">${base}</div>' not in html
+            assert 'row.innerHTML = `' not in html
+            # base must be assigned through textContent
+            assert 'urlSpan.textContent = base' in html
+            assert 'upVal.textContent = uptimePct(base)' in html
 
 
 class TestHistoryTrimming:

--- a/website/static/network-status.html
+++ b/website/static/network-status.html
@@ -232,17 +232,29 @@
 
     function renderHistory() {
       const box = document.getElementById('historyList');
-      box.innerHTML = '';
+      box.replaceChildren();
       for (const base of NODE_ENDPOINTS) {
         const row = document.createElement('div');
         row.className = 'rounded border border-slate-800 bg-slate-950 p-3';
-        row.innerHTML = `
-          <div class="flex items-center justify-between mb-2">
-            <div class="font-mono text-xs break-all">${base}</div>
-            <div class="text-xs text-slate-300">90d uptime: <span class="text-emerald-300">${uptimePct(base)}</span></div>
-          </div>
-          ${sparkline(base)}
-        `;
+        // Build with safe DOM construction — never innerHTML for untrusted fields.
+        const top = document.createElement('div');
+        top.className = 'flex items-center justify-between mb-2';
+        const urlSpan = document.createElement('div');
+        urlSpan.className = 'font-mono text-xs break-all';
+        urlSpan.textContent = base;
+        const upSpan = document.createElement('div');
+        upSpan.className = 'text-xs text-slate-300';
+        upSpan.textContent = '90d uptime: ';
+        const upVal = document.createElement('span');
+        upVal.className = 'text-emerald-300';
+        upVal.textContent = uptimePct(base);
+        upSpan.appendChild(upVal);
+        top.append(urlSpan, upSpan);
+        // The sparkline returns an <svg> string with no untrusted interpolation,
+        // so a controlled innerHTML assignment is safe here.
+        const spark = document.createElement('div');
+        spark.innerHTML = sparkline(base);
+        row.append(top, spark);
         box.appendChild(row);
       }
     }


### PR DESCRIPTION
## Summary

Replace innerHTML template interpolation with safe DOM construction (`textContent` + class whitelisting) across the health dashboard surfaces for issue #7216. The current code interpolates server-supplied node fields (`node.name`, `node.location`, `node.origin`, `node.version`, `node.error`, plus incident `event`/`detail`/`node`) into `innerHTML` and into `class="${...}"` attribute strings. A compromised, misconfigured, or hostile upstream health endpoint can return markup in fields such as `version` or in error strings and have it execute as script in the dashboard origin; stored incident records replay the same payload through the incident log and the Atom feed.

## Changes

- `status/index.html` — `renderNodes()`, `renderArchitecture()`, `renderLog()` rebuilt with `document.createElement` + `textContent`. Added `STATUS_WHITELIST` so the `badge` class can only ever be `ok`, `bad`, `blocked`, or `""`.
- `status/templates/status.html` — the per-node card body, the uptime-bar ticks, and the incident list are all rebuilt with `createElement` + `textContent`. Added `ALLOWED_STATUS_CLASSES = {up, down, recovered, unknown}` and a `safeClass()` helper used for `status-badge`, `event-${event}`, and `tick ${state}`.
- `website/static/network-status.html` and `docs/network-status.html` — `renderHistory()` no longer interpolates the URL `base` into `innerHTML`; uses `textContent` for the URL and uptime text and only assigns the static SVG returned by `sparkline()`.
- `status/test_status.py`:
  - Rewrote `TestAPI.test_index_page_escapes_dynamic_status_fields` to assert the new safe DOM markers (`nameSpan.textContent = node.name`, `badge.textContent = …`, `evt.textContent = …`) and explicitly forbid `card.innerHTML` / `incEl.innerHTML` / raw `${node.name}` / `${i.detail?' · '+i.detail:''}` interpolation.
  - Added `TestStaticDashboardFiles` with two tests covering `status/index.html` and both `network-status.html` copies so the GitHub Pages surfaces are regression-protected even though they aren't served by the Flask app.

Files: 5 changed (+281 / -86).

## Why this approach

The existing code mixed `escapeHtml()` (HTML text) with raw `${...}` interpolation (HTML attribute + class + URL), and the class-attribute interpolations are not a use case `escapeHtml` solves. Using `createElement` + `textContent` makes every text sink trivially safe; using a class whitelist (`safeClass`) makes every class-attribute sink safe by construction. This matches the same hardening shape used in #7218 (fossil-record tooltip), #7146 (dashboard wallet search), #7137 (BCOS badge preview), and #7224 (CSV export).

Trade-offs considered:

- *Stripping markup from version/error text vs. accepting HTML.* — Opted to treat these as plain text. They are telemetry, not user-authored markup, and rendering them as text keeps the dashboard safe even if the upstream `/health` or `/api/incidents` endpoint is compromised.
- *DOM construction vs. `textContent` + `replaceChildren`.* — Used a mix to keep the diff readable; `replaceChildren(...nodes)` is used where the static skeleton was already preserved, `createElement` loops where it wasn't.

## Testing

```
$ cd status && python -m pytest test_status.py -v
============================== 19 passed in 21.34s ==============================
```

All 19 tests in `status/test_status.py` pass, including:

- `TestAPI::test_index_page_escapes_dynamic_status_fields` (rewritten)
- `TestStaticDashboardFiles::test_status_index_html_escapes_node_and_incident_fields` (new)
- `TestStaticDashboardFiles::test_network_status_html_escapes_base_and_message` (new)
- `TestAPI::test_rss_feed_escapes_incident_fields` (unchanged — server-side RSS already escaped via `xml_text`)

The existing CI test `tests/test_docs_network_status_security.py` (7 tests) also still passes:

```
$ python -m pytest tests/test_docs_network_status_security.py -v
============================== 7 passed in 0.10s ==============================
```

## Manual verification

JS syntax check across all 4 edited HTML files:

```
$ for f in status/index.html status/templates/status.html \
           website/static/network-status.html docs/network-status.html; do
    node --check <(python3 -c "import re,sys; \
      print(re.search(r'<script>(.*?)</script>', \
        open('$f').read(), re.DOTALL).group(1))") && echo OK $f
  done
OK status/index.html
OK status/templates/status.html
OK website/static/network-status.html
OK docs/network-status.html
```

Smoke render of `templates/status.html` through the Flask test client — `GET /` returns 200 and the response body now contains `nameSpan.textContent = node.name`, `badge.textContent = …`, `evt.textContent = …`, and `function safeClass(value …)`, while no longer containing `card.innerHTML`, `incEl.innerHTML`, `${node.name}`, or `${i.detail?' · '+i.detail:''}`.

## Trade-offs

- The static GitHub Pages copies (`status/index.html`, `docs/network-status.html`, `website/static/network-status.html`) are not exercised by the Flask test suite; the new `TestStaticDashboardFiles` regression-tests their source so a future careless `innerHTML` rewrite gets caught at CI time.
- The dashboard no longer renders any inline HTML in `version`, `error`, `incident.message`, or `node.name`. Operators who were relying on rich formatting in those fields (there is no such usage in the codebase today) will see plain text instead.

Closes #7216
