### PR TITLE
fix(sync): tolerate malformed committee env

### DIFF
--- a/tests/test_sync_committee_tracker.py
+++ b/tests/test_sync_committee_tracker.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 """Tests for the sync committee rotation tracker."""
 
+import importlib.util
+import sys
 from pathlib import Path
 
 from tools.sync_committee_tracker.sync_committee_tracker import (
@@ -10,6 +12,35 @@ from tools.sync_committee_tracker.sync_committee_tracker import (
     render_metrics,
     select_committee,
 )
+
+
+TRACKER_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "tools"
+    / "sync_committee_tracker"
+    / "sync_committee_tracker.py"
+)
+
+
+def load_tracker_module(name: str):
+    spec = importlib.util.spec_from_file_location(name, TRACKER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(name, None)
+    return module
+
+
+def test_malformed_env_defaults_do_not_crash_import(monkeypatch):
+    monkeypatch.setenv("SYNC_COMMITTEE_SIZE", "not-an-int")
+    monkeypatch.setenv("SYNC_COMMITTEE_ROTATION_EPOCHS", "")
+
+    module = load_tracker_module("sync_committee_tracker_malformed_env")
+
+    assert module.DEFAULT_COMMITTEE_SIZE == 8
+    assert module.DEFAULT_ROTATION_EPOCHS == 1
 
 
 def test_normalize_miners_accepts_common_payload_shapes():

--- a/tools/sync_committee_tracker/sync_committee_tracker.py
+++ b/tools/sync_committee_tracker/sync_committee_tracker.py
@@ -22,10 +22,19 @@ from typing import Any
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
+
+def _safe_int(val: str | None, default: int) -> int:
+    """Cast *val* to int, returning *default* on malformed input."""
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return default
+
+
 DEFAULT_NODE_URL = os.getenv("RUSTCHAIN_NODE_URL", "https://rustchain.org").rstrip("/")
 DEFAULT_DB_PATH = Path(os.getenv("SYNC_COMMITTEE_DB", "sync_committee_history.db"))
-DEFAULT_COMMITTEE_SIZE = int(os.getenv("SYNC_COMMITTEE_SIZE", "8"))
-DEFAULT_ROTATION_EPOCHS = int(os.getenv("SYNC_COMMITTEE_ROTATION_EPOCHS", "1"))
+DEFAULT_COMMITTEE_SIZE = _safe_int(os.getenv("SYNC_COMMITTEE_SIZE", "8"), 8)
+DEFAULT_ROTATION_EPOCHS = _safe_int(os.getenv("SYNC_COMMITTEE_ROTATION_EPOCHS", "1"), 1)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Problem

`tools/sync_committee_tracker/sync_committee_tracker.py` parses `SYNC_COMMITTEE_SIZE` and `SYNC_COMMITTEE_ROTATION_EPOCHS` with direct `int(...)` calls at module import time.

If an operator sets either env var to an empty or malformed value, the tracker crashes before it can start the dashboard/metrics utility.

## Impact

This is an operational reliability hardening for the sync committee tracker. Malformed numeric env values should fall back to documented defaults instead of preventing the utility from importing.

## Fix

- Add a local `_safe_int(...)` helper for import-time numeric env parsing.
- Use it for `DEFAULT_COMMITTEE_SIZE` and `DEFAULT_ROTATION_EPOCHS`.
- Add a regression test that dynamically imports the tracker with malformed env values and verifies the defaults are preserved.

## Tests

- `uv run --no-project --with pytest --with flask python -B -m pytest -q tests/test_sync_committee_tracker.py` -> 6 passed
- `python3 -m py_compile tools/sync_committee_tracker/sync_committee_tracker.py tests/test_sync_committee_tracker.py` -> passed
- `git diff --check` -> passed

## Boundaries

- No committee selection algorithm changes.
- No node, wallet, payout, transfer, reward, admin secret, or production wallet changes.
- No user-callable payout or crediting path changes.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
