### PR TITLE
fix(tools): avoid disabled TLS certificate checks

### DIFF
--- a/tests/test_miner_score.py
+++ b/tests/test_miner_score.py
@@ -104,7 +104,7 @@ def test_api_uses_configured_node_timeout_and_ssl_context(monkeypatch):
 
     class DummyContext:
         check_hostname = True
-        verify_mode = None
+        verify_mode = miner_score.ssl.CERT_REQUIRED
 
     class DummyResponse:
         closed = False
@@ -135,8 +135,8 @@ def test_api_uses_configured_node_timeout_and_ssl_context(monkeypatch):
 
     assert miner_score.api("/api/miners") == {"miners": []}
     assert calls == [(("https://node.example/api/miners",), {"timeout": 10, "context": contexts[0]})]
-    assert contexts[0].check_hostname is False
-    assert contexts[0].verify_mode == miner_score.ssl.CERT_NONE
+    assert contexts[0].check_hostname is True
+    assert contexts[0].verify_mode == miner_score.ssl.CERT_REQUIRED
     assert responses[0].closed is True
 
 

--- a/tools/miner_score.py
+++ b/tools/miner_score.py
@@ -9,10 +9,23 @@ import urllib.request
 NODE = os.environ.get("RUSTCHAIN_NODE", "https://rustchain.org")
 
 
-def api(p):
+def _env_bool(name, default=False):
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _ssl_context(insecure_tls=False):
     ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
+    if insecure_tls:
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def api(p):
+    ctx = _ssl_context(_env_bool("RUSTCHAIN_MINER_SCORE_INSECURE_TLS"))
     try:
         with urllib.request.urlopen(f"{NODE}{p}", timeout=10, context=ctx) as response:
             return json.loads(response.read())


### PR DESCRIPTION
Clean redo of #7598 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `tools/miner_score.py`
- `tests/test_miner_score.py`

Validation:
- `python3 -m py_compile tools/miner_score.py -> passed`
- `python3 -m py_compile tests/test_miner_score.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
