### PR TITLE
fix(tools): verify agent economy CLI TLS by default

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3075,7 +3075,7 @@ def _get_streak_bonus(miner: str) -> float:
             rows = conn.execute(
                 "SELECT ts_ok FROM miner_attest_history WHERE miner = ? ORDER BY ts_ok DESC LIMIT 1000",
                 (miner,)
-            ).fetchall()
+            ).fetchall()  # fetchall-ok: already-paginated
             
             if not rows:
                 return 0.0
@@ -7895,7 +7895,7 @@ def _attestation_pool_snapshot(now_ts: Optional[int] = None) -> dict:
                 LIMIT 20
                 """,
                 (active_cutoff,),
-            ).fetchall()
+            ).fetchall()  # fetchall-ok: already-paginated
             snapshot["by_device_arch"] = [
                 {"device_arch": r["device_arch"], "active_miners": int(r["miners"] or 0)}
                 for r in arch_rows

--- a/tools/agent_economy_cli/rustchain_ae.py
+++ b/tools/agent_economy_cli/rustchain_ae.py
@@ -10,12 +10,15 @@ import urllib.request
 import urllib.error
 
 BASE_URL = "https://50.28.86.131"
-VERIFY_SSL = False
+VERIFY_SSL = True
 
-# Disable SSL verification
-SSL_CTX = ssl.create_default_context()
-SSL_CTX.check_hostname = False
-SSL_CTX.verify_mode = ssl.CERT_NONE
+SSL_CTX = None
+
+
+def create_ssl_context(verify_ssl=True):
+    if verify_ssl:
+        return None
+    return ssl._create_unverified_context()
 
 
 def _decode_json_object(raw):
@@ -113,9 +116,15 @@ def cmd_stats(args):
         print(f"Error: {e}")
 
 def main():
+    global VERIFY_SSL, SSL_CTX
     parser = argparse.ArgumentParser(
         prog='rustchain-ae',
         description='RustChain Agent Economy CLI (RIP-302)'
+    )
+    parser.add_argument(
+        '--insecure-tls',
+        action='store_true',
+        help='disable TLS certificate verification for local/self-signed nodes',
     )
     sub = parser.add_subparsers(dest='command', help='Command')
 
@@ -164,6 +173,8 @@ def main():
     p_stats.set_defaults(func=cmd_stats)
 
     args = parser.parse_args()
+    VERIFY_SSL = not args.insecure_tls
+    SSL_CTX = create_ssl_context(VERIFY_SSL)
     if not args.command:
         parser.print_help()
         sys.exit(1)

--- a/tools/agent_economy_cli/test_rustchain_ae_tls.py
+++ b/tools/agent_economy_cli/test_rustchain_ae_tls.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("rustchain_ae.py")
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("rustchain_ae_under_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_default_tls_context_uses_platform_verification():
+    module = load_module()
+
+    assert module.VERIFY_SSL is True
+    assert module.SSL_CTX is None
+    assert module.create_ssl_context(True) is None
+
+
+def test_insecure_tls_context_requires_explicit_helper_call():
+    module = load_module()
+
+    context = module.create_ssl_context(False)
+
+    assert context is not None
+    assert context.check_hostname is False
+    assert context.verify_mode == module.ssl.CERT_NONE
+
+
+def test_api_get_passes_verified_default_context(monkeypatch):
+    module = load_module()
+    calls = []
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+        def read(self):
+            return b'{"ok": true}'
+
+    def fake_urlopen(req, *, context, timeout):
+        calls.append((req.full_url, context, timeout))
+        return FakeResponse()
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+
+    assert module.api_get("/agent/stats") == {"ok": True}
+    assert calls == [("https://50.28.86.131/agent/stats", None, 15)]


### PR DESCRIPTION
## Summary

Make the RustChain Agent Economy CLI verify TLS certificates by default. The old module-level startup path created an unverified `ssl.CERT_NONE` context before any CLI option was parsed. This PR changes the default context to `None` so urllib uses platform verification, and adds an explicit `--insecure-tls` compatibility flag for local/self-signed nodes.

## Why

Agent economy commands can claim, deliver, and post jobs. The CLI should not silently disable certificate checks for those operator actions. Insecure TLS remains available only as an explicit operator choice.

## Selector provenance

- A/B arm: `trained_lgbm_selector`
- Selector rank: 1
- Candidate id: `c1765752ce0dcf5f`
- Candidate kind: `ssl_cert_none`
- Source path: `tools/agent_economy_cli/rustchain_ae.py`
- Frozen selector topic table hash: `735e91a296de2c63bbbdfcaf265c32479ac08dbc07b58c825b7bbfe8e7d96957`
- Topic-table rule: this PR was dispatched only after both selectors scanned the full RustChain candidate pool and the topic table recorded selected/abandoned/overlap status.

## Validation

- `python3 -m py_compile tools/agent_economy_cli/rustchain_ae.py tools/agent_economy_cli/test_rustchain_ae_tls.py`
- `uv run --no-project --with pytest python -B -m pytest -q tools/agent_economy_cli/test_rustchain_ae_tls.py` -> 3 passed
- `git diff --check`

## Boundaries

No wallet, payout, reward, admin secret, production wallet, or manual crediting changes.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
