### PR TITLE
fix(tools): avoid disabled TLS certificate checks

### DIFF
--- a/tools/agent_economy_cli/rustchain_ae.py
+++ b/tools/agent_economy_cli/rustchain_ae.py
@@ -10,12 +10,15 @@ import urllib.request
 import urllib.error
 
 BASE_URL = "https://50.28.86.131"
-VERIFY_SSL = False
+VERIFY_SSL = True
 
-# Disable SSL verification
-SSL_CTX = ssl.create_default_context()
-SSL_CTX.check_hostname = False
-SSL_CTX.verify_mode = ssl.CERT_NONE
+SSL_CTX = None
+
+
+def create_ssl_context(verify_ssl=True):
+    if verify_ssl:
+        return None
+    return ssl._create_unverified_context()
 
 
 def _decode_json_object(raw):
@@ -113,9 +116,15 @@ def cmd_stats(args):
         print(f"Error: {e}")
 
 def main():
+    global VERIFY_SSL, SSL_CTX
     parser = argparse.ArgumentParser(
         prog='rustchain-ae',
         description='RustChain Agent Economy CLI (RIP-302)'
+    )
+    parser.add_argument(
+        '--insecure-tls',
+        action='store_true',
+        help='disable TLS certificate verification for local/self-signed nodes',
     )
     sub = parser.add_subparsers(dest='command', help='Command')
 
@@ -164,6 +173,8 @@ def main():
     p_stats.set_defaults(func=cmd_stats)
 
     args = parser.parse_args()
+    VERIFY_SSL = not args.insecure_tls
+    SSL_CTX = create_ssl_context(VERIFY_SSL)
     if not args.command:
         parser.print_help()
         sys.exit(1)


### PR DESCRIPTION
Clean redo of #7602 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `tools/agent_economy_cli/rustchain_ae.py`

Validation:
- `python3 -m py_compile tools/agent_economy_cli/rustchain_ae.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
