### PR TITLE
fix(websocket): tolerate malformed numeric env

### DIFF
--- a/node/websocket_feed.py
+++ b/node/websocket_feed.py
@@ -41,11 +41,34 @@ except ImportError:
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
+def _env_int(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+    try:
+        return int(raw_value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r; using default %s", name, raw_value, default)
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+    try:
+        return float(raw_value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r; using default %s", name, raw_value, default)
+        return default
+
+
 # Configuration
-WS_PORT = int(os.environ.get('WEBSOCKET_PORT', 8765))
+WS_PORT = _env_int('WEBSOCKET_PORT', 8765)
 API_BASE = os.environ.get('RUSTCHAIN_API_BASE', 'http://localhost:8088')
-POLL_INTERVAL = float(os.environ.get('WS_POLL_INTERVAL', '3'))
-MAX_EVENTS = int(os.environ.get('WS_MAX_EVENTS', '100'))
+POLL_INTERVAL = _env_float('WS_POLL_INTERVAL', 3.0)
+MAX_EVENTS = _env_int('WS_MAX_EVENTS', 100)
 JSON_RPC_VERSION = '2.0'
 MINING_STATS_SUBSCRIPTION = 'mining_stats'
 BLOCK_SUBSCRIPTION = 'blocks'

--- a/tests/test_node_websocket_feed_env.py
+++ b/tests/test_node_websocket_feed_env.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_websocket_feed_module():
+    module_path = REPO_ROOT / "node" / "websocket_feed.py"
+    spec = importlib.util.spec_from_file_location(
+        "test_node_websocket_feed_env_module",
+        module_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(spec.name, None)
+    return module
+
+
+def test_websocket_feed_invalid_numeric_env_falls_back(monkeypatch):
+    monkeypatch.setenv("WEBSOCKET_PORT", "not-a-port")
+    monkeypatch.setenv("WS_POLL_INTERVAL", "not-a-float")
+    monkeypatch.setenv("WS_MAX_EVENTS", "not-an-int")
+
+    module = load_websocket_feed_module()
+
+    assert module.WS_PORT == 8765
+    assert module.POLL_INTERVAL == 3.0
+    assert module.MAX_EVENTS == 100
+
+    feed = module.WebSocketFeed()
+    assert feed.block_history.maxlen == 100
+    assert feed.attestation_history.maxlen == 100
+
+
+def test_websocket_feed_valid_numeric_env_is_preserved(monkeypatch):
+    monkeypatch.setenv("WEBSOCKET_PORT", "9001")
+    monkeypatch.setenv("WS_POLL_INTERVAL", "0.25")
+    monkeypatch.setenv("WS_MAX_EVENTS", "7")
+
+    module = load_websocket_feed_module()
+
+    assert module.WS_PORT == 9001
+    assert module.POLL_INTERVAL == 0.25
+    assert module.MAX_EVENTS == 7


### PR DESCRIPTION
## Problem

`node/websocket_feed.py` parsed `WEBSOCKET_PORT`, `WS_POLL_INTERVAL`, and `WS_MAX_EVENTS` directly at import time. A malformed deployment env value raises `ValueError` before the runtime can fall back or even start with WebSocket features disabled.

## Impact

A single bad numeric env value can crash the RustChain node WebSocket feed on import/startup, making the realtime block/miner/attestation feed unavailable.

## Fix

Add small local `_env_int` / `_env_float` helpers that log malformed values and fall back to the existing defaults. Valid numeric env values are preserved.

## Tests

- `uv run --no-project --with pytest --with flask python -B -m pytest -q tests/test_node_websocket_feed_env.py` -> 2 passed
- `git diff --check` -> passed

## Boundaries

Related to the general bug bounty surface (#305). This PR does not change payout amounts, wallet crediting, admin secrets, or production wallet behavior.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
