### PR TITLE
fix(explorer): tolerate malformed numeric env

### DIFF
--- a/explorer/realtime_server.py
+++ b/explorer/realtime_server.py
@@ -19,11 +19,26 @@ try:
 except ModuleNotFoundError:
     from socketio_cors import parse_socketio_cors_origins
 
+
+def _float_env(name, default):
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _int_env(name, default):
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 # Configuration
-EXPLORER_PORT = int(os.environ.get('EXPLORER_PORT', 8080))
+EXPLORER_PORT = _int_env('EXPLORER_PORT', 8080)
 API_BASE = os.environ.get('RUSTCHAIN_API_BASE', 'https://rustchain.org').rstrip('/')
-API_TIMEOUT = float(os.environ.get('API_TIMEOUT', '8'))
-POLL_INTERVAL = float(os.environ.get('POLL_INTERVAL', '5'))  # seconds
+API_TIMEOUT = _float_env('API_TIMEOUT', 8.0)
+POLL_INTERVAL = _float_env('POLL_INTERVAL', 5.0)  # seconds
 SOCKETIO_CORS_ORIGINS = parse_socketio_cors_origins(local_port=EXPLORER_PORT)
 
 # Flask app with SocketIO


### PR DESCRIPTION
Clean redo of #7589 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `explorer/realtime_server.py`

Validation:
- `python3 -m py_compile explorer/realtime_server.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
