### PR TITLE
fix(miners): bound subprocess execution timeouts

### DIFF
--- a/miners/windows/installer/build_miner.py
+++ b/miners/windows/installer/build_miner.py
@@ -21,6 +21,7 @@ SRC_DIR = PROJECT_DIR / "src"
 ENTRY_POINT = SRC_DIR / "rustchain_windows_miner.py"
 ICON_FILE = PROJECT_DIR / "assets" / "rustchain.ico"
 DIST_DIR = PROJECT_DIR / "dist"
+BUILD_TIMEOUT_SECONDS = 900
 
 
 def build():
@@ -88,7 +89,11 @@ def build():
     print("-" * 60)
 
     # Run PyInstaller
-    result = subprocess.run(cmd, cwd=str(PROJECT_DIR))
+    try:
+        result = subprocess.run(cmd, cwd=str(PROJECT_DIR), timeout=BUILD_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        print(f"  ERROR: PyInstaller build timed out after {BUILD_TIMEOUT_SECONDS} seconds!")
+        sys.exit(1)
 
     if result.returncode == 0:
         exe_path = DIST_DIR / "RustChainMiner.exe"

--- a/miners/windows/installer/test_build_miner.py
+++ b/miners/windows/installer/test_build_miner.py
@@ -1,0 +1,72 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_module():
+    module_path = Path(__file__).with_name("build_miner.py")
+    spec = importlib.util.spec_from_file_location("build_miner_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_passes_timeout_to_pyinstaller(monkeypatch, tmp_path):
+    module = load_module()
+    project_dir = tmp_path / "installer"
+    src_dir = project_dir / "src"
+    dist_dir = project_dir / "dist"
+    src_dir.mkdir(parents=True)
+    entry_point = src_dir / "rustchain_windows_miner.py"
+    entry_point.write_text("print('miner')\n", encoding="utf-8")
+    (dist_dir).mkdir()
+    exe_path = dist_dir / "RustChainMiner.exe"
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        exe_path.write_bytes(b"exe")
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(module, "PROJECT_DIR", project_dir)
+    monkeypatch.setattr(module, "SRC_DIR", src_dir)
+    monkeypatch.setattr(module, "ENTRY_POINT", entry_point)
+    monkeypatch.setattr(module, "ICON_FILE", project_dir / "assets" / "rustchain.ico")
+    monkeypatch.setattr(module, "DIST_DIR", dist_dir)
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    module.build()
+
+    assert calls
+    assert calls[0][1]["cwd"] == str(project_dir)
+    assert calls[0][1]["timeout"] == module.BUILD_TIMEOUT_SECONDS
+
+
+def test_build_exits_cleanly_on_pyinstaller_timeout(monkeypatch, tmp_path):
+    module = load_module()
+    project_dir = tmp_path / "installer"
+    src_dir = project_dir / "src"
+    src_dir.mkdir(parents=True)
+    entry_point = src_dir / "rustchain_windows_miner.py"
+    entry_point.write_text("print('miner')\n", encoding="utf-8")
+
+    def fake_run(cmd, **kwargs):
+        raise module.subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(module, "PROJECT_DIR", project_dir)
+    monkeypatch.setattr(module, "SRC_DIR", src_dir)
+    monkeypatch.setattr(module, "ENTRY_POINT", entry_point)
+    monkeypatch.setattr(module, "ICON_FILE", project_dir / "assets" / "rustchain.ico")
+    monkeypatch.setattr(module, "DIST_DIR", project_dir / "dist")
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    try:
+        module.build()
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        raise AssertionError("expected timeout SystemExit")


### PR DESCRIPTION
Clean redo of #7616 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `native_druid_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `miners/windows/installer/build_miner.py`
- `miners/windows/installer/test_build_miner.py`

Validation:
- `python3 -m py_compile miners/windows/installer/build_miner.py -> passed`
- `python3 -m py_compile miners/windows/installer/test_build_miner.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
