### PR TITLE
fix(#7170): harden tools explorer error card rendering with DOM nodes

### DIFF
--- a/tests/test_tools_explorer_security.py
+++ b/tests/test_tools_explorer_security.py
@@ -51,8 +51,9 @@ def test_filter_options_are_built_with_option_nodes():
     assert "`<option value=\"${c}\">${c}</option>`" not in html
 
 
-def test_error_card_escapes_exception_message():
+def test_error_card_uses_dom_nodes_not_inner_html():
     html = source()
 
-    assert "${safeText(err.message || err)}" in html
-    assert "${String(err.message || err)}" not in html
+    assert "function renderErrorCard(message)" in html
+    assert "innerHTML = `<div class=\"card\"><div class=\"label\">Error</div><div class=\"value\">${safeText(err.message || err)}</div></div>`" not in html
+    assert "document.getElementById(\"topCards\").innerHTML = `<div class=\"card\"><div class=\"label\">Error</div>" not in html

--- a/tools/explorer/index.html
+++ b/tools/explorer/index.html
@@ -619,6 +619,21 @@
       renderReputation();
     }
 
+    function renderErrorCard(message) {
+      const container = document.getElementById("topCards");
+      const card = document.createElement("div");
+      card.className = "card";
+      const label = document.createElement("div");
+      label.className = "label";
+      label.textContent = "Error";
+      const value = document.createElement("div");
+      value.className = "value";
+      value.textContent = message;
+      card.appendChild(label);
+      card.appendChild(value);
+      container.replaceChildren(card);
+    }
+
     async function refresh() {
       try {
         const [health, epoch, miners, agentStats, agentJobs, mempool] = await Promise.all([
@@ -644,7 +659,7 @@
         document.getElementById("updatedAt").textContent = `Last update: ${new Date().toLocaleTimeString()}`;
         document.getElementById("agentUpdatedAt").textContent = `Agent update: ${new Date().toLocaleTimeString()}`;
       } catch (err) {
-        document.getElementById("topCards").innerHTML = `<div class="card"><div class="label">Error</div><div class="value">${safeText(err.message || err)}</div></div>`;
+        renderErrorCard(err.message || err);
         document.getElementById("minerRows").innerHTML = "";
       }
     }


### PR DESCRIPTION
## Summary
Replaces the innerHTML template in the tools explorer error-card path with a small DOM-node helper (`renderErrorCard`). This removes the HTML parser sink from exception handling and keeps dynamic exception text out of `innerHTML`.

## Changes
- `tools/explorer/index.html`
  - Add `renderErrorCard(message)` helper that builds the card via `createElement`, `textContent`, and `replaceChildren`.
  - Replace the error-path `innerHTML` assignment with `renderErrorCard(err.message || err)`.
- `tests/test_tools_explorer_security.py`
  - Update security test to assert the old innerHTML error-card template is gone.
  - Assert `renderErrorCard(message)` is defined.

## Testing
```bash
pytest tests/test_tools_explorer_security.py -q
```

## Manual verification
1. Open `tools/explorer/index.html`.
2. Trigger a failing fetch in the dashboard refresh path.
3. Top cards should show a single `Error` card with the exception message rendered as plain text.

## Trade-offs
- No CSS changes — reuses the existing `.card`, `.label`, and `.value` classes.

Closes #7170