### PR TITLE
fix(tools): tolerate malformed numeric env

### DIFF
--- a/tools/telegram_bot/telegram_bot.py
+++ b/tools/telegram_bot/telegram_bot.py
@@ -71,10 +71,25 @@ RAYDIUM_SWAP_URL = (
     f"{WRTC_MINT}"
 )
 
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 # Alert config
-PRICE_ALERT_INTERVAL = int(os.getenv("PRICE_ALERT_INTERVAL", "120"))   # seconds
-MINER_ALERT_INTERVAL = int(os.getenv("MINER_ALERT_INTERVAL", "60"))    # seconds
-PRICE_CHANGE_THRESHOLD = float(os.getenv("PRICE_CHANGE_THRESHOLD", "5.0"))  # percent
+PRICE_ALERT_INTERVAL = _int_env("PRICE_ALERT_INTERVAL", 120)   # seconds
+MINER_ALERT_INTERVAL = _int_env("MINER_ALERT_INTERVAL", 60)    # seconds
+PRICE_CHANGE_THRESHOLD = _float_env("PRICE_CHANGE_THRESHOLD", 5.0)  # percent
 HTTP_HEADERS = {
     "Accept": "application/json",
     "User-Agent": "RustChain-Telegram-Bot/1.0 (+https://github.com/Scottcjn/Rustchain)",


### PR DESCRIPTION
Clean redo of #7583 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `tools/telegram_bot/telegram_bot.py`

Validation:
- `python3 -m py_compile tools/telegram_bot/telegram_bot.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
