### PR TITLE
fix(health): tolerate malformed dashboard env

### DIFF
--- a/health-dashboard/server.py
+++ b/health-dashboard/server.py
@@ -35,8 +35,22 @@ TEMPLATES_DIR = BASE_DIR / 'templates'
 DATA_DIR = BASE_DIR / 'data'
 DATA_DIR.mkdir(exist_ok=True)
 
+
+def _safe_int(value, default: int) -> int:
+    """Cast *value* to int, returning *default* on malformed input."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read an integer environment variable with a safe default fallback."""
+    return _safe_int(os.environ.get(name, default), default)
+
+
 DB_PATH = DATA_DIR / 'health_history.db'
-POLLING_INTERVAL = int(os.environ.get('POLLING_INTERVAL', 60))  # 60 seconds
+POLLING_INTERVAL = _env_int('POLLING_INTERVAL', 60)  # 60 seconds
 HISTORY_RETENTION_HOURS = 24
 
 # Node configuration from issue #2300
@@ -1244,7 +1258,7 @@ def main():
     poll_nodes()
     
     # Start Flask server
-    port = int(os.environ.get('PORT', 5000))
+    port = _env_int('PORT', 5000)
     logger.info(f"Starting web server on port {port}")
     
     app.run(host='0.0.0.0', port=port, debug=False, threaded=True)

--- a/health-dashboard/test_health_dashboard.py
+++ b/health-dashboard/test_health_dashboard.py
@@ -3,6 +3,7 @@
 Tests for RustChain Multi-Node Health Dashboard
 Issue #2300
 """
+import importlib.util
 import json
 import os
 import sqlite3
@@ -28,6 +29,30 @@ from server import (
     cleanup_old_data,
     HISTORY_RETENTION_HOURS
 )
+
+
+SERVER_PATH = Path(__file__).parent / 'server.py'
+
+
+def load_dashboard_module(name: str):
+    spec = importlib.util.spec_from_file_location(name, SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(name, None)
+    return module
+
+
+def test_malformed_numeric_env_defaults_do_not_crash_import(monkeypatch):
+    monkeypatch.setenv('POLLING_INTERVAL', 'not-an-int')
+    monkeypatch.setenv('PORT', '')
+
+    module = load_dashboard_module('health_dashboard_malformed_env')
+
+    assert module.POLLING_INTERVAL == 60
+    assert module._env_int('PORT', 5000) == 5000
 
 
 class TestNodeStatus(unittest.TestCase):


### PR DESCRIPTION
## Problem

`health-dashboard/server.py` parses numeric env values with raw `int(...)` calls:

- `POLLING_INTERVAL` at module import time
- `PORT` in the startup path

Empty or malformed values crash the dashboard before it can start.

## Impact

This hardens the multi-node health dashboard startup path. Operator env mistakes should fall back to documented defaults instead of taking the dashboard offline.

## Fix

- Add local `_safe_int(...)` / `_env_int(...)` helpers.
- Use them for `POLLING_INTERVAL` and `PORT`.
- Add a regression test that dynamically imports the dashboard with malformed numeric env values.

## Tests

- `uv run --no-project --with pytest --with flask --with requests python -B -m pytest -q health-dashboard/test_health_dashboard.py` -> 25 passed
- `python3 -m py_compile health-dashboard/server.py health-dashboard/test_health_dashboard.py` -> passed
- `git diff --check` -> passed

## Boundaries

- No dashboard API response shape changes.
- No node health check logic changes.
- No wallet, payout, transfer, reward, admin secret, or production wallet changes.
- No user-callable payout or crediting path changes.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
