### PR TITLE
fix(tools): tolerate malformed numeric env

### DIFF
--- a/tools/telegram-bot/rustchain_bot.py
+++ b/tools/telegram-bot/rustchain_bot.py
@@ -30,8 +30,24 @@ from telegram.ext import Application, CommandHandler, ContextTypes
 
 RUSTCHAIN_API = os.getenv("RUSTCHAIN_API_URL", "https://rustchain.org")
 BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
-RATE_LIMIT_RPM = int(os.getenv("RATE_LIMIT_PER_MINUTE", "10"))
-RTC_PRICE_USD = float(os.getenv("RTC_PRICE_USD", "0.10"))
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+RATE_LIMIT_RPM = _int_env("RATE_LIMIT_PER_MINUTE", 10)
+RTC_PRICE_USD = _float_env("RTC_PRICE_USD", 0.10)
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO").upper(),

--- a/tools/telegram-bot/test_rustchain_bot.py
+++ b/tools/telegram-bot/test_rustchain_bot.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("rustchain_bot.py")
+
+
+class FakeAsyncClient:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+def _load_bot(monkeypatch, rate_limit: str, price: str):
+    monkeypatch.setenv("RATE_LIMIT_PER_MINUTE", rate_limit)
+    monkeypatch.setenv("RTC_PRICE_USD", price)
+
+    fake_httpx = types.SimpleNamespace(
+        AsyncClient=FakeAsyncClient,
+        TimeoutException=TimeoutError,
+        HTTPStatusError=Exception,
+    )
+    fake_telegram = types.SimpleNamespace(BotCommand=object, Update=object)
+    fake_ext = types.SimpleNamespace(
+        Application=object,
+        CommandHandler=lambda *args, **kwargs: (args, kwargs),
+        ContextTypes=types.SimpleNamespace(DEFAULT_TYPE=object),
+    )
+    fake_node = types.ModuleType("node")
+    fake_tls = types.ModuleType("node.tls_config")
+    fake_tls.get_async_tls_verify = lambda: True
+
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+    monkeypatch.setitem(sys.modules, "telegram", fake_telegram)
+    monkeypatch.setitem(sys.modules, "telegram.ext", fake_ext)
+    monkeypatch.setitem(sys.modules, "node", fake_node)
+    monkeypatch.setitem(sys.modules, "node.tls_config", fake_tls)
+
+    module_name = f"rustchain_bot_env_test_{rate_limit.replace('-', '_')}_{price.replace('.', '_')}"
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+    return module
+
+
+def test_malformed_numeric_env_falls_back_to_defaults(monkeypatch):
+    module = _load_bot(monkeypatch, "fast", "cheap")
+
+    assert module.RATE_LIMIT_RPM == 10
+    assert module.RTC_PRICE_USD == 0.10
+
+
+def test_valid_numeric_env_is_used(monkeypatch):
+    module = _load_bot(monkeypatch, "25", "0.42")
+
+    assert module.RATE_LIMIT_RPM == 25
+    assert module.RTC_PRICE_USD == 0.42


### PR DESCRIPTION
Clean redo of #7584 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `trained_lgbm_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `tools/telegram-bot/rustchain_bot.py`
- `tools/telegram-bot/test_rustchain_bot.py`

Validation:
- `python3 -m py_compile tools/telegram-bot/rustchain_bot.py -> passed`
- `python3 -m py_compile tools/telegram-bot/test_rustchain_bot.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
