### PR TITLE
fix(poa): bound subprocess execution timeouts

### DIFF
--- a/rustchain-poa/validator/emulation_detector.py
+++ b/rustchain-poa/validator/emulation_detector.py
@@ -1,11 +1,17 @@
 import platform, subprocess
 
+EMULATION_COMMAND_TIMEOUT = 10
+
 def detect_emulation():
     emu_flags = []
     score = 0
     try:
         if platform.system() == 'Linux':
-            output = subprocess.check_output(['systemd-detect-virt']).decode().strip()
+            output = subprocess.check_output(
+                ['systemd-detect-virt'],
+                stderr=subprocess.DEVNULL,
+                timeout=EMULATION_COMMAND_TIMEOUT,
+            ).decode().strip()
             if output and output != 'none':
                 emu_flags.append(f"Detected virtualization: {output}")
                 score += 50


### PR DESCRIPTION
Clean redo of #7625 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `native_druid_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `rustchain-poa/validator/emulation_detector.py`

Validation:
- `python3 -m py_compile rustchain-poa/validator/emulation_detector.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
