### PR TITLE
fix(tools): tolerate malformed telegram bot env

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3075,7 +3075,7 @@ def _get_streak_bonus(miner: str) -> float:
             rows = conn.execute(
                 "SELECT ts_ok FROM miner_attest_history WHERE miner = ? ORDER BY ts_ok DESC LIMIT 1000",
                 (miner,)
-            ).fetchall()
+            ).fetchall()  # fetchall-ok: already-paginated
             
             if not rows:
                 return 0.0
@@ -7895,7 +7895,7 @@ def _attestation_pool_snapshot(now_ts: Optional[int] = None) -> dict:
                 LIMIT 20
                 """,
                 (active_cutoff,),
-            ).fetchall()
+            ).fetchall()  # fetchall-ok: already-paginated
             snapshot["by_device_arch"] = [
                 {"device_arch": r["device_arch"], "active_miners": int(r["miners"] or 0)}
                 for r in arch_rows

--- a/tools/telegram-bot/bot.py
+++ b/tools/telegram-bot/bot.py
@@ -28,10 +28,25 @@ from telegram.ext import Application, CommandHandler, ContextTypes
 # Configuration
 # ---------------------------------------------------------------------------
 
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 RUSTCHAIN_API = os.getenv("RUSTCHAIN_API_URL", "https://rustchain.org")
 BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
-RATE_LIMIT_RPM = int(os.getenv("RATE_LIMIT_PER_MINUTE", "10"))
-RTC_PRICE_USD = float(os.getenv("RTC_PRICE_USD", "0.10"))
+RATE_LIMIT_RPM = _int_env("RATE_LIMIT_PER_MINUTE", 10)
+RTC_PRICE_USD = _float_env("RTC_PRICE_USD", 0.10)
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO").upper(),

--- a/tools/telegram-bot/test_bot.py
+++ b/tools/telegram-bot/test_bot.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("bot.py")
+
+
+def install_telegram_stubs(monkeypatch):
+    telegram = types.ModuleType("telegram")
+
+    class BotCommand:
+        def __init__(self, name, description):
+            self.name = name
+            self.description = description
+
+    class Update:
+        ALL_TYPES = object()
+
+    telegram.BotCommand = BotCommand
+    telegram.Update = Update
+
+    telegram_ext = types.ModuleType("telegram.ext")
+
+    class _Builder:
+        def token(self, _token):
+            return self
+
+        def build(self):
+            return object()
+
+    class Application:
+        @classmethod
+        def builder(cls):
+            return _Builder()
+
+    class CommandHandler:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    class ContextTypes:
+        DEFAULT_TYPE = object()
+
+    telegram_ext.Application = Application
+    telegram_ext.CommandHandler = CommandHandler
+    telegram_ext.ContextTypes = ContextTypes
+    monkeypatch.setitem(sys.modules, "telegram", telegram)
+    monkeypatch.setitem(sys.modules, "telegram.ext", telegram_ext)
+
+
+def load_bot_module(monkeypatch):
+    install_telegram_stubs(monkeypatch)
+    module_name = "test_tools_telegram_bot_module"
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+    return module
+
+
+def test_malformed_numeric_env_falls_back(monkeypatch):
+    monkeypatch.setenv("RATE_LIMIT_PER_MINUTE", "not-an-int")
+    monkeypatch.setenv("RTC_PRICE_USD", "not-a-float")
+
+    module = load_bot_module(monkeypatch)
+
+    assert module.RATE_LIMIT_RPM == 10
+    assert module.RTC_PRICE_USD == 0.10
+
+
+def test_valid_numeric_env_is_preserved(monkeypatch):
+    monkeypatch.setenv("RATE_LIMIT_PER_MINUTE", "42")
+    monkeypatch.setenv("RTC_PRICE_USD", "0.25")
+
+    module = load_bot_module(monkeypatch)
+
+    assert module.RATE_LIMIT_RPM == 42
+    assert module.RTC_PRICE_USD == 0.25


### PR DESCRIPTION
## Problem
- tools/telegram-bot/bot.py parses RATE_LIMIT_PER_MINUTE and RTC_PRICE_USD at import time with raw int()/float().
- A malformed operator env value can crash the Telegram bot before it starts.

## Related evidence
- Repository-local evidence: selector-owned current-main code audit found this focused RustChain risk surface and generated the matching regression patch.

## Impact
- Small deployment/env typos can take down the bot instead of falling back to documented defaults.

## Fix
- Add small numeric env helpers that fall back only for malformed values.
- Preserve valid configured rate-limit and RTC price values.

## Tests
- python3 -m py_compile tools/telegram-bot/bot.py tools/telegram-bot/test_bot.py
- uv run --no-project --with pytest --with requests python -B -m pytest -q tools/telegram-bot/test_bot.py -> 2 passed
- git diff --check


## Maintenance-only CI baseline note
- This branch also includes a follow-up fetchall guard baseline annotation in `node/rustchain_v2_integrated_v2.2.1_rip200.py`.
- The maintenance commit only marks two existing LIMIT-bounded `.fetchall()` reads as `fetchall-ok: already-paginated`; no business logic for this PR changed.

## Additional maintenance validation
- `bash scripts/check_fetchall.sh` -> passed
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py` -> passed
- `git diff --check` -> passed

## Risk
- Narrow config-hardening change only; no Telegram command behavior, wallet lookup, payout, or reward logic changes.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
