### PR TITLE
fix(explorer): tolerate malformed API env

### DIFF
--- a/tests/test_explorer_api_query_validation.py
+++ b/tests/test_explorer_api_query_validation.py
@@ -19,6 +19,30 @@ def load_explorer_api():
     return module
 
 
+def test_malformed_numeric_env_uses_safe_defaults(monkeypatch):
+    monkeypatch.setenv("EXPLORER_PORT", "not-a-port")
+    monkeypatch.setenv("CACHE_TTL", "bad-ttl")
+    monkeypatch.setenv("REQUEST_TIMEOUT", "bad-timeout")
+
+    explorer_api = load_explorer_api()
+
+    assert explorer_api.EXPLORER_PORT == 6100
+    assert explorer_api.CACHE_TTL == 15
+    assert explorer_api.REQUEST_TIMEOUT == 10.0
+
+
+def test_numeric_env_overrides_are_preserved(monkeypatch):
+    monkeypatch.setenv("EXPLORER_PORT", "6200")
+    monkeypatch.setenv("CACHE_TTL", "30")
+    monkeypatch.setenv("REQUEST_TIMEOUT", "2.5")
+
+    explorer_api = load_explorer_api()
+
+    assert explorer_api.EXPLORER_PORT == 6200
+    assert explorer_api.CACHE_TTL == 30
+    assert explorer_api.REQUEST_TIMEOUT == 2.5
+
+
 def test_blocks_rejects_non_integer_pagination_params():
     explorer_api = load_explorer_api()
 

--- a/tools/explorer-api/api.py
+++ b/tools/explorer-api/api.py
@@ -16,6 +16,7 @@ CACHE_TTL           – response cache lifetime in seconds (default: 15)
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import threading
 import time
@@ -25,14 +26,33 @@ import requests
 from flask import Flask, jsonify, request
 from flask_cors import CORS
 
+logger = logging.getLogger(__name__)
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
 
+
+def _safe_int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s env value; using default %s", name, default)
+        return default
+
+
+def _safe_float_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s env value; using default %s", name, default)
+        return default
+
+
 NODE_URL = os.environ.get("RUSTCHAIN_NODE_URL", "http://localhost:5000").rstrip("/")
-EXPLORER_PORT = int(os.environ.get("EXPLORER_PORT", "6100"))
-CACHE_TTL = int(os.environ.get("CACHE_TTL", "15"))
-REQUEST_TIMEOUT = float(os.environ.get("REQUEST_TIMEOUT", "10"))
+EXPLORER_PORT = _safe_int_env("EXPLORER_PORT", 6100)
+CACHE_TTL = _safe_int_env("CACHE_TTL", 15)
+REQUEST_TIMEOUT = _safe_float_env("REQUEST_TIMEOUT", 10.0)
 
 app = Flask(__name__)
 CORS(app)


### PR DESCRIPTION
## Problem

`tools/explorer-api/api.py` parsed `EXPLORER_PORT`, `CACHE_TTL`, and `REQUEST_TIMEOUT` directly at import time. A malformed deployment env value raises `ValueError` before the Explorer API can start.

## Impact

A single bad numeric env value can crash the lightweight Explorer API during startup, making explorer endpoints unavailable until the environment is corrected.

## Fix

Add small local `_safe_int_env` and `_safe_float_env` helpers that log malformed numeric env values and fall back to the existing defaults. Valid numeric env overrides are preserved.

## Tests

- `uv run --no-project --with pytest --with flask --with flask-cors --with requests python -B -m pytest -q tests/test_explorer_api_query_validation.py` -> 10 passed
- `python3 -m py_compile tools/explorer-api/api.py tests/test_explorer_api_query_validation.py` -> passed
- `git diff --check` -> passed

## Boundaries

Related to the general bug bounty surface (#305). This PR does not change payout amounts, wallet crediting, admin secrets, or production wallet behavior.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945