### PR TITLE
fix(discord): tolerate malformed timeout env

### DIFF
--- a/discord_bot/config.py
+++ b/discord_bot/config.py
@@ -8,6 +8,14 @@ import os
 from dataclasses import dataclass
 
 
+def _safe_float(val: str | None, default: float) -> float:
+    """Cast *val* to float, returning *default* on malformed input."""
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return default
+
+
 @dataclass
 class BotConfig:
     """Bot configuration loaded from environment variables."""
@@ -36,7 +44,7 @@ class BotConfig:
             rustchain_node_url=os.getenv(
                 "RUSTCHAIN_NODE_URL", "https://rustchain.org"
             ),
-            api_timeout=float(os.getenv("RUSTCHAIN_API_TIMEOUT", "10.0")),
+            api_timeout=_safe_float(os.getenv("RUSTCHAIN_API_TIMEOUT", "10.0"), 10.0),
             prefix=os.getenv("BOT_PREFIX", "!"),
             owner_id=os.getenv("BOT_OWNER_ID", ""),
             log_level=os.getenv("LOG_LEVEL", "INFO"),

--- a/tests/test_discord_bot_config.py
+++ b/tests/test_discord_bot_config.py
@@ -58,6 +58,15 @@ def test_from_env_loads_custom_values(monkeypatch):
     assert config.log_level == "DEBUG"
 
 
+def test_from_env_falls_back_on_malformed_timeout(monkeypatch):
+    module = load_config_module()
+    monkeypatch.setenv("RUSTCHAIN_API_TIMEOUT", "not-a-float")
+
+    config = module.BotConfig.from_env()
+
+    assert config.api_timeout == 10.0
+
+
 def test_validate_reports_required_and_timeout_errors():
     module = load_config_module()
     config = module.BotConfig(

--- a/tests/test_python_discord_bot_miners.py
+++ b/tests/test_python_discord_bot_miners.py
@@ -146,3 +146,11 @@ def test_miners_command_uses_paginated_total_and_miner_id_fallback(monkeypatch):
     assert "Arch: G4" in embed.fields[0]["value"]
     assert embed.fields[1]["name"] == "bob"
     assert embed.footer == "Showing 2 of 37 miners | https://rustchain.org"
+
+
+def test_module_import_falls_back_on_malformed_timeout(monkeypatch):
+    monkeypatch.setenv("API_TIMEOUT", "not-a-float")
+
+    module = load_bot_module(monkeypatch)
+
+    assert module.API_TIMEOUT == 10.0

--- a/tools/discord-bot/bot.py
+++ b/tools/discord-bot/bot.py
@@ -42,7 +42,17 @@ log = logging.getLogger("rustchain-bot")
 
 RUSTCHAIN_URL = os.getenv("RUSTCHAIN_NODE_URL", "https://rustchain.org").rstrip("/")
 DISCORD_TOKEN = os.getenv("DISCORD_TOKEN", "")
-API_TIMEOUT = float(os.getenv("API_TIMEOUT", "10"))
+
+
+def _safe_float(val: str | None, default: float) -> float:
+    """Cast *val* to float, returning *default* on malformed input."""
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return default
+
+
+API_TIMEOUT = _safe_float(os.getenv("API_TIMEOUT", "10"), 10.0)
 
 
 def _format_uptime(value) -> str:


### PR DESCRIPTION
## Problem

Both Discord bot entry points parse timeout environment variables with a direct `float(...)` at import/config-load time:

- `tools/discord-bot/bot.py` reads `API_TIMEOUT`
- `discord_bot/config.py` reads `RUSTCHAIN_API_TIMEOUT`

If either variable is empty or malformed, the bot crashes before validation can run or before the command module can be imported.

## Impact

This is an operational reliability hardening for Discord bot deployments. A single bad timeout value should fall back to the documented default instead of taking the bot down at startup.

## Fix

- Add local `_safe_float(...)` helpers for the two Discord timeout reads.
- Preserve valid custom timeout values.
- Preserve existing positive-timeout validation in `BotConfig.validate()`.

## Tests

- `uv run --no-project --with pytest --with flask python -B -m pytest -q tests/test_discord_bot_config.py tests/test_python_discord_bot_miners.py tests/test_discord_bot_commands.py` -> 10 passed
- `python3 -m py_compile discord_bot/config.py tools/discord-bot/bot.py tests/test_discord_bot_config.py tests/test_python_discord_bot_miners.py tests/test_discord_bot_commands.py` -> passed
- `git diff --check` -> passed

## Boundaries

- No Discord command behavior changes.
- No wallet, payout, transfer, reward, admin secret, or production wallet changes.
- No user-callable payout or crediting path changes.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
