### PR TITLE
fix(miners): bound subprocess execution timeouts

### DIFF
--- a/miners/windows/installer/src/fingerprint_checks_win.py
+++ b/miners/windows/installer/src/fingerprint_checks_win.py
@@ -14,6 +14,8 @@ import winreg
 import uuid
 from typing import Dict, List, Optional, Tuple
 
+COMMAND_TIMEOUT_SECONDS = 10
+
 def check_clock_drift(samples: int = 200) -> Tuple[bool, Dict]:
     """Check 1: Clock-Skew & Oscillator Drift"""
     intervals = []
@@ -107,9 +109,10 @@ def check_simd_identity() -> Tuple[bool, Dict]:
         cpu_info = subprocess.check_output(
             ["wmic", "cpu", "get", "Caption"],
             stderr=subprocess.DEVNULL,
-            creationflags=subprocess.CREATE_NO_WINDOW
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            timeout=COMMAND_TIMEOUT_SECONDS,
         ).decode().strip()
-    except:
+    except Exception:
         cpu_info = platform.processor()
 
     has_sse = "sse" in cpu_info.lower() or "intel" in cpu_info.lower() or "amd" in cpu_info.lower()

--- a/miners/windows/installer/src/test_fingerprint_checks_win.py
+++ b/miners/windows/installer/src/test_fingerprint_checks_win.py
@@ -1,0 +1,48 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def load_module(monkeypatch):
+    monkeypatch.setitem(sys.modules, "winreg", types.SimpleNamespace())
+    module_path = Path(__file__).with_name("fingerprint_checks_win.py")
+    spec = importlib.util.spec_from_file_location("fingerprint_checks_win_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_simd_identity_wmic_probe_uses_timeout(monkeypatch):
+    module = load_module(monkeypatch)
+    calls = []
+
+    def fake_check_output(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return b"Caption\r\nIntel CPU with SSE AVX\r\n"
+
+    monkeypatch.setattr(module.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(module.platform, "machine", lambda: "AMD64")
+
+    valid, data = module.check_simd_identity()
+
+    assert valid is True
+    assert data["has_sse"] is True
+    assert calls[0][0] == ["wmic", "cpu", "get", "Caption"]
+    assert calls[0][1]["timeout"] == module.COMMAND_TIMEOUT_SECONDS
+
+
+def test_simd_identity_falls_back_when_wmic_times_out(monkeypatch):
+    module = load_module(monkeypatch)
+
+    def fake_check_output(cmd, **kwargs):
+        raise module.subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(module.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(module.platform, "processor", lambda: "fallback cpu")
+    monkeypatch.setattr(module.platform, "machine", lambda: "AMD64")
+
+    valid, data = module.check_simd_identity()
+
+    assert valid is True
+    assert data["cpu_caption"] == "fallback cpu"


### PR DESCRIPTION
Clean redo of #7615 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `miners/windows/installer/src/fingerprint_checks_win.py`
- `miners/windows/installer/src/test_fingerprint_checks_win.py`

Validation:
- `python3 -m py_compile miners/windows/installer/src/fingerprint_checks_win.py -> passed`
- `python3 -m py_compile miners/windows/installer/src/test_fingerprint_checks_win.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
