### PR TITLE
fix(docker): tolerate malformed entrypoint port env

### DIFF
--- a/docker-entrypoint.py
+++ b/docker-entrypoint.py
@@ -12,6 +12,14 @@ sys.path.insert(0, '/app/node')
 # Import the Flask app from rustchain_dashboard
 from rustchain_dashboard import app
 
+
+def _safe_int_env(name, default):
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 # Add health check endpoint
 @app.route('/health')
 def health_check():
@@ -43,5 +51,5 @@ def health_check():
 
 if __name__ == '__main__':
     # Run the app
-    port = int(os.environ.get('PORT', 8099))
+    port = _safe_int_env('PORT', 8099)
     app.run(host='0.0.0.0', port=port, debug=False)

--- a/tests/test_docker_entrypoint_env.py
+++ b/tests/test_docker_entrypoint_env.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+from flask import Flask
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "docker-entrypoint.py"
+
+
+def load_entrypoint(monkeypatch):
+    dashboard = types.ModuleType("rustchain_dashboard")
+    dashboard.app = Flask("rustchain_dashboard_test")
+    monkeypatch.setitem(sys.modules, "rustchain_dashboard", dashboard)
+
+    module_name = "docker_entrypoint_under_test"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_malformed_port_env_uses_default(monkeypatch):
+    monkeypatch.setenv("PORT", "not-a-port")
+    module = load_entrypoint(monkeypatch)
+
+    assert module._safe_int_env("PORT", 8099) == 8099
+
+
+def test_numeric_port_env_is_preserved(monkeypatch):
+    monkeypatch.setenv("PORT", "8100")
+    module = load_entrypoint(monkeypatch)
+
+    assert module._safe_int_env("PORT", 8099) == 8100
+
+
+def test_health_route_registers_with_stub_dashboard(monkeypatch):
+    monkeypatch.delenv("PORT", raising=False)
+    module = load_entrypoint(monkeypatch)
+
+    response = module.app.test_client().get("/health")
+
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "healthy"


### PR DESCRIPTION
## Problem

`docker-entrypoint.py` parsed `PORT` directly in the container startup path. A malformed deployment env value raises `ValueError` before the Docker entrypoint can start the RustChain dashboard/health endpoint.

## Impact

A single bad `PORT` value can crash the Docker container at startup, making the dashboard and `/health` endpoint unavailable until the environment is corrected.

## Fix

Add a small local `_safe_int_env` helper and use it for the entrypoint port. Valid numeric values are preserved, while malformed values fall back to the existing `8099` default.

## Tests

- `uv run --no-project --with pytest --with flask python -B -m pytest -q tests/test_docker_entrypoint_env.py` -> 3 passed
- `python3 -m py_compile docker-entrypoint.py tests/test_docker_entrypoint_env.py` -> passed
- `git diff --check` -> passed

## Boundaries

Related to the general bug bounty surface (#305). This PR does not change payout amounts, wallet crediting, admin secrets, or production wallet behavior.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945