### PR TITLE
fix(explorer): tolerate malformed numeric env

### DIFF
--- a/explorer/dashboard/app.py
+++ b/explorer/dashboard/app.py
@@ -3,8 +3,23 @@
 import os, requests
 from flask import Flask, jsonify, render_template_string, request
 
+
+def _int_env(name, default):
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_env(name, default):
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 API_BASE = os.environ.get('RUSTCHAIN_API_BASE', 'https://rustchain.org').rstrip('/')
-TIMEOUT = float(os.environ.get('RUSTCHAIN_API_TIMEOUT', '8'))
+TIMEOUT = _float_env('RUSTCHAIN_API_TIMEOUT', 8.0)
 
 app = Flask(__name__)
 
@@ -86,4 +101,4 @@ def dashboard():
     })
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=int(os.environ.get('PORT','8787')))
+    app.run(host='0.0.0.0', port=_int_env('PORT', 8787))

--- a/explorer/dashboard/test_app.py
+++ b/explorer/dashboard/test_app.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("app.py")
+
+
+def _load_dashboard(monkeypatch, port: str, timeout: str):
+    monkeypatch.setenv("PORT", port)
+    monkeypatch.setenv("RUSTCHAIN_API_TIMEOUT", timeout)
+    module_name = f"explorer_dashboard_app_test_{port.replace('-', '_')}_{timeout.replace('.', '_')}"
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+    return module
+
+
+def test_malformed_numeric_env_falls_back_to_defaults(monkeypatch):
+    module = _load_dashboard(monkeypatch, "bad-port", "slow")
+
+    assert module._int_env("PORT", 8787) == 8787
+    assert module.TIMEOUT == 8.0
+
+
+def test_valid_numeric_env_is_used(monkeypatch):
+    module = _load_dashboard(monkeypatch, "9090", "2.5")
+
+    assert module._int_env("PORT", 8787) == 9090
+    assert module.TIMEOUT == 2.5


### PR DESCRIPTION
Clean redo of #7585 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `explorer/dashboard/app.py`
- `explorer/dashboard/test_app.py`

Validation:
- `python3 -m py_compile explorer/dashboard/app.py -> passed`
- `python3 -m py_compile explorer/dashboard/test_app.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
