### PR TITLE
fix(validate-bounty-2303.py): bound subprocess execution timeouts

### DIFF
--- a/validate_bounty_2303.py
+++ b/validate_bounty_2303.py
@@ -23,6 +23,7 @@ import urllib.error
 # Configuration
 BASE_URL = os.environ.get("DASHBOARD_TEST_URL", "http://localhost:8096")
 TEST_TIMEOUT = 30  # seconds
+PYTEST_TIMEOUT = 120  # seconds
 
 def print_header(text):
     print("\n" + "=" * 60)
@@ -176,7 +177,8 @@ def run_tests():
     result = subprocess.run(
         [sys.executable, "-m", "pytest", "bridge/test_dashboard_api.py", "-v", "--tb=short"],
         capture_output=True,
-        text=True
+        text=True,
+        timeout=PYTEST_TIMEOUT,
     )
     
     passed = result.returncode == 0


### PR DESCRIPTION
Clean redo of #7622 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `validate_bounty_2303.py`

Validation:
- `python3 -m py_compile validate_bounty_2303.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
