### PR TITLE
fix(#7109): add /api/network backend route + proxy /api/network and /api/peers via nginx

### DIFF
--- a/rips/rustchain-core/api/rpc.py
+++ b/rips/rustchain-core/api/rpc.py
@@ -45,6 +45,7 @@ RPC_PUBLIC_METHODS = frozenset({
     "getProposal",
     "getNodeInfo",
     "getPeers",
+    "getNetwork",
     "getEntropyProfile",
 })
 
@@ -203,6 +204,7 @@ class RustChainApi:
         # Node methods
         self.rpc.register("getNodeInfo", self._get_node_info)
         self.rpc.register("getPeers", self._get_peers)
+        self.rpc.register("getNetwork", self._get_network)
         self.rpc.register("getEntropyProfile", self._get_entropy_profile)
 
     # =========================================================================
@@ -324,6 +326,21 @@ class RustChainApi:
     def _get_peers(self, params: Dict[str, Any]) -> list:
         """Get connected peers"""
         return self.node.get_peers()
+
+    def _get_network(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Combined network status: node info + peer count + peer list.
+
+        Maps to the public `/api/network` endpoint documented in
+        `docs/API_REFERENCE.md` and consumed by operator monitoring scripts
+        in `docs/NODE_OPERATOR_GUIDE.md`. Closes #7109.
+        """
+        node_info = self._get_node_info(params)
+        peers = self._get_peers(params)
+        return {
+            **node_info,
+            "peer_count": len(peers) if isinstance(peers, list) else 0,
+            "peers": peers,
+        }
 
     def _get_entropy_profile(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Get node's entropy profile"""
@@ -487,6 +504,7 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
         routes = {
             "/api/stats": ("getStats", {}),
             "/api/node/info": ("getNodeInfo", {}),
+            "/api/network": ("getNetwork", {}),
             "/api/peers": ("getPeers", {}),
             "/api/proposals": ("getProposals", {}),
             "/api/entropy": ("getEntropyProfile", {}),

--- a/site/nginx-rustchain-org.conf
+++ b/site/nginx-rustchain-org.conf
@@ -46,6 +46,18 @@ server {
         add_header Access-Control-Allow-Origin "*" always;
     }
 
+    location /api/network {
+        proxy_pass http://127.0.0.1:8099/api/network;
+        proxy_set_header Host $host;
+        add_header Access-Control-Allow-Origin "*" always;
+    }
+
+    location /api/peers {
+        proxy_pass http://127.0.0.1:8099/api/peers;
+        proxy_set_header Host $host;
+        add_header Access-Control-Allow-Origin "*" always;
+    }
+
     # Explorer UI (served by rustchain-gui on port 5555)
     location = /explorer {
         return 301 /explorer/;
@@ -359,6 +371,18 @@ server {
 
     location /api/stats {
         proxy_pass http://127.0.0.1:8099/api/stats;
+        proxy_set_header Host $host;
+        add_header Access-Control-Allow-Origin "*" always;
+    }
+
+    location /api/network {
+        proxy_pass http://127.0.0.1:8099/api/network;
+        proxy_set_header Host $host;
+        add_header Access-Control-Allow-Origin "*" always;
+    }
+
+    location /api/peers {
+        proxy_pass http://127.0.0.1:8099/api/peers;
         proxy_set_header Host $host;
         add_header Access-Control-Allow-Origin "*" always;
     }

--- a/tests/test_rpc_network_endpoint.py
+++ b/tests/test_rpc_network_endpoint.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: MIT
+"""Tests for /api/network and /api/peers endpoints.
+
+Regression coverage for issue #7109 — public docs /api/network and /api/peers
+were returning nginx HTML 404 on production. The backend RPC layer now exposes
+both, and nginx proxies them to the node.
+
+These tests verify:
+1. `/api/network` returns combined node info + peer list + peer count
+2. `/api/peers` returns the peer list (already existed but no regression test)
+3. Both routes are routed through the same `RustChainApi` allowlist (read-only)
+4. The /api/network response degrades safely when get_peers returns non-list
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RPC_PATH = REPO_ROOT / "rips" / "rustchain-core" / "api" / "rpc.py"
+
+
+def load_rpc_module():
+    module_name = "rustchain_core_rpc_under_test_network"
+    spec = importlib.util.spec_from_file_location(module_name, RPC_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeNode:
+    """Stand-in for `Node` exposing only the methods the RPC needs."""
+
+    def __init__(self, peers=None):
+        self.chain_id = 2718
+        self.version = "2.2.1-security-hardened"
+        self.validator_id = "validator-test"
+        self.is_mining = True
+        self.peers = peers or [
+            {"id": "peer-a", "address": "10.0.0.1:8099"},
+            {"id": "peer-b", "address": "10.0.0.2:8099"},
+            {"id": "peer-c", "address": "10.0.0.3:8099"},
+        ]
+
+    def get_uptime(self):
+        return 86400  # 1 day
+
+    def get_peers(self):
+        return self.peers
+
+
+def _route(path):
+    """Route a static REST path through `ApiRequestHandler._route_request`."""
+    rpc_module = load_rpc_module()
+    node = FakeNode()
+    handler = object.__new__(rpc_module.ApiRequestHandler)
+    handler.api = rpc_module.RustChainApi(node)
+    return handler._route_request(path, {})
+
+
+def test_api_network_returns_combined_node_info_and_peers():
+    response = _route("/api/network")
+
+    assert response.success is True
+    data = response.data
+
+    # Node info fields from getNodeInfo
+    assert data["chain_id"] == 2718
+    assert data["version"] == "2.2.1-security-hardened"
+    assert data["validator_id"] == "validator-test"
+    assert data["is_mining"] is True
+    assert data["uptime_seconds"] == 86400
+
+    # Peer list passthrough from getPeers
+    assert data["peers"] == [
+        {"id": "peer-a", "address": "10.0.0.1:8099"},
+        {"id": "peer-b", "address": "10.0.0.2:8099"},
+        {"id": "peer-c", "address": "10.0.0.3:8099"},
+    ]
+    assert data["peer_count"] == 3
+
+
+def test_api_peers_returns_peer_list():
+    response = _route("/api/peers")
+
+    assert response.success is True
+    assert response.data == [
+        {"id": "peer-a", "address": "10.0.0.1:8099"},
+        {"id": "peer-b", "address": "10.0.0.2:8099"},
+        {"id": "peer-c", "address": "10.0.0.3:8099"},
+    ]
+
+
+def test_api_network_degrades_when_get_peers_returns_non_list():
+    """Defensive: if get_peers returns non-list, peer_count is 0 and peers is empty."""
+
+    class BrokenNode(FakeNode):
+        def get_peers(self):
+            return {"unexpected": "dict-not-list"}  # wrong type on purpose
+
+    rpc_module = load_rpc_module()
+    handler = object.__new__(rpc_module.ApiRequestHandler)
+    handler.api = rpc_module.RustChainApi(BrokenNode())
+    response = handler._route_request("/api/network", {})
+
+    assert response.success is True
+    assert response.data["peer_count"] == 0
+    assert response.data["peers"] == {"unexpected": "dict-not-list"}
+    # Node info still intact
+    assert response.data["chain_id"] == 2718
+
+
+def test_api_network_with_empty_peer_list():
+    """Solo node with no peers should return peer_count=0 and peers=[]."""
+
+    class SoloNode(FakeNode):
+        def get_peers(self):
+            return []
+
+    rpc_module = load_rpc_module()
+    handler = object.__new__(rpc_module.ApiRequestHandler)
+    handler.api = rpc_module.RustChainApi(SoloNode())
+    response = handler._route_request("/api/network", {})
+
+    assert response.success is True
+    assert response.data["peer_count"] == 0
+    assert response.data["peers"] == []
+
+
+def test_get_network_is_in_public_allowlist():
+    """`getNetwork` must be callable via the RPC allowlist (read-only)."""
+    rpc_module = load_rpc_module()
+    assert "getNetwork" in rpc_module.RPC_PUBLIC_METHODS


### PR DESCRIPTION
## Summary

Fixes the production 404 reported in #7109: `GET /api/network` and `GET /api/peers` now return JSON instead of the nginx HTML 404 page.

Two-part fix:
1. **Backend** (`rips/rustchain-core/api/rpc.py`) — adds a new `getNetwork` RPC method that combines node info + peer list + peer count, mapped to the `/api/network` REST path.
2. **Nginx** (`site/nginx-rustchain-org.conf`) — adds `location /api/network` and `location /api/peers` proxy blocks in **both** server contexts (port 8070 testing + production `rustchain.org`), matching the CORS + Host forwarding pattern of existing `/api/*` blocks.

`/api/peers` already existed in the backend (`getPeers` method, registered in the public allowlist) — only the nginx proxy was missing. So the only NEW backend addition is `/api/network` + the `getNetwork` method that returns `{...node_info, peer_count, peers}`.

## Changes

| File | What changed | Why |
|---|---|---|
| `rips/rustchain-core/api/rpc.py` | +18 lines: `_get_network` method, RPC allowlist entry, REST route | Closes the backend half of #7109 — `/api/network` had no implementation |
| `site/nginx-rustchain-org.conf` | +24 lines: 2 nginx locations per server block | Closes the nginx half of #7109 — even `/api/peers` (already in backend) was being 404'd because nginx had no proxy |
| `tests/test_rpc_network_endpoint.py` | +135 lines: 5 regression tests | Lock in the fix so this can't regress |

## Tests

```text
$ python3 -m pytest tests/test_rpc_network_endpoint.py -v
tests/test_rpc_network_endpoint.py::test_api_network_returns_combined_node_info_and_peers PASSED [ 20%]
tests/test_rpc_network_endpoint.py::test_api_peers_returns_peer_list PASSED [ 40%]
tests/test_rpc_network_endpoint.py::test_api_network_degrades_when_get_peers_returns_non_list PASSED [ 60%]
tests/test_rpc_network_endpoint.py::test_api_network_with_empty_peer_list PASSED [ 80%]
tests/test_rpc_network_endpoint.py::test_get_network_is_in_public_allowlist PASSED [100%]
============================== 5 passed in 0.10s ===============================
```

Test coverage:
1. Combined `/api/network` response shape (node info + peer list + peer count)
2. `/api/peers` returns the peer list (regression test for the existing endpoint)
3. Defensive: `/api/network` degrades safely when `get_peers()` returns non-list (peer_count=0, peers passed through)
4. Solo node case: zero peers → `peer_count=0, peers=[]`
5. `getNetwork` is in `RPC_PUBLIC_METHODS` allowlist (read-only contract)

The test mirrors the pattern in `tests/test_core_rpc_allowlist.py` — loads `rpc.py` directly via importlib, mocks `Node` with a `FakeNode` stub exposing only the methods the RPC needs.

## Safety / contract

- **No new env vars.** Uses existing `RustChainApi` config.
- **No new deps.** Stdlib only (`json`, `urllib`, `dataclasses`).
- **No breaking changes.** Existing `/api/peers` behavior unchanged (peer list only). Existing `/api/node/info` unchanged. Only NEW route is `/api/network`.
- **Read-only contract.** `getNetwork` added to `RPC_PUBLIC_METHODS` allowlist; the `/rpc` endpoint blocks mutating methods and this isn't one.
- **Defensive degradation.** If `get_peers()` ever returns non-list, `peer_count` is set to 0 and `peers` is the raw value (caller can detect via type).

## Deployment

After merge, `rustchain.org/api/network` and `rustchain.org/api/peers` should immediately return JSON once nginx is reloaded with the new config (`nginx -s reload` or restart).

Expected pre-fix vs post-fix:
```bash
# Pre-fix
$ curl -i https://rustchain.org/api/network
HTTP/1.1 404 Not Found
Content-Type: text/html
<html>...nginx 404...</html>

# Post-fix
$ curl -i https://rustchain.org/api/network
HTTP/1.1 200 OK
Content-Type: application/json
{"chain_id": 2718, "version": "...", "validator_id": "...", "uptime_seconds": ..., "is_mining": true, "peer_count": 3, "peers": [...]}
```

## Bounty payout details

- **RTC wallet (XLM/Stellar, Binance deposit):** `GABFQIK63R2NETJM7T673EAMZN4RJLLGP3OFUEJU5SZVTGWUKULZJNL6` + memo `396193324`
- **EVM (fallback):** `0x683d2759cb626f536c842e8a3d943776198b8b8a`
- **PayPal:** ahmadyusrizal89@gmail.com

Closes #7109