### PR TITLE
fix(mcp): tolerate malformed client env

### DIFF
--- a/rustchain-bounties-mcp/rustchain_bounties_mcp/client.py
+++ b/rustchain-bounties-mcp/rustchain_bounties_mcp/client.py
@@ -34,8 +34,18 @@ logger = logging.getLogger(__name__)
 
 # Defaults — node URL is configurable, defaulting to the live node
 DEFAULT_NODE_URL = os.getenv("RUSTCHAIN_NODE_URL", "https://50.28.86.131")
-REQUEST_TIMEOUT = int(os.getenv("RUSTCHAIN_TIMEOUT", "30"))
-RETRY_COUNT = int(os.getenv("RUSTCHAIN_RETRY", "2"))
+
+
+def _safe_int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s env value; using default %s", name, default)
+        return default
+
+
+REQUEST_TIMEOUT = _safe_int_env("RUSTCHAIN_TIMEOUT", 30)
+RETRY_COUNT = _safe_int_env("RUSTCHAIN_RETRY", 2)
 
 # GitHub bounties repo — used as the authoritative source for open bounties
 # because the node does not expose a native /api/bounties endpoint.

--- a/rustchain-bounties-mcp/tests/test_client_miners.py
+++ b/rustchain-bounties-mcp/tests/test_client_miners.py
@@ -1,5 +1,6 @@
 """Tests for RustChain bounties MCP miner client normalization."""
 
+import importlib
 import os
 import sys
 from unittest.mock import MagicMock
@@ -9,6 +10,7 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from rustchain_bounties_mcp.client import RustChainClient
+import rustchain_bounties_mcp.client as client_module
 
 
 class AsyncContextManager:
@@ -40,6 +42,26 @@ def client_for_response(data) -> RustChainClient:
     client._session = session
     client._owns_session = False
     return client
+
+
+def test_malformed_numeric_env_uses_safe_defaults(monkeypatch):
+    monkeypatch.setenv("RUSTCHAIN_TIMEOUT", "not-a-timeout")
+    monkeypatch.setenv("RUSTCHAIN_RETRY", "bad-retry")
+
+    module = importlib.reload(client_module)
+
+    assert module.REQUEST_TIMEOUT == 30
+    assert module.RETRY_COUNT == 2
+
+
+def test_numeric_env_overrides_are_preserved(monkeypatch):
+    monkeypatch.setenv("RUSTCHAIN_TIMEOUT", "12")
+    monkeypatch.setenv("RUSTCHAIN_RETRY", "4")
+
+    module = importlib.reload(client_module)
+
+    assert module.REQUEST_TIMEOUT == 12
+    assert module.RETRY_COUNT == 4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`rustchain-bounties-mcp/rustchain_bounties_mcp/client.py` parsed `RUSTCHAIN_TIMEOUT` and `RUSTCHAIN_RETRY` directly at import time. A malformed local environment value raises `ValueError` before the MCP client can start.

## Impact

A single bad numeric env value can crash the RustChain bounties MCP client during startup, preventing bounty/node tooling from initializing until the environment is corrected.

## Fix

Add a small local `_safe_int_env` helper that logs malformed numeric env values and falls back to the existing defaults. Valid numeric env overrides are preserved.

## Tests

- `uv run --no-project --with pytest --with pytest-asyncio --with aiohttp python -B -m pytest -q tests/test_client_miners.py` -> 4 passed
- `python3 -m py_compile rustchain_bounties_mcp/client.py tests/test_client_miners.py` -> passed
- `git diff --check` -> passed

## Boundaries

Related to the general bug bounty surface (#305). This PR does not change payout amounts, wallet crediting, admin secrets, or production wallet behavior.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945