### PR TITLE
fix(tools): tolerate malformed numeric env

### DIFF
--- a/tools/testnet_faucet.py
+++ b/tools/testnet_faucet.py
@@ -46,6 +46,13 @@ def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 def init_db(path: str) -> None:
     conn = sqlite3.connect(path)
     try:
@@ -267,4 +274,4 @@ def create_app(config: dict[str, Any] | None = None) -> Flask:
 
 if __name__ == "__main__":
     app = create_app()
-    app.run(host="0.0.0.0", port=int(os.getenv("PORT", "8090")))
+    app.run(host="0.0.0.0", port=_int_env("PORT", 8090))


### PR DESCRIPTION
Clean redo of #7580 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `tools/testnet_faucet.py`

Validation:
- `python3 -m py_compile tools/testnet_faucet.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
