### PR TITLE
fix(explorer): tolerate malformed websocket env

### DIFF
--- a/explorer/test_ws_explorer.py
+++ b/explorer/test_ws_explorer.py
@@ -1,10 +1,45 @@
 # SPDX-License-Identifier: MIT
 """Unit tests for RustChain Explorer WebSocket Feed (Bounty #2295)."""
 
+import importlib.util
 import json
+import sys
+import threading
 import pytest
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 from ws_explorer_server import app, socketio, state, fetch_api, poll_and_broadcast
+
+
+MODULE_PATH = Path(__file__).with_name("ws_explorer_server.py")
+
+
+class _NoopThread:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def start(self):
+        pass
+
+
+def load_ws_explorer_module(monkeypatch):
+    module_name = "test_ws_explorer_server_env_module"
+    monkeypatch.setattr(threading, "Thread", _NoopThread)
+    sys.path.insert(0, str(MODULE_PATH.parent))
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            sys.modules.pop(module_name, None)
+    finally:
+        try:
+            sys.path.remove(str(MODULE_PATH.parent))
+        except ValueError:
+            pass
+    return module
 
 
 @pytest.fixture
@@ -51,6 +86,30 @@ class TestFetchAPI:
         with patch("ws_explorer_server.requests.get", return_value=mock_resp):
             result = fetch_api("/health")
         assert result is None
+
+
+class TestNumericEnv:
+    def test_malformed_numeric_env_falls_back(self, monkeypatch):
+        monkeypatch.setenv("API_TIMEOUT", "not-a-timeout")
+        monkeypatch.setenv("WS_POLL_INTERVAL", "not-an-interval")
+        monkeypatch.setenv("WS_EXPLORER_PORT", "not-a-port")
+
+        module = load_ws_explorer_module(monkeypatch)
+
+        assert module.API_TIMEOUT == 8.0
+        assert module.POLL_INTERVAL == 10.0
+        assert module.PORT == 8060
+
+    def test_valid_numeric_env_is_preserved(self, monkeypatch):
+        monkeypatch.setenv("API_TIMEOUT", "2.5")
+        monkeypatch.setenv("WS_POLL_INTERVAL", "0.75")
+        monkeypatch.setenv("WS_EXPLORER_PORT", "9002")
+
+        module = load_ws_explorer_module(monkeypatch)
+
+        assert module.API_TIMEOUT == 2.5
+        assert module.POLL_INTERVAL == 0.75
+        assert module.PORT == 9002
 
 
 class TestHTTPRoutes:

--- a/explorer/ws_explorer_server.py
+++ b/explorer/ws_explorer_server.py
@@ -23,10 +23,26 @@ except ModuleNotFoundError:
     from socketio_cors import parse_socketio_cors_origins
 
 # ── Configuration ─────────────────────────────────────────────────
+
+
+def _float_env(name, default):
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _int_env(name, default):
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 API_BASE = os.environ.get("RUSTCHAIN_API_BASE", "https://rustchain.org").rstrip("/")
-API_TIMEOUT = float(os.environ.get("API_TIMEOUT", "8"))
-POLL_INTERVAL = float(os.environ.get("WS_POLL_INTERVAL", "10"))
-PORT = int(os.environ.get("WS_EXPLORER_PORT", "8060"))
+API_TIMEOUT = _float_env("API_TIMEOUT", 8.0)
+POLL_INTERVAL = _float_env("WS_POLL_INTERVAL", 10.0)
+PORT = _int_env("WS_EXPLORER_PORT", 8060)
 SOCKETIO_CORS_ORIGINS = parse_socketio_cors_origins(local_port=PORT)
 
 app = Flask(__name__, template_folder="templates", static_folder="static")

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3075,7 +3075,7 @@ def _get_streak_bonus(miner: str) -> float:
             rows = conn.execute(
                 "SELECT ts_ok FROM miner_attest_history WHERE miner = ? ORDER BY ts_ok DESC LIMIT 1000",
                 (miner,)
-            ).fetchall()
+            ).fetchall()  # fetchall-ok: already-paginated
             
             if not rows:
                 return 0.0
@@ -7895,7 +7895,7 @@ def _attestation_pool_snapshot(now_ts: Optional[int] = None) -> dict:
                 LIMIT 20
                 """,
                 (active_cutoff,),
-            ).fetchall()
+            ).fetchall()  # fetchall-ok: already-paginated
             snapshot["by_device_arch"] = [
                 {"device_arch": r["device_arch"], "active_miners": int(r["miners"] or 0)}
                 for r in arch_rows


### PR DESCRIPTION
## Problem
- explorer/ws_explorer_server.py parses API_TIMEOUT, WS_POLL_INTERVAL, and WS_EXPLORER_PORT at import time with raw float()/int().
- A malformed deployment env value crashes the WebSocket explorer before it can start.

## Related evidence
- Repository-local evidence: selector-owned current-main code audit found this focused RustChain risk surface and generated the matching regression patch.

## Impact
- Operator typo or stale env injection can take down this real-time explorer process.

## Fix
- Add small numeric env helpers that fall back to the documented defaults on malformed values.
- Preserve valid configured values.

## Tests
- python3 -m py_compile explorer/ws_explorer_server.py explorer/test_ws_explorer.py
- uv run --no-project --with pytest --with flask --with flask-socketio --with requests python -B -m pytest -q explorer/test_ws_explorer.py -> 14 passed
- git diff --check


## Maintenance-only CI baseline note
- This branch also includes a follow-up fetchall guard baseline annotation in `node/rustchain_v2_integrated_v2.2.1_rip200.py`.
- The maintenance commit only marks two existing LIMIT-bounded `.fetchall()` reads as `fetchall-ok: already-paginated`; no business logic for this PR changed.

## Additional maintenance validation
- `bash scripts/check_fetchall.sh` -> passed
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py` -> passed
- `git diff --check` -> passed

## Risk
- Narrow config-hardening change only; no WebSocket protocol or API behavior changes.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
