### PR TITLE
fix(tools): avoid disabled TLS verification by default

### DIFF
--- a/tests/test_mining_video_pipeline.py
+++ b/tests/test_mining_video_pipeline.py
@@ -58,7 +58,7 @@ def test_fetch_miners_accepts_enveloped_miner_payload(monkeypatch):
     assert calls == [
         (
             "https://50.28.86.131/api/miners",
-            {"verify": False, "timeout": 30},
+            {"verify": True, "timeout": 30},
         )
     ]
     assert len(miners) == 1
@@ -68,10 +68,17 @@ def test_fetch_miners_accepts_enveloped_miner_payload(monkeypatch):
 
 
 def test_fetch_miners_ignores_malformed_envelope_rows(monkeypatch):
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return FakeResponse({"miners": [None, "bad"]})
+
     monkeypatch.setattr(
         mining_video_pipeline.requests,
         "get",
-        lambda *_args, **_kwargs: FakeResponse({"miners": [None, "bad"]}),
+        fake_get,
     )
 
     assert mining_video_pipeline.fetch_miners() == []
+    assert calls[0][1]["verify"] is True

--- a/tools/mining-video-pipeline/mining_video_pipeline.py
+++ b/tools/mining-video-pipeline/mining_video_pipeline.py
@@ -51,6 +51,18 @@ FRAMES_DIR = "/tmp/rustchain_video_frames"
 WIDTH, HEIGHT = 1280, 720
 FPS = 15
 
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _verify_tls(insecure_tls: bool = False) -> bool:
+    return not (insecure_tls or _env_bool("RUSTCHAIN_VIDEO_PIPELINE_INSECURE_TLS"))
+
+
 # === Architecture Visual Styles ===
 # Each architecture gets unique colors, themes, and visual elements
 ARCH_STYLES = {
@@ -142,9 +154,9 @@ class MinerData:
 
 # === Data Fetching ===
 
-def fetch_miners() -> list[MinerData]:
+def fetch_miners(*, insecure_tls: bool = False) -> list[MinerData]:
     """Fetch active miners from RustChain API."""
-    resp = requests.get(f"{RUSTCHAIN_API}/api/miners", verify=False, timeout=30)
+    resp = requests.get(f"{RUSTCHAIN_API}/api/miners", verify=_verify_tls(insecure_tls), timeout=30)
     resp.raise_for_status()
     payload = resp.json()
     if isinstance(payload, dict):
@@ -156,9 +168,9 @@ def fetch_miners() -> list[MinerData]:
     return [MinerData.from_api(m) for m in rows if isinstance(m, dict)]
 
 
-def fetch_epoch() -> dict:
+def fetch_epoch(*, insecure_tls: bool = False) -> dict:
     """Fetch current epoch info."""
-    resp = requests.get(f"{RUSTCHAIN_API}/epoch", verify=False, timeout=30)
+    resp = requests.get(f"{RUSTCHAIN_API}/epoch", verify=_verify_tls(insecure_tls), timeout=30)
     resp.raise_for_status()
     return resp.json()
 
@@ -508,19 +520,24 @@ def main():
     parser.add_argument("--count", type=int, default=10, help="Number of videos to generate")
     parser.add_argument("--miner", type=str, help="Generate video for specific miner ID")
     parser.add_argument("--list", action="store_true", help="List active miners")
+    parser.add_argument(
+        "--insecure-tls",
+        action="store_true",
+        help="Disable TLS certificate verification for self-signed development nodes",
+    )
     args = parser.parse_args()
 
     if args.list:
-        miners = fetch_miners()
-        epoch = fetch_epoch()
+        miners = fetch_miners(insecure_tls=args.insecure_tls)
+        epoch = fetch_epoch(insecure_tls=args.insecure_tls)
         print(f"Epoch {epoch['epoch']} | Slot {epoch['slot']} | {epoch['enrolled_miners']} miners")
         for m in miners:
             print(f"  {m.miner_id[:30]:30s} | {m.hardware_type:25s} | mult={m.antiquity_multiplier}")
         return
 
     if args.generate or args.full or args.miner:
-        miners = fetch_miners()
-        epoch = fetch_epoch()
+        miners = fetch_miners(insecure_tls=args.insecure_tls)
+        epoch = fetch_epoch(insecure_tls=args.insecure_tls)
 
         if args.miner:
             miner = next((m for m in miners if args.miner in m.miner_id), None)
@@ -544,7 +561,7 @@ def main():
         if not videos:
             print(f"No videos found in {OUTPUT_DIR}")
             return
-        epoch = fetch_epoch()
+        epoch = fetch_epoch(insecure_tls=args.insecure_tls)
         generated = [(str(v), MinerData(
             miner_id=v.stem, device_arch="", device_family="",
             hardware_type=v.stem.split("_")[1].replace("_", " ") if "_" in v.stem else "Unknown",


### PR DESCRIPTION
Clean redo of #7596 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `tools/mining-video-pipeline/mining_video_pipeline.py`
- `tests/test_mining_video_pipeline.py`

Validation:
- `python3 -m py_compile tools/mining-video-pipeline/mining_video_pipeline.py -> passed`
- `python3 -m py_compile tests/test_mining_video_pipeline.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
