### PR TITLE
fix(tools): bound subprocess execution timeouts

### DIFF
--- a/tests/test_bcos_spdx_check.py
+++ b/tests/test_bcos_spdx_check.py
@@ -33,6 +33,39 @@ def test_top_lines_returns_empty_list_for_missing_file(tmp_path):
     assert bcos_spdx_check._top_lines(tmp_path / "missing.py") == []
 
 
+def test_run_bounds_git_command_timeout(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+
+        class Result:
+            returncode = 0
+            stdout = "ok\n"
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr(bcos_spdx_check.subprocess, "run", fake_run)
+
+    assert bcos_spdx_check._run(["git", "status"]) == "ok\n"
+    assert calls[0][1]["timeout"] == bcos_spdx_check.GIT_COMMAND_TIMEOUT_SECONDS
+
+
+def test_run_reports_timeout(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise bcos_spdx_check.subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(bcos_spdx_check.subprocess, "run", fake_run)
+
+    try:
+        bcos_spdx_check._run(["git", "status"])
+    except RuntimeError as exc:
+        assert "command timed out after 30s: git status" in str(exc)
+    else:
+        raise AssertionError("expected timeout RuntimeError")
+
+
 def test_git_diff_name_status_parses_valid_rows(monkeypatch):
     def fake_run(cmd):
         assert cmd == ["git", "diff", "--name-status", "origin/main...HEAD"]

--- a/tools/bcos_spdx_check.py
+++ b/tools/bcos_spdx_check.py
@@ -37,10 +37,22 @@ CODE_EXTS = {
 }
 
 SPDX_RE = re.compile(r"SPDX-License-Identifier:\s*[A-Za-z0-9.\-+]+")
+GIT_COMMAND_TIMEOUT_SECONDS = 30
 
 
 def _run(cmd: List[str]) -> str:
-    p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    try:
+        p = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=GIT_COMMAND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"command timed out after {GIT_COMMAND_TIMEOUT_SECONDS}s: {' '.join(cmd)}"
+        ) from exc
     if p.returncode != 0:
         raise RuntimeError(f"command failed ({p.returncode}): {' '.join(cmd)}\n{p.stderr.strip()}")
     return p.stdout


### PR DESCRIPTION
Clean redo of #7614 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `tools/bcos_spdx_check.py`
- `tests/test_bcos_spdx_check.py`

Validation:
- `python3 -m py_compile tools/bcos_spdx_check.py -> passed`
- `python3 -m py_compile tests/test_bcos_spdx_check.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
