### PR TITLE
fix(integrations): tolerate malformed mcp client env

### DIFF
--- a/integrations/rustchain-mcp/client.py
+++ b/integrations/rustchain-mcp/client.py
@@ -39,8 +39,18 @@ logger = logging.getLogger(__name__)
 # Default configuration
 RUSTCHAIN_API_BASE = os.getenv("RUSTCHAIN_API_BASE", "https://50.28.86.131")
 RUSTCHAIN_NODE_URL = os.getenv("RUSTCHAIN_NODE_URL", "https://50.28.86.131:5000")
-REQUEST_TIMEOUT = int(os.getenv("RUSTCHAIN_TIMEOUT", "30"))
-RETRY_COUNT = int(os.getenv("RUSTCHAIN_RETRY", "2"))
+
+
+def _safe_int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s env value; using default %s", name, default)
+        return default
+
+
+REQUEST_TIMEOUT = _safe_int_env("RUSTCHAIN_TIMEOUT", 30)
+RETRY_COUNT = _safe_int_env("RUSTCHAIN_RETRY", 2)
 
 
 class RustChainClient:

--- a/integrations/rustchain-mcp/tests/test_client.py
+++ b/integrations/rustchain-mcp/tests/test_client.py
@@ -5,6 +5,7 @@ RustChain MCP - Client Tests
 Unit tests for RustChainClient with mocked HTTP responses.
 """
 
+import importlib
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -14,6 +15,7 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 try:
+    import rustchain_mcp.client as client_module
     from rustchain_mcp.client import RustChainClient
     from rustchain_mcp.schemas import (
         APIError,
@@ -24,6 +26,7 @@ try:
         WalletBalance,
     )
 except ImportError:
+    import client as client_module
     from client import RustChainClient
     from schemas import (
         APIError,
@@ -33,6 +36,26 @@ except ImportError:
         QueryResult,
         WalletBalance,
     )
+
+
+def test_malformed_numeric_env_uses_safe_defaults(monkeypatch):
+    monkeypatch.setenv("RUSTCHAIN_TIMEOUT", "not-a-timeout")
+    monkeypatch.setenv("RUSTCHAIN_RETRY", "bad-retry")
+
+    module = importlib.reload(client_module)
+
+    assert module.REQUEST_TIMEOUT == 30
+    assert module.RETRY_COUNT == 2
+
+
+def test_numeric_env_overrides_are_preserved(monkeypatch):
+    monkeypatch.setenv("RUSTCHAIN_TIMEOUT", "12")
+    monkeypatch.setenv("RUSTCHAIN_RETRY", "4")
+
+    module = importlib.reload(client_module)
+
+    assert module.REQUEST_TIMEOUT == 12
+    assert module.RETRY_COUNT == 4
 
 
 class AsyncContextManager:


### PR DESCRIPTION
## Problem

`integrations/rustchain-mcp/client.py` parsed `RUSTCHAIN_TIMEOUT` and `RUSTCHAIN_RETRY` directly at import time. A malformed local environment value raises `ValueError` before the generic RustChain MCP client can start.

## Impact

A single bad numeric env value can crash MCP integration tooling during startup, preventing health/epoch/wallet query helpers from initializing until the environment is corrected.

## Fix

Add a small local `_safe_int_env` helper that logs malformed numeric env values and falls back to the existing defaults. Valid numeric env overrides are preserved.

## Tests

- `uv run --no-project --with pytest --with pytest-asyncio --with aiohttp python -B -m pytest -q tests/test_client.py` -> 15 passed
- `python3 -m py_compile client.py tests/test_client.py` -> passed
- `git diff --check` -> passed

## Boundaries

Related to the general bug bounty surface (#305). This PR does not change payout amounts, wallet crediting, admin secrets, or production wallet behavior.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945