### PR TITLE
fix(integrations): avoid wildcard CORS by default

### DIFF
--- a/integrations/epoch-viz/server.py
+++ b/integrations/epoch-viz/server.py
@@ -6,12 +6,19 @@ Serves static files and proxies API requests to bypass CORS
 
 import http.server
 import json
+import os
 import urllib.request
 import urllib.error
 from pathlib import Path
 
 NODE_URL = "https://50.28.86.131"
 PORT = 8888
+DEFAULT_CORS_ORIGIN = f"http://localhost:{PORT}"
+
+
+def cors_origin():
+    """Return the single origin allowed to read the local proxy."""
+    return os.environ.get("EPOCH_VIZ_CORS_ORIGIN", DEFAULT_CORS_ORIGIN).strip() or DEFAULT_CORS_ORIGIN
 
 class ProxyHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
@@ -40,7 +47,7 @@ class ProxyHandler(http.server.SimpleHTTPRequestHandler):
                 
                 self.send_response(200)
                 self.send_header('Content-Type', 'application/json')
-                self.send_header('Access-Control-Allow-Origin', '*')
+                self.send_header('Access-Control-Allow-Origin', cors_origin())
                 self.end_headers()
                 self.wfile.write(data)
         except urllib.error.URLError as e:
@@ -51,7 +58,7 @@ class ProxyHandler(http.server.SimpleHTTPRequestHandler):
     
     def end_headers(self):
         # Add CORS headers to all responses
-        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Origin', cors_origin())
         super().end_headers()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Clean redo of #7607 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `native_druid_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `integrations/epoch-viz/server.py`

Validation:
- `python3 -m py_compile integrations/epoch-viz/server.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
