### PR TITLE
fix(node): reject non-JSON request bodies explicitly

### DIFF
--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -516,8 +516,11 @@ def register_routes(app):
     protocol = GPURenderProtocol()
 
     def _json_object_body():
-        data = request.get_json(force=True, silent=True)
+        raw_body = request.get_data(cache=True, as_text=True)
+        data = request.get_json(silent=True)
         if data is None:
+            if raw_body.strip():
+                return None, (jsonify({"error": "JSON object required"}), 400)
             return {}, None
         if not isinstance(data, dict):
             return None, (jsonify({"error": "JSON object required"}), 400)

--- a/tests/test_gpu_render_protocol.py
+++ b/tests/test_gpu_render_protocol.py
@@ -247,6 +247,35 @@ def test_gpu_protocol_routes_reject_non_object_json(tmp_path, monkeypatch, path)
     assert response.get_json() == {"error": "JSON object required"}
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/gpu/attest",
+        "/render/escrow",
+        "/voice/escrow",
+        "/llm/escrow",
+        "/render/release",
+        "/voice/release",
+        "/llm/release",
+        "/render/refund",
+        "/render/pricing/check",
+    ],
+)
+def test_gpu_protocol_routes_reject_json_text_without_json_content_type(
+    tmp_path, monkeypatch, path
+):
+    client = _route_client(tmp_path, monkeypatch)
+
+    response = client.post(
+        path,
+        data='{"unexpected":"object"}',
+        content_type="text/plain",
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
 def test_gpu_protocol_escrow_rejects_structured_wallet(tmp_path, monkeypatch):
     client = _route_client(tmp_path, monkeypatch)
 


### PR DESCRIPTION
Clean redo of #7608 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `native_druid_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `node/gpu_render_protocol.py`
- `tests/test_gpu_render_protocol.py`

Validation:
- `python3 -m py_compile node/gpu_render_protocol.py -> passed`
- `python3 -m py_compile tests/test_gpu_render_protocol.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
