### PR TITLE
fix(sdk): avoid disabled TLS verification by default

### DIFF
--- a/sdk/python/rustchain_sdk/tools/eligibility_checker.py
+++ b/sdk/python/rustchain_sdk/tools/eligibility_checker.py
@@ -3,9 +3,10 @@ import argparse
 import sys
 from rustchain_sdk import RustChainClient
 
-async def check_eligibility(miner_id, epoch, node_url):
-    # Use verify=False by default for PoC tools as many nodes use self-signed certs
-    async with RustChainClient(base_url=node_url, verify=False) as client:
+
+async def check_eligibility(miner_id, epoch, node_url, *, insecure_tls=False):
+    verify = False if insecure_tls else None
+    async with RustChainClient(base_url=node_url, verify=verify) as client:
         try:
             # Use public SDK method
             response = await client.get_epoch_rewards(epoch)
@@ -25,6 +26,11 @@ if __name__ == "__main__":
     parser.add_argument("--miner", required=True, help="Miner ID to check")
     parser.add_argument("--epoch", type=int, required=True, help="Epoch number")
     parser.add_argument("--node", default="https://rustchain.org", help="Node URL (default: https://rustchain.org)")
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Disable TLS certificate verification for self-signed development nodes.",
+    )
     
     args = parser.parse_args()
-    asyncio.run(check_eligibility(args.miner, args.epoch, args.node))
+    asyncio.run(check_eligibility(args.miner, args.epoch, args.node, insecure_tls=args.insecure))


### PR DESCRIPTION
Clean redo of #7592 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `sdk/python/rustchain_sdk/tools/eligibility_checker.py`

Validation:
- `python3 -m py_compile sdk/python/rustchain_sdk/tools/eligibility_checker.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
