### PR TITLE
fix(bridge): reject non-JSON request bodies explicitly

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -220,7 +220,7 @@ def _sweep_expired_locks(conn, now: int):
 
 def _json_object_body():
     """Return the parsed JSON body only when it is an object."""
-    data = request.get_json(force=True, silent=True)
+    data = request.get_json(silent=True)
     if not isinstance(data, dict):
         return None, (jsonify({"error": "JSON object body is required"}), 400)
     return data, None

--- a/bridge/test_bridge_api.py
+++ b/bridge/test_bridge_api.py
@@ -653,6 +653,16 @@ class TestBridgeRequestValidation:
         assert resp.status_code == 400
         assert resp.get_json()["error"] == "JSON object body is required"
 
+    def test_lock_rejects_json_text_without_json_content_type(self, client):
+        resp = client.post(
+            "/bridge/lock",
+            data='{"sender_wallet":"test-miner"}',
+            content_type="text/plain",
+        )
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "JSON object body is required"
+
     def test_lock_rejects_non_string_fields(self, client):
         resp = client.post("/bridge/lock", json={
             "sender_wallet": ["test-miner"],


### PR DESCRIPTION
Clean redo of #7606 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `native_druid_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `bridge/bridge_api.py`
- `bridge/test_bridge_api.py`

Validation:
- `python3 -m py_compile bridge/bridge_api.py -> passed`
- `python3 -m py_compile bridge/test_bridge_api.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
