### PR TITLE
fix(otc-bridge): tolerate malformed numeric env

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -2178,5 +2178,5 @@ def _start_reconciler_once():
 
 
 if __name__ == "__main__":
-    port = int(os.environ.get("OTC_PORT", 5580))
+    port = _int_env("OTC_PORT", 5580)
     app.run(host="0.0.0.0", port=port, debug=False)

--- a/otc-bridge/test_otc_bridge.py
+++ b/otc-bridge/test_otc_bridge.py
@@ -40,6 +40,14 @@ class OTCBridgeTestCase(unittest.TestCase):
             except PermissionError:
                 pass
 
+    def test_int_env_falls_back_on_malformed_port(self):
+        with patch.dict(os.environ, {"OTC_PORT": "not-an-int"}):
+            self.assertEqual(otc_bridge._int_env("OTC_PORT", 5580), 5580)
+
+    def test_int_env_accepts_valid_port(self):
+        with patch.dict(os.environ, {"OTC_PORT": "5599"}):
+            self.assertEqual(otc_bridge._int_env("OTC_PORT", 5580), 5599)
+
     def signed_create_order_payload(self, payload):
         private_key = Ed25519PrivateKey.generate()
         public_key_hex = private_key.public_key().public_bytes(


### PR DESCRIPTION
Clean redo of #7573 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `otc-bridge/otc_bridge.py`
- `otc-bridge/test_otc_bridge.py`

Validation:
- `python3 -m py_compile otc-bridge/otc_bridge.py -> passed`
- `python3 -m py_compile otc-bridge/test_otc_bridge.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
