### PR TITLE
fix(bottube-telegram-bot): tolerate malformed numeric env

### DIFF
--- a/bottube_telegram_bot/bottube_bot.py
+++ b/bottube_telegram_bot/bottube_bot.py
@@ -59,15 +59,23 @@ BOTTUBE_API_KEY = os.getenv("BOTTUBE_API_KEY", "")
 # Telegram bot configuration
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
 
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 # Rate limiting (requests per minute per user)
-RATE_LIMIT_PER_MINUTE = int(os.getenv("RATE_LIMIT_PER_MINUTE", "10"))
+RATE_LIMIT_PER_MINUTE = _int_env("RATE_LIMIT_PER_MINUTE", 10)
 
 # Logging configuration
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
 # Pagination
-VIDEOS_PER_PAGE = int(os.getenv("VIDEOS_PER_PAGE", "10"))
+VIDEOS_PER_PAGE = _int_env("VIDEOS_PER_PAGE", 10)
 
 # =============================================================================
 # Logging Setup

--- a/bottube_telegram_bot/test_bottube_bot.py
+++ b/bottube_telegram_bot/test_bottube_bot.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("bottube_bot.py")
+
+
+def _load_bottube_bot(monkeypatch, rate_limit: str, videos_per_page: str):
+    monkeypatch.setenv("RATE_LIMIT_PER_MINUTE", rate_limit)
+    monkeypatch.setenv("VIDEOS_PER_PAGE", videos_per_page)
+    module_name = f"bottube_bot_test_{rate_limit.replace('-', '_')}_{videos_per_page.replace('-', '_')}"
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+    return module
+
+
+def test_malformed_numeric_env_falls_back_to_defaults(monkeypatch):
+    module = _load_bottube_bot(monkeypatch, "not-a-number", "many")
+
+    assert module.RATE_LIMIT_PER_MINUTE == 10
+    assert module.VIDEOS_PER_PAGE == 10
+    assert module.rate_limiter.max_requests == 10
+
+
+def test_valid_numeric_env_is_used(monkeypatch):
+    module = _load_bottube_bot(monkeypatch, "42", "7")
+
+    assert module.RATE_LIMIT_PER_MINUTE == 42
+    assert module.VIDEOS_PER_PAGE == 7
+    assert module.rate_limiter.max_requests == 42


### PR DESCRIPTION
Clean redo of #7582 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `bottube_telegram_bot/bottube_bot.py`
- `bottube_telegram_bot/test_bottube_bot.py`

Validation:
- `python3 -m py_compile bottube_telegram_bot/bottube_bot.py -> passed`
- `python3 -m py_compile bottube_telegram_bot/test_bottube_bot.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
