### PR TITLE
fix(tools): tolerate malformed prometheus exporter env

### DIFF
--- a/tests/test_prometheus_rustchain_exporter.py
+++ b/tests/test_prometheus_rustchain_exporter.py
@@ -44,6 +44,30 @@ def load_module():
     return module
 
 
+def test_malformed_numeric_env_uses_safe_defaults(monkeypatch):
+    monkeypatch.setenv("EXPORTER_PORT", "not-a-port")
+    monkeypatch.setenv("SCRAPE_INTERVAL", "not-an-interval")
+    monkeypatch.setenv("REQUEST_TIMEOUT", "not-a-timeout")
+
+    module = load_module()
+
+    assert module.EXPORTER_PORT == 9100
+    assert module.SCRAPE_INTERVAL == 60
+    assert module.REQUEST_TIMEOUT == 15
+
+
+def test_numeric_env_overrides_are_preserved(monkeypatch):
+    monkeypatch.setenv("EXPORTER_PORT", "9200")
+    monkeypatch.setenv("SCRAPE_INTERVAL", "30")
+    monkeypatch.setenv("REQUEST_TIMEOUT", "7")
+
+    module = load_module()
+
+    assert module.EXPORTER_PORT == 9200
+    assert module.SCRAPE_INTERVAL == 30
+    assert module.REQUEST_TIMEOUT == 7
+
+
 def test_numeric_coercion_helpers_use_defaults_for_bad_values():
     module = load_module()
 

--- a/tools/prometheus/rustchain_exporter.py
+++ b/tools/prometheus/rustchain_exporter.py
@@ -12,11 +12,22 @@ from urllib.parse import urlsplit, urlunsplit
 import requests
 from prometheus_client import Gauge, start_http_server
 
+
+def _safe_int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        logging.getLogger("rustchain_exporter").warning(
+            "Invalid %s env value; using default %s", name, default
+        )
+        return default
+
+
 NODE_URL = os.getenv("NODE_URL", "https://rustchain.org").rstrip("/")
 P2P_NODE_URL = os.getenv("P2P_NODE_URL", "").rstrip("/")
-EXPORTER_PORT = int(os.getenv("EXPORTER_PORT", "9100"))
-SCRAPE_INTERVAL = int(os.getenv("SCRAPE_INTERVAL", "60"))
-REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT", "15"))
+EXPORTER_PORT = _safe_int_env("EXPORTER_PORT", 9100)
+SCRAPE_INTERVAL = _safe_int_env("SCRAPE_INTERVAL", 60)
+REQUEST_TIMEOUT = _safe_int_env("REQUEST_TIMEOUT", 15)
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),


### PR DESCRIPTION
## Problem

`tools/prometheus/rustchain_exporter.py` parsed `EXPORTER_PORT`, `SCRAPE_INTERVAL`, and `REQUEST_TIMEOUT` directly at import time. A malformed deployment env value raises `ValueError` before the exporter can start.

## Impact

A single bad numeric env value can crash the standalone RustChain Prometheus exporter during startup, removing monitoring visibility until the env is fixed.

## Fix

Add a small local `_safe_int_env` helper that logs malformed numeric env values and falls back to the existing defaults. Valid numeric env overrides are preserved.

## Tests

- `uv run --no-project --with pytest --with requests --with flask python -B -m pytest -q tests/test_prometheus_rustchain_exporter.py` -> 15 passed
- `python3 -m py_compile tools/prometheus/rustchain_exporter.py tests/test_prometheus_rustchain_exporter.py` -> passed
- `git diff --check` -> passed

## Boundaries

Related to the general bug bounty surface (#305). This PR does not change payout amounts, wallet crediting, admin secrets, or production wallet behavior.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945