### PR TITLE
fix(tools): bound bounty validation test runner

### DIFF
--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -141,6 +141,8 @@ node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall():
 node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall():
 node/rustchain_v2_integrated_v2.2.1_rip200.py:WHERE active=1 ORDER BY signer_id""").fetchall()

--- a/tests/test_validate_bounty_2303.py
+++ b/tests/test_validate_bounty_2303.py
@@ -1,0 +1,42 @@
+import importlib.util
+import subprocess
+from pathlib import Path
+
+
+def load_validator():
+    path = Path(__file__).resolve().parents[1] / "validate_bounty_2303.py"
+    spec = importlib.util.spec_from_file_location("validate_bounty_2303", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_tests_bounds_pytest_subprocess(monkeypatch):
+    validator = load_validator()
+    captured = {}
+
+    class Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return Result()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert validator.run_tests() is True
+    assert captured["args"] == [
+        validator.sys.executable,
+        "-m",
+        "pytest",
+        "bridge/test_dashboard_api.py",
+        "-v",
+        "--tb=short",
+    ]
+    assert captured["kwargs"]["capture_output"] is True
+    assert captured["kwargs"]["text"] is True
+    assert captured["kwargs"]["timeout"] == validator.PYTEST_TIMEOUT

--- a/validate_bounty_2303.py
+++ b/validate_bounty_2303.py
@@ -23,6 +23,7 @@ import urllib.error
 # Configuration
 BASE_URL = os.environ.get("DASHBOARD_TEST_URL", "http://localhost:8096")
 TEST_TIMEOUT = 30  # seconds
+PYTEST_TIMEOUT = 120  # seconds
 
 def print_header(text):
     print("\n" + "=" * 60)
@@ -176,7 +177,8 @@ def run_tests():
     result = subprocess.run(
         [sys.executable, "-m", "pytest", "bridge/test_dashboard_api.py", "-v", "--tb=short"],
         capture_output=True,
-        text=True
+        text=True,
+        timeout=PYTEST_TIMEOUT,
     )
     
     passed = result.returncode == 0


### PR DESCRIPTION
## Problem
`validate_bounty_2303.py` shells out to `python -m pytest bridge/test_dashboard_api.py` without a timeout. If pytest or a plugin stalls, the validation helper can hang indefinitely instead of failing boundedly.

Selector provenance: corrected natural selector attribution is `both_selectors` (`selected_by_lgbm=true`, `selected_by_native=true`) for the dispatchable queue used when this PR was opened. It was executed with `dispatch_arm=trained_lgbm_selector`; dispatch arm is operational routing, not selector ownership. This supersedes the earlier LGBM-only wording.

## Fix
- Add a bounded `PYTEST_TIMEOUT` for the validation subprocess.
- Add a focused regression test that verifies the subprocess call carries the timeout contract without executing the bridge suite.
- Maintenance-only: refresh the fetchall guard baseline for two existing `node/rustchain_v2_integrated_v2.2.1_rip200.py` legacy entries so the repo-wide guard remains green. This does not change node runtime code.

## Boundaries
BCOS-L1: developer validation tooling only. No wallet, payout, bridge, reward, admin secret, production wallet, or manual crediting changes.

## Validation
- `python3 -m py_compile validate_bounty_2303.py tests/test_validate_bounty_2303.py`
- `uv run --no-project --with pytest --with flask python -B -m pytest -q tests/test_validate_bounty_2303.py` -> 1 passed
- `bash scripts/check_fetchall.sh` -> passed
- `uv run --no-project --with pytest --with flask python -B -m pytest -q tests/test_validate_bounty_2303.py tests/test_fetchall_guard.py` -> 7 passed
- `git diff --check`

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
