### PR TITLE
fix(explorer): tolerate malformed realtime env

### DIFF
--- a/explorer/realtime_server.py
+++ b/explorer/realtime_server.py
@@ -19,11 +19,26 @@ try:
 except ModuleNotFoundError:
     from socketio_cors import parse_socketio_cors_origins
 
+
+def _float_env(name, default):
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _int_env(name, default):
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 # Configuration
-EXPLORER_PORT = int(os.environ.get('EXPLORER_PORT', 8080))
+EXPLORER_PORT = _int_env('EXPLORER_PORT', 8080)
 API_BASE = os.environ.get('RUSTCHAIN_API_BASE', 'https://rustchain.org').rstrip('/')
-API_TIMEOUT = float(os.environ.get('API_TIMEOUT', '8'))
-POLL_INTERVAL = float(os.environ.get('POLL_INTERVAL', '5'))  # seconds
+API_TIMEOUT = _float_env('API_TIMEOUT', 8.0)
+POLL_INTERVAL = _float_env('POLL_INTERVAL', 5.0)  # seconds
 SOCKETIO_CORS_ORIGINS = parse_socketio_cors_origins(local_port=EXPLORER_PORT)
 
 # Flask app with SocketIO

--- a/explorer/test_realtime.py
+++ b/explorer/test_realtime.py
@@ -5,10 +5,35 @@ Tests for WebSocket server, real-time client, and dashboard functionality
 """
 
 import unittest
+import importlib.util
 import json
+import sys
 import time
+from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock
 from io import BytesIO
+
+
+MODULE_PATH = Path(__file__).with_name("realtime_server.py")
+
+
+def load_realtime_server_module():
+    module_name = "test_realtime_server_env_module"
+    sys.path.insert(0, str(MODULE_PATH.parent))
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            sys.modules.pop(module_name, None)
+    finally:
+        try:
+            sys.path.remove(str(MODULE_PATH.parent))
+        except ValueError:
+            pass
+    return module
 
 
 class TestRealtimeServer(unittest.TestCase):
@@ -50,6 +75,30 @@ class TestRealtimeServer(unittest.TestCase):
         self.assertIn('active_connections', state.metrics)
         self.assertIn('messages_sent', state.metrics)
         self.assertIn('polls_executed', state.metrics)
+
+    def test_malformed_numeric_env_falls_back(self):
+        with patch.dict('os.environ', {
+            'EXPLORER_PORT': 'not-a-port',
+            'API_TIMEOUT': 'not-a-timeout',
+            'POLL_INTERVAL': 'not-an-interval',
+        }):
+            module = load_realtime_server_module()
+
+        self.assertEqual(module.EXPLORER_PORT, 8080)
+        self.assertEqual(module.API_TIMEOUT, 8.0)
+        self.assertEqual(module.POLL_INTERVAL, 5.0)
+
+    def test_valid_numeric_env_is_preserved(self):
+        with patch.dict('os.environ', {
+            'EXPLORER_PORT': '9010',
+            'API_TIMEOUT': '2.25',
+            'POLL_INTERVAL': '0.5',
+        }):
+            module = load_realtime_server_module()
+
+        self.assertEqual(module.EXPLORER_PORT, 9010)
+        self.assertEqual(module.API_TIMEOUT, 2.25)
+        self.assertEqual(module.POLL_INTERVAL, 0.5)
         
     def test_explorer_state_metrics_defaults(self):
         """Test ExplorerState metrics have correct default values"""

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3075,7 +3075,7 @@ def _get_streak_bonus(miner: str) -> float:
             rows = conn.execute(
                 "SELECT ts_ok FROM miner_attest_history WHERE miner = ? ORDER BY ts_ok DESC LIMIT 1000",
                 (miner,)
-            ).fetchall()
+            ).fetchall()  # fetchall-ok: already-paginated
             
             if not rows:
                 return 0.0
@@ -7895,7 +7895,7 @@ def _attestation_pool_snapshot(now_ts: Optional[int] = None) -> dict:
                 LIMIT 20
                 """,
                 (active_cutoff,),
-            ).fetchall()
+            ).fetchall()  # fetchall-ok: already-paginated
             snapshot["by_device_arch"] = [
                 {"device_arch": r["device_arch"], "active_miners": int(r["miners"] or 0)}
                 for r in arch_rows


### PR DESCRIPTION
## Problem
- explorer/realtime_server.py parses EXPLORER_PORT, API_TIMEOUT, and POLL_INTERVAL at import time with raw int()/float().
- A malformed deployment env value can crash the realtime explorer before it starts.

## Related evidence
- Repository-local evidence: selector-owned current-main code audit found this focused RustChain risk surface and generated the matching regression patch.

## Impact
- Small operator/env typos can take down the realtime dashboard process instead of falling back to the documented defaults.

## Fix
- Add small numeric env helpers that fall back only when values are malformed.
- Preserve valid configured values.

## Tests
- python3 -m py_compile explorer/realtime_server.py explorer/test_realtime.py
- uv run --no-project --with pytest --with flask --with flask-socketio --with requests python -B -m pytest -q explorer/test_realtime.py -> 30 passed
- git diff --check


## Maintenance-only CI baseline note
- This branch also includes a follow-up fetchall guard baseline annotation in `node/rustchain_v2_integrated_v2.2.1_rip200.py`.
- The maintenance commit only marks two existing LIMIT-bounded `.fetchall()` reads as `fetchall-ok: already-paginated`; no business logic for this PR changed.

## Additional maintenance validation
- `bash scripts/check_fetchall.sh` -> passed
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py` -> passed
- `git diff --check` -> passed

## Risk
- Narrow config-hardening change only; no realtime API, WebSocket, or dashboard behavior changes.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
