### PR TITLE
fix(beacon): tolerate malformed key ttl env

### DIFF
--- a/node/beacon_identity.py
+++ b/node/beacon_identity.py
@@ -24,8 +24,20 @@ from typing import Any, Dict, List, Optional, Tuple
 
 log = logging.getLogger("beacon.identity")
 
+
+def _env_int(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+    try:
+        return int(raw_value)
+    except (TypeError, ValueError):
+        log.warning("Invalid %s=%r; using default %s", name, raw_value, default)
+        return default
+
+
 # Default key TTL: 30 days in seconds
-DEFAULT_KEY_TTL: int = int(os.environ.get("BEACON_KEY_TTL", str(30 * 24 * 60 * 60)))
+DEFAULT_KEY_TTL: int = _env_int("BEACON_KEY_TTL", 30 * 24 * 60 * 60)
 
 DB_PATH: str = os.environ.get("BEACON_DB_PATH", "/root/rustchain/rustchain_v2.db")
 

--- a/node/tests/test_beacon_identity.py
+++ b/node/tests/test_beacon_identity.py
@@ -85,6 +85,15 @@ class TestAgentIdFromPubkey:
 # ---------------------------------------------------------------------------
 
 class TestInitIdentityTables:
+    def test_invalid_ttl_env_falls_back_to_default(self, monkeypatch):
+        import importlib
+        from node import beacon_identity as bi
+
+        monkeypatch.setenv("BEACON_KEY_TTL", "not-an-int")
+        reloaded = importlib.reload(bi)
+
+        assert reloaded.DEFAULT_KEY_TTL == 30 * 24 * 60 * 60
+
     def test_creates_tables_without_error(self, db_path):
         import beacon_identity as bi
         bi.init_identity_tables(db_path)  # should not raise


### PR DESCRIPTION
## Problem

`node/beacon_identity.py` parsed `BEACON_KEY_TTL` with `int(...)` at import time. A malformed TTL env value raises `ValueError`, which can crash beacon identity/key-management callers before the TOFU key store is usable.

## Impact

A bad deployment env value can take down beacon identity helpers and CLI/test entrypoints that import the module. This is especially brittle around key TTL / rotation / revocation maintenance paths.

## Fix

Add a small `_env_int` helper that logs malformed values and falls back to the existing 30-day TTL default. Valid numeric env values are preserved.

## Tests

- `uv run --no-project --with pytest --with cryptography python -B -m pytest -q node/tests/test_beacon_identity.py` -> 34 passed
- `git diff --check` -> passed

## Boundaries

Related to the general bug bounty surface (#305). This PR does not change beacon key semantics, payout amounts, wallet crediting, admin secrets, or production wallet behavior.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
