### PR TITLE
fix(node): avoid wildcard websocket CORS

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3075,7 +3075,7 @@ def _get_streak_bonus(miner: str) -> float:
             rows = conn.execute(
                 "SELECT ts_ok FROM miner_attest_history WHERE miner = ? ORDER BY ts_ok DESC LIMIT 1000",
                 (miner,)
-            ).fetchall()
+            ).fetchall()  # fetchall-ok: already-paginated
             
             if not rows:
                 return 0.0
@@ -7895,7 +7895,7 @@ def _attestation_pool_snapshot(now_ts: Optional[int] = None) -> dict:
                 LIMIT 20
                 """,
                 (active_cutoff,),
-            ).fetchall()
+            ).fetchall()  # fetchall-ok: already-paginated
             snapshot["by_device_arch"] = [
                 {"device_arch": r["device_arch"], "active_miners": int(r["miners"] or 0)}
                 for r in arch_rows

--- a/node/websocket_feed.py
+++ b/node/websocket_feed.py
@@ -42,6 +42,50 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+TRUSTED_WEBSOCKET_ORIGINS = (
+    "https://rustchain.org",
+    "https://www.rustchain.org",
+)
+
+
+def default_websocket_cors_origins(local_port: int | str | None = None) -> List[str]:
+    origins = list(TRUSTED_WEBSOCKET_ORIGINS)
+    if local_port is not None:
+        origins.extend(
+            [
+                f"http://localhost:{local_port}",
+                f"http://127.0.0.1:{local_port}",
+            ]
+        )
+    return origins
+
+
+def parse_websocket_cors_origins(
+    raw_value: str | None = None,
+    *,
+    local_port: int | str | None = None,
+) -> List[str]:
+    if raw_value is None:
+        raw_value = os.environ.get("WEBSOCKET_CORS_ORIGINS")
+
+    if raw_value is None or not raw_value.strip():
+        return default_websocket_cors_origins(local_port)
+
+    origins: List[str] = []
+    for item in raw_value.split(","):
+        origin = item.strip()
+        if not origin:
+            continue
+        if origin == "*":
+            raise ValueError("WEBSOCKET_CORS_ORIGINS must not include '*'")
+        if origin not in origins:
+            origins.append(origin)
+
+    if not origins:
+        return default_websocket_cors_origins(local_port)
+    return origins
+
+
 def _env_int(name: str, default: int) -> int:
     raw_value = os.environ.get(name)
     if raw_value is None:
@@ -69,6 +113,7 @@ WS_PORT = _env_int('WEBSOCKET_PORT', 8765)
 API_BASE = os.environ.get('RUSTCHAIN_API_BASE', 'http://localhost:8088')
 POLL_INTERVAL = _env_float('WS_POLL_INTERVAL', 3.0)
 MAX_EVENTS = _env_int('WS_MAX_EVENTS', 100)
+WEBSOCKET_CORS_ORIGINS = parse_websocket_cors_origins(local_port=WS_PORT)
 JSON_RPC_VERSION = '2.0'
 MINING_STATS_SUBSCRIPTION = 'mining_stats'
 BLOCK_SUBSCRIPTION = 'blocks'
@@ -234,7 +279,7 @@ class WebSocketFeed:
         self.app = app
         self.socketio = SocketIO(
             app, 
-            cors_allowed_origins="*",
+            cors_allowed_origins=WEBSOCKET_CORS_ORIGINS,
             async_mode='threading',
             ping_timeout=60,
             ping_interval=25,

--- a/tests/test_node_websocket_feed_env.py
+++ b/tests/test_node_websocket_feed_env.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: MIT
 import importlib.util
 import sys
+import types
 from pathlib import Path
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -32,6 +35,7 @@ def test_websocket_feed_invalid_numeric_env_falls_back(monkeypatch):
     assert module.WS_PORT == 8765
     assert module.POLL_INTERVAL == 3.0
     assert module.MAX_EVENTS == 100
+    assert "*" not in module.WEBSOCKET_CORS_ORIGINS
 
     feed = module.WebSocketFeed()
     assert feed.block_history.maxlen == 100
@@ -48,3 +52,71 @@ def test_websocket_feed_valid_numeric_env_is_preserved(monkeypatch):
     assert module.WS_PORT == 9001
     assert module.POLL_INTERVAL == 0.25
     assert module.MAX_EVENTS == 7
+
+
+def test_websocket_feed_default_cors_origins_are_allowlisted(monkeypatch):
+    monkeypatch.delenv("WEBSOCKET_CORS_ORIGINS", raising=False)
+    monkeypatch.setenv("WEBSOCKET_PORT", "9001")
+
+    module = load_websocket_feed_module()
+
+    assert module.WEBSOCKET_CORS_ORIGINS == [
+        "https://rustchain.org",
+        "https://www.rustchain.org",
+        "http://localhost:9001",
+        "http://127.0.0.1:9001",
+    ]
+
+
+def test_websocket_feed_cors_origins_parse_explicit_allowlist(monkeypatch):
+    monkeypatch.setenv(
+        "WEBSOCKET_CORS_ORIGINS",
+        "https://dash.rustchain.org, https://ops.rustchain.org, https://dash.rustchain.org",
+    )
+
+    module = load_websocket_feed_module()
+
+    assert module.WEBSOCKET_CORS_ORIGINS == [
+        "https://dash.rustchain.org",
+        "https://ops.rustchain.org",
+    ]
+
+
+def test_websocket_feed_cors_origins_reject_wildcard(monkeypatch):
+    monkeypatch.setenv("WEBSOCKET_CORS_ORIGINS", "https://dash.rustchain.org,*")
+
+    with pytest.raises(ValueError, match="must not include"):
+        load_websocket_feed_module()
+
+
+def test_websocket_feed_passes_allowlist_to_socketio(monkeypatch):
+    socketio_module = types.ModuleType("flask_socketio")
+    instances = []
+
+    class SocketIO:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            instances.append(self)
+
+        def on(self, *args, **kwargs):
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+        def emit(self, *args, **kwargs):
+            pass
+
+    socketio_module.SocketIO = SocketIO
+    socketio_module.emit = lambda *args, **kwargs: None
+    socketio_module.join_room = lambda *args, **kwargs: None
+    socketio_module.leave_room = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "flask_socketio", socketio_module)
+    monkeypatch.setenv("WEBSOCKET_CORS_ORIGINS", "https://dash.rustchain.org")
+
+    module = load_websocket_feed_module()
+    feed = module.WebSocketFeed()
+    feed.init_app(module.Flask("test-websocket-feed"))
+
+    assert instances[0].kwargs["cors_allowed_origins"] == ["https://dash.rustchain.org"]


### PR DESCRIPTION
## Problem
- node/websocket_feed.py initializes Flask-SocketIO with cors_allowed_origins="*".
- The feed can expose live chain, transaction, miner, and attestation events, so a permissive default is broader than needed.

## Related evidence
- Repository-local evidence: selector-owned current-main code audit found this focused RustChain risk surface and generated the matching regression patch.

## Impact
- Any browser origin can open a Socket.IO connection to this node feed when it is deployed with the default configuration.

## Fix
- Replace the wildcard default with an explicit allowlist: rustchain.org, www.rustchain.org, localhost, and 127.0.0.1 for the configured websocket port.
- Add WEBSOCKET_CORS_ORIGINS for explicit deployment allowlists.
- Reject wildcard entries instead of silently accepting them.

## Tests
- python3 -m py_compile node/websocket_feed.py tests/test_node_websocket_feed_env.py node/tests/test_websocket_feed_json_rpc.py
- uv run --no-project --with pytest --with flask --with flask-socketio python -B -m pytest -q tests/test_node_websocket_feed_env.py node/tests/test_websocket_feed_json_rpc.py -> 19 passed
- git diff --check


## Maintenance-only CI baseline note
- This branch also includes a follow-up fetchall guard baseline annotation in `node/rustchain_v2_integrated_v2.2.1_rip200.py`.
- The maintenance commit only marks two existing LIMIT-bounded `.fetchall()` reads as `fetchall-ok: already-paginated`; no business logic for this PR changed.

## Additional maintenance validation
- `bash scripts/check_fetchall.sh` -> passed
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py` -> passed
- `git diff --check` -> passed

## Risk
- Narrow Socket.IO boundary hardening only; existing JSON-RPC subscription behavior is covered by the focused tests.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
