### PR TITLE
fix(prometheus): tolerate malformed exporter env

### DIFF
--- a/prometheus_exporter.py
+++ b/prometheus_exporter.py
@@ -19,9 +19,19 @@ EXPORTER_HOST = os.getenv(
     'PROMETHEUS_EXPORTER_HOST',
     '0.0.0.0' if os.getenv('RUSTCHAIN_AUTH') else '127.0.0.1'
 )
-EXPORTER_PORT = int(os.getenv('PROMETHEUS_EXPORTER_PORT', '9100'))
-SCRAPE_INTERVAL = int(os.getenv('SCRAPE_INTERVAL', '15'))
 DB_PATH = os.getenv('DB_PATH', 'rustchain.db')
+
+
+def _safe_int_env(name, default):
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s env value; using default %s", name, default)
+        return default
+
+
+EXPORTER_PORT = _safe_int_env('PROMETHEUS_EXPORTER_PORT', 9100)
+SCRAPE_INTERVAL = _safe_int_env('SCRAPE_INTERVAL', 15)
 
 # Metrics storage
 METRIC_DEFAULTS = {

--- a/tests/test_prometheus_exporter_security.py
+++ b/tests/test_prometheus_exporter_security.py
@@ -28,6 +28,26 @@ def load_exporter(monkeypatch, *, auth=None, host=None):
     return module
 
 
+def test_malformed_numeric_env_uses_safe_defaults(monkeypatch):
+    monkeypatch.setenv("PROMETHEUS_EXPORTER_PORT", "not-a-port")
+    monkeypatch.setenv("SCRAPE_INTERVAL", "bad-interval")
+
+    exporter = load_exporter(monkeypatch)
+
+    assert exporter.EXPORTER_PORT == 9100
+    assert exporter.SCRAPE_INTERVAL == 15
+
+
+def test_numeric_env_overrides_are_preserved(monkeypatch):
+    monkeypatch.setenv("PROMETHEUS_EXPORTER_PORT", "9200")
+    monkeypatch.setenv("SCRAPE_INTERVAL", "30")
+
+    exporter = load_exporter(monkeypatch)
+
+    assert exporter.EXPORTER_PORT == 9200
+    assert exporter.SCRAPE_INTERVAL == 30
+
+
 def test_metrics_update_ignores_private_key_payload(monkeypatch):
     exporter = load_exporter(monkeypatch)
 


### PR DESCRIPTION
## Problem

`prometheus_exporter.py` parsed `PROMETHEUS_EXPORTER_PORT` and `SCRAPE_INTERVAL` directly at import time. A malformed deployment env value raises `ValueError` before the exporter can fall back or start.

## Impact

A single bad numeric env value can crash the RustChain Prometheus exporter during startup, removing metrics visibility until the environment is corrected.

## Fix

Add a small local `_safe_int_env` helper that logs malformed numeric env values and falls back to the existing defaults. Valid numeric env overrides are preserved.

## Tests

- `uv run --no-project --with pytest --with flask --with requests python -B -m pytest -q tests/test_prometheus_exporter_security.py` -> 5 passed
- `python3 -m py_compile prometheus_exporter.py tests/test_prometheus_exporter_security.py` -> passed
- `git diff --check` -> passed

## Boundaries

Related to the general bug bounty surface (#305). This PR does not change payout amounts, wallet crediting, admin secrets, or production wallet behavior.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945