### PR TITLE
fix(node): reject non-JSON request bodies explicitly

### DIFF
--- a/node/sophia_elya_service.py
+++ b/node/sophia_elya_service.py
@@ -441,7 +441,9 @@ def balance(miner_pk):
 
 
 def _json_object_body():
-    data = request.get_json(force=True, silent=True)
+    if not request.is_json:
+        return None, (jsonify({"error": "content_type_json_required"}), 415)
+    data = request.get_json(silent=True)
     if not isinstance(data, dict):
         return None, (jsonify({"error": "json_object_required"}), 400)
     return data, None

--- a/node/tests/test_sophia_elya_service.py
+++ b/node/tests/test_sophia_elya_service.py
@@ -15,6 +15,17 @@ def test_elya_register_requires_json_object():
     assert resp.get_json()["error"] == "json_object_required"
 
 
+def test_elya_register_requires_json_content_type():
+    resp = _client().post(
+        "/api/register",
+        data='{"system_id":"miner-a","fingerprint":{"cpu":"g4"}}',
+        content_type="text/plain",
+    )
+
+    assert resp.status_code == 415
+    assert resp.get_json()["error"] == "content_type_json_required"
+
+
 def test_elya_epoch_enroll_rejects_invalid_nested_shapes():
     client = _client()
 


### PR DESCRIPTION
Clean redo of #7613 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `native_druid_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `node/sophia_elya_service.py`
- `node/tests/test_sophia_elya_service.py`

Validation:
- `python3 -m py_compile node/sophia_elya_service.py -> passed`
- `python3 -m py_compile node/tests/test_sophia_elya_service.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
