### PR TITLE
fix(bottube): tolerate malformed digest env

### DIFF
--- a/bottube_digest_bot/config.py
+++ b/bottube_digest_bot/config.py
@@ -9,6 +9,20 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 @dataclass
 class BotConfig:
     """Bot configuration loaded from environment variables."""
@@ -76,23 +90,23 @@ class BotConfig:
             rustchain_node_url=os.getenv(
                 "RUSTCHAIN_NODE_URL", "https://50.28.86.131"
             ),
-            api_timeout=float(os.getenv("RUSTCHAIN_API_TIMEOUT", "15.0")),
+            api_timeout=_env_float("RUSTCHAIN_API_TIMEOUT", 15.0),
             verify_ssl=os.getenv("RUSTCHAIN_VERIFY_SSL", "false").lower() == "true",
             bottube_url=os.getenv("BOTTUBE_URL", "https://bottube.ai"),
-            bottube_api_timeout=float(os.getenv("BOTTUBE_API_TIMEOUT", "10.0")),
+            bottube_api_timeout=_env_float("BOTTUBE_API_TIMEOUT", 10.0),
             discord_webhook_url=os.getenv("DISCORD_WEBHOOK_URL", ""),
             discord_bot_token=os.getenv("DISCORD_BOT_TOKEN", ""),
             discord_channel_id=os.getenv("DISCORD_CHANNEL_ID", ""),
             telegram_bot_token=os.getenv("TELEGRAM_BOT_TOKEN", ""),
             telegram_chat_id=os.getenv("TELEGRAM_CHAT_ID", ""),
             smtp_host=os.getenv("SMTP_HOST", ""),
-            smtp_port=int(os.getenv("SMTP_PORT", "587")),
+            smtp_port=_env_int("SMTP_PORT", 587),
             smtp_user=os.getenv("SMTP_USER", ""),
             smtp_password=os.getenv("SMTP_PASSWORD", ""),
             smtp_from=os.getenv("SMTP_FROM", ""),
             digest_recipients=recipients,
-            digest_top_n=int(os.getenv("DIGEST_TOP_N", "10")),
-            digest_top_videos=int(os.getenv("DIGEST_TOP_VIDEOS", "5")),
+            digest_top_n=_env_int("DIGEST_TOP_N", 10),
+            digest_top_videos=_env_int("DIGEST_TOP_VIDEOS", 5),
             include_epoch_summary=os.getenv("INCLUDE_EPOCH_SUMMARY", "true").lower()
             != "false",
             include_miner_stats=os.getenv("INCLUDE_MINER_STATS", "true").lower()
@@ -103,8 +117,8 @@ class BotConfig:
             != "false",
             schedule_mode=os.getenv("SCHEDULE_MODE", "weekly"),
             schedule_day=os.getenv("SCHEDULE_DAY", "monday"),
-            schedule_hour=int(os.getenv("SCHEDULE_HOUR", "9")),
-            schedule_minute=int(os.getenv("SCHEDULE_MINUTE", "0")),
+            schedule_hour=_env_int("SCHEDULE_HOUR", 9),
+            schedule_minute=_env_int("SCHEDULE_MINUTE", 0),
             log_level=os.getenv("LOG_LEVEL", "INFO"),
             log_file=os.getenv("LOG_FILE", ""),
             dry_run=os.getenv("DRY_RUN", "false").lower() == "true",

--- a/bottube_digest_bot/tests/test_bottube_digest_bot.py
+++ b/bottube_digest_bot/tests/test_bottube_digest_bot.py
@@ -58,6 +58,30 @@ class TestBotConfig(unittest.TestCase):
             self.assertEqual(config.schedule_day, "friday")
             self.assertEqual(config.log_level, "DEBUG")
 
+    def test_malformed_numeric_env_falls_back_to_defaults(self):
+        """Malformed numeric env should not crash config loading."""
+        with patch.dict(
+            os.environ,
+            {
+                "RUSTCHAIN_API_TIMEOUT": "not-a-timeout",
+                "BOTTUBE_API_TIMEOUT": "not-a-timeout",
+                "SMTP_PORT": "not-a-port",
+                "DIGEST_TOP_N": "not-a-count",
+                "DIGEST_TOP_VIDEOS": "not-a-count",
+                "SCHEDULE_HOUR": "not-an-hour",
+                "SCHEDULE_MINUTE": "not-a-minute",
+            },
+        ):
+            config = BotConfig.from_env()
+
+        self.assertEqual(config.api_timeout, 15.0)
+        self.assertEqual(config.bottube_api_timeout, 10.0)
+        self.assertEqual(config.smtp_port, 587)
+        self.assertEqual(config.digest_top_n, 10)
+        self.assertEqual(config.digest_top_videos, 5)
+        self.assertEqual(config.schedule_hour, 9)
+        self.assertEqual(config.schedule_minute, 0)
+
     def test_config_validation_valid(self):
         """Test validation with valid configuration."""
         config = BotConfig(dry_run=True)  # Dry run skips delivery validation


### PR DESCRIPTION
## Problem

`bottube_digest_bot/config.py` loaded several numeric environment variables with raw `int(...)` / `float(...)` calls. A malformed value for `RUSTCHAIN_API_TIMEOUT`, `BOTTUBE_API_TIMEOUT`, `SMTP_PORT`, digest limits, or schedule fields could raise `ValueError` while loading config instead of using the documented defaults.

## Impact

This is a small operational reliability hardening fix for the BoTTube digest bot. Bad deployment env no longer prevents config loading; valid numeric overrides and existing validation behavior are preserved.

## Fix

- Add local `_env_int` and `_env_float` helpers.
- Fall back to existing defaults only when numeric env parsing fails.
- Keep positive-value and schedule validation unchanged.

## Tests

- `uv run --no-project --with pytest --with aiohttp --with httpx python -B -m pytest -q bottube_digest_bot/tests/test_bottube_digest_bot.py` -> 29 passed
- `python3 -m py_compile bottube_digest_bot/config.py bottube_digest_bot/tests/test_bottube_digest_bot.py` -> passed
- `git diff --check` -> passed

## Boundaries

No payout amount, wallet crediting, admin-secret, production-wallet, peer-trust, bridge, or bot delivery behavior changes.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
