### PR TITLE
fix(.github): bound subprocess execution timeouts

### DIFF
--- a/.github/actions/bcos-action/main.py
+++ b/.github/actions/bcos-action/main.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError
 
+HTTP_TIMEOUT_SECONDS = 30
+
 
 def load_bcos_engine():
     """Load the BCOS engine module from the Rustchain repo."""
@@ -250,7 +252,7 @@ def post_github_comment(repo: str, pr_number: str, report: dict, token: str) -> 
     )
     
     try:
-        response = urlopen(req)
+        response = urlopen(req, timeout=HTTP_TIMEOUT_SECONDS)
         print(f"✅ Comment posted successfully: {response.status}")
         return True
     except HTTPError as e:
@@ -283,7 +285,7 @@ def anchor_to_rustchain(node_url: str, report: dict, repo: str,
     )
     
     try:
-        response = urlopen(req)
+        response = urlopen(req, timeout=HTTP_TIMEOUT_SECONDS)
         result = json.loads(response.read().decode("utf-8"))
         print(f"✅ Attestation anchored successfully!")
         print(f"Transaction: {result.get('tx_hash', 'N/A')}")


### PR DESCRIPTION
Clean redo of #7610 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `.github/actions/bcos-action/main.py`

Validation:
- `python3 -m py_compile .github/actions/bcos-action/main.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
