### PR TITLE
fix(tools): avoid disabled TLS certificate checks

### DIFF
--- a/tools/miner_checklist.py
+++ b/tools/miner_checklist.py
@@ -5,6 +5,19 @@ import shutil
 import ssl
 import urllib.request
 
+def _env_bool(name, default=False):
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+def _ssl_context(insecure_tls=False):
+    ctx = ssl.create_default_context()
+    if insecure_tls:
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
 def check(name, condition):
     status = "PASS" if condition else "FAIL"
     print(f"  [{status}] {name}")
@@ -22,9 +35,7 @@ def preflight():
         disk_ok = False
     ok &= check("Disk > 1GB free", disk_ok)
     try:
-        ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
+        ctx = _ssl_context(_env_bool("RUSTCHAIN_MINER_CHECKLIST_INSECURE_TLS"))
         urllib.request.urlopen("https://rustchain.org/health", timeout=5, context=ctx)
         ok &= check("Node reachable", True)
     except Exception:


### PR DESCRIPTION
Clean redo of #7600 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `tools/miner_checklist.py`

Validation:
- `python3 -m py_compile tools/miner_checklist.py -> passed`
- `python3 -m py_compile tests/test_miner_checklist.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
