### PR TITLE
fix(p2p): tolerate malformed numeric env

### DIFF
--- a/node/rustchain_p2p_init.py
+++ b/node/rustchain_p2p_init.py
@@ -29,6 +29,17 @@ def _env_flag(name, default=False):
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _env_int(name, default):
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        print(f"[P2P] Invalid {name}={value!r}; using default {default}")
+        return default
+
+
 def _is_private_host(host):
     try:
         return ipaddress.ip_address(host).is_private
@@ -54,7 +65,7 @@ def _discover_upnp_external_url(local_ip, local_port):
 
     try:
         upnp = miniupnpc.UPnP()
-        upnp.discoverdelay = int(os.environ.get("RC_P2P_UPNP_DISCOVER_DELAY_MS", "200"))
+        upnp.discoverdelay = _env_int("RC_P2P_UPNP_DISCOVER_DELAY_MS", 200)
         if upnp.discover() <= 0:
             return None
         upnp.selectigd()
@@ -141,7 +152,7 @@ def init_p2p(app, db_path, node_id=None):
     if my_ips:
         local_ip = next((ip for ip in my_ips if "." in ip and not ip.startswith("127.")), None)
 
-    p2p_port = int(os.environ.get("RC_P2P_PORT", "8099"))
+    p2p_port = _env_int("RC_P2P_PORT", 8099)
     advertised_url = resolve_advertised_url(local_ip or "127.0.0.1", p2p_port)
 
     for k, v in PEER_NODES.items():

--- a/node/tests/test_p2p_nat_upnp.py
+++ b/node/tests/test_p2p_nat_upnp.py
@@ -48,6 +48,36 @@ def test_private_host_uses_upnp_when_available(monkeypatch):
     assert p2p_init.resolve_advertised_url("192.168.1.20", 8099) == "http://203.0.113.7:8099"
 
 
+def test_malformed_upnp_delay_env_falls_back(monkeypatch):
+    class FakeUPnP:
+        discoverdelay = None
+
+        def discover(self):
+            assert self.discoverdelay == 200
+            return 1
+
+        def selectigd(self):
+            return None
+
+        def externalipaddress(self):
+            return "203.0.113.8"
+
+        def addportmapping(self, external_port, proto, local_ip, local_port, desc, remote):
+            return True
+
+    monkeypatch.delenv("RC_P2P_EXTERNAL_URL", raising=False)
+    monkeypatch.setenv("RC_P2P_UPNP_DISCOVER_DELAY_MS", "not-an-int")
+    monkeypatch.setitem(sys.modules, "miniupnpc", types.SimpleNamespace(UPnP=FakeUPnP))
+
+    assert p2p_init.resolve_advertised_url("192.168.1.20", 8099) == "http://203.0.113.8:8099"
+
+
+def test_malformed_p2p_port_env_falls_back(monkeypatch):
+    monkeypatch.setenv("RC_P2P_PORT", "not-an-int")
+
+    assert p2p_init._env_int("RC_P2P_PORT", 8099) == 8099
+
+
 def test_peer_announce_adds_signed_public_peer(tmp_path):
     db_path = tmp_path / "p2p.db"
     receiver = gossip.GossipLayer("node-a", {}, db_path=str(db_path))


### PR DESCRIPTION
## Problem

`node/rustchain_p2p_init.py` parsed P2P numeric env values directly with `int(...)`:

- `RC_P2P_PORT` during `init_p2p(...)`
- `RC_P2P_UPNP_DISCOVER_DELAY_MS` during UPnP discovery

Malformed deployment env values can make P2P init fail or silently disable UPnP discovery via the broad discovery exception path.

## Impact

A single bad numeric env value can prevent a node from starting its P2P helper or from advertising a reachable public P2P URL.

## Fix

Add a small `_env_int` helper that logs malformed numeric env values and falls back to the existing defaults. Valid numeric values are preserved.

## Tests

- `uv run --no-project --with pytest --with flask --with requests python -B -m pytest -q node/tests/test_p2p_nat_upnp.py` -> 6 passed
- `git diff --check` -> passed

## Boundaries

Related to the general bug bounty surface (#305). This PR does not change peer trust, payout amounts, wallet crediting, admin secrets, or production wallet behavior.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
