### PR TITLE
fix(.github): bound urlopen request timeouts

### DIFF
--- a/.github/actions/bcos-action/anchor.py
+++ b/.github/actions/bcos-action/anchor.py
@@ -12,6 +12,7 @@ from urllib.request import Request, urlopen
 from urllib.error import HTTPError
 
 logger = logging.getLogger("bcos-action")
+HTTP_TIMEOUT_SECONDS = 30
 
 
 def main():
@@ -56,7 +57,7 @@ def main():
     )
     
     try:
-        response = urlopen(req)
+        response = urlopen(req, timeout=HTTP_TIMEOUT_SECONDS)
         result = json.loads(response.read().decode('utf-8'))
         logger.info("Attestation anchored successfully!")
         logger.info("Transaction: %s", result.get("tx_hash", "N/A"))


### PR DESCRIPTION
Clean redo of #7611 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `native_druid_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `.github/actions/bcos-action/anchor.py`

Validation:
- `python3 -m py_compile .github/actions/bcos-action/anchor.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
