### PR TITLE
fix(node): avoid hardcoded secret defaults

### DIFF
--- a/node/rustchain_bft_consensus.py
+++ b/node/rustchain_bft_consensus.py
@@ -1022,6 +1022,13 @@ class BFTConsensus:
 # FLASK ROUTES FOR BFT
 # ============================================================================
 
+def _load_bft_secret(cli_secret: Optional[str] = None) -> str:
+    secret = (cli_secret or os.environ.get("RUSTCHAIN_BFT_SECRET") or "").strip()
+    if not secret:
+        raise ValueError("BFT shared secret must be provided via --secret or RUSTCHAIN_BFT_SECRET")
+    return secret
+
+
 def create_bft_routes(app, bft: BFTConsensus):
     """Add BFT consensus routes to Flask app"""
     from flask import request, jsonify
@@ -1144,16 +1151,26 @@ def create_bft_routes(app, bft: BFTConsensus):
 # ============================================================================
 
 if __name__ == "__main__":
+    import argparse
     import sys
 
     print("=" * 60)
     print("RustChain BFT Consensus Module - RIP-0202")
     print("=" * 60)
 
-    # Test with mock data
-    node_id = sys.argv[1] if len(sys.argv) > 1 else "node-131"
-    db_path = "/tmp/bft_test.db"
-    secret_key = "rustchain_bft_testnet_key_2025"
+    parser = argparse.ArgumentParser(description="RustChain BFT Consensus Module - RIP-0202")
+    parser.add_argument("node_id", nargs="?", default="node-131")
+    parser.add_argument("--db-path", default="/tmp/bft_test.db")
+    parser.add_argument("--secret", help="Shared BFT HMAC secret; defaults to RUSTCHAIN_BFT_SECRET")
+    args = parser.parse_args()
+
+    node_id = args.node_id
+    db_path = args.db_path
+    try:
+        secret_key = _load_bft_secret(args.secret)
+    except ValueError as exc:
+        print(f"[BFT] {exc}", file=sys.stderr)
+        sys.exit(2)
 
     bft = BFTConsensus(node_id, db_path, secret_key)
 


### PR DESCRIPTION
Clean redo of #7595 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `native_druid_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `node/rustchain_bft_consensus.py`

Validation:
- `python3 -m py_compile node/rustchain_bft_consensus.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
