### PR TITLE
fix(explorer): tolerate malformed websocket env

### DIFF
--- a/explorer/explorer_websocket_server.py
+++ b/explorer/explorer_websocket_server.py
@@ -50,11 +50,25 @@ except ImportError:
     HAVE_SOCKETIO = False
     print("Warning: flask-socketio not installed. Run: pip install flask-socketio")
 
+def _env_int(name, default):
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name, default):
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 # ─── Configuration ─────────────────────────────────────────────────────────── #
-EXPLORER_PORT = int(os.environ.get('EXPLORER_PORT', 8080))
+EXPLORER_PORT = _env_int('EXPLORER_PORT', 8080)
 NODE_URL = os.environ.get('RUSTCHAIN_NODE_URL', os.environ.get('RUSTCHAIN_API_BASE', 'https://rustchain.org'))
-API_TIMEOUT = float(os.environ.get('API_TIMEOUT', '8'))
-POLL_INTERVAL = float(os.environ.get('POLL_INTERVAL', '5'))  # seconds between polls
+API_TIMEOUT = _env_float('API_TIMEOUT', 8)
+POLL_INTERVAL = _env_float('POLL_INTERVAL', 5)  # seconds between polls
 HEARTBEAT_S = 30  # ping/pong interval for connection health
 MAX_QUEUE = 100  # max buffered events per client (backpressure)
 SOCKETIO_CORS_ORIGINS = parse_socketio_cors_origins(local_port=EXPLORER_PORT)

--- a/explorer/test_explorer_websocket.py
+++ b/explorer/test_explorer_websocket.py
@@ -228,6 +228,21 @@ class TestWebSocketConfiguration(unittest.TestCase):
         self.assertEqual(POLL_INTERVAL, 10)
         self.assertEqual(NODE_URL, 'https://test.node.com')
 
+    @patch.dict(os.environ, {
+        'EXPLORER_PORT': 'not-a-port',
+        'API_TIMEOUT': 'not-a-timeout',
+        'POLL_INTERVAL': 'not-an-interval',
+    })
+    def test_malformed_numeric_env_falls_back_to_defaults(self):
+        """Malformed numeric env should not crash module import."""
+        import importlib
+        import explorer_websocket_server
+        importlib.reload(explorer_websocket_server)
+
+        self.assertEqual(explorer_websocket_server.EXPLORER_PORT, 8080)
+        self.assertEqual(explorer_websocket_server.API_TIMEOUT, 8)
+        self.assertEqual(explorer_websocket_server.POLL_INTERVAL, 5)
+
 
 class TestAPIEndpoints(unittest.TestCase):
     """Tests for HTTP API endpoints"""


### PR DESCRIPTION
## Problem

`explorer/explorer_websocket_server.py` parsed `EXPLORER_PORT`, `API_TIMEOUT`, and `POLL_INTERVAL` with raw `int(...)` / `float(...)` calls during module import. A malformed numeric environment value could raise `ValueError` before the Explorer WebSocket server starts, even though the existing defaults are safe.

## Impact

This is a small operational reliability hardening fix for the real-time explorer process. It keeps malformed deployment env from taking down startup while preserving valid numeric overrides.

## Fix

- Add local `_env_int` and `_env_float` helpers.
- Fall back to the existing defaults when numeric env values are malformed.
- Keep `RUSTCHAIN_NODE_URL` / `RUSTCHAIN_API_BASE` behavior unchanged.

## Tests

- `uv run --no-project --with pytest --with flask --with flask-socketio --with requests python -B -m pytest -q explorer/test_explorer_websocket.py` -> 39 passed
- `python3 -m py_compile explorer/explorer_websocket_server.py explorer/test_explorer_websocket.py` -> passed
- `git diff --check` -> passed

## Boundaries

No payout amount, wallet crediting, admin-secret, production-wallet, peer-trust, or bridge behavior changes.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
