### PR TITLE
fix(monitoring): tolerate malformed exporter env

### DIFF
--- a/monitoring/rustchain-exporter.py
+++ b/monitoring/rustchain-exporter.py
@@ -14,8 +14,17 @@ logger = logging.getLogger('rustchain-exporter')
 
 # Configuration
 RUSTCHAIN_NODE = os.environ.get('RUSTCHAIN_NODE', 'https://rustchain.org')
-EXPORTER_PORT = int(os.environ.get('EXPORTER_PORT', 9100))
-SCRAPE_INTERVAL = int(os.environ.get('SCRAPE_INTERVAL', 30))  # seconds
+
+
+def _int_env(name, default):
+    try:
+        return int(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+EXPORTER_PORT = _int_env('EXPORTER_PORT', 9100)
+SCRAPE_INTERVAL = _int_env('SCRAPE_INTERVAL', 30)  # seconds
 TLS_VERIFY = os.environ.get('TLS_VERIFY', 'true').lower() in ('true', '1', 'yes')
 TLS_CA_BUNDLE = os.environ.get('TLS_CA_BUNDLE', None)  # Optional CA cert path
 


### PR DESCRIPTION
Clean redo of #7579 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `monitoring/rustchain-exporter.py`

Validation:
- `python3 -m py_compile monitoring/rustchain-exporter.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
