### PR TITLE
fix(miners): bound subprocess execution timeouts

### DIFF
--- a/miners/windows/installer/src/rustchain_windows_miner.py
+++ b/miners/windows/installer/src/rustchain_windows_miner.py
@@ -46,11 +46,18 @@ except ImportError:
 RUSTCHAIN_API = "https://rustchain.org"
 WALLET_DIR = Path.home() / ".rustchain"
 CONFIG_FILE = WALLET_DIR / "config.json"
+COMMAND_TIMEOUT_SECONDS = 10
 
 # TLS verification: pinned cert or system CA bundle
 _CERT_PATH = str(WALLET_DIR / "node_cert.pem")
 TLS_VERIFY = _CERT_PATH if os.path.exists(_CERT_PATH) else True
 WALLET_FILE = WALLET_DIR / "wallet.json"
+
+
+def _check_output_with_timeout(cmd, **kwargs):
+    kwargs.setdefault("timeout", COMMAND_TIMEOUT_SECONDS)
+    return subprocess.check_output(cmd, **kwargs)
+
 
 class RustChainWallet:
     """Windows wallet for RustChain"""
@@ -151,7 +158,7 @@ def _windows_fingerprint_checks():
     flags = []
     creation_flag = getattr(subprocess, "CREATE_NO_WINDOW", 0)
     try:
-        out = subprocess.check_output(
+        out = _check_output_with_timeout(
             ["wmic", "cpu", "get", "Name,Description,Caption"],
             stderr=subprocess.DEVNULL, creationflags=creation_flag
         ).decode("utf-8", "ignore")
@@ -248,7 +255,7 @@ def _windows_fingerprint_checks():
     vm_indicators = []
     # WMI-based VM detection
     try:
-        out = subprocess.check_output(
+        out = _check_output_with_timeout(
             ["wmic", "computersystem", "get", "Model,Manufacturer"],
             stderr=subprocess.DEVNULL, creationflags=creation_flag
         ).decode("utf-8", "ignore").lower()
@@ -263,7 +270,7 @@ def _windows_fingerprint_checks():
         pass
     # BIOS vendor check
     try:
-        out = subprocess.check_output(
+        out = _check_output_with_timeout(
             ["wmic", "bios", "get", "Manufacturer,SMBIOSBIOSVersion"],
             stderr=subprocess.DEVNULL, creationflags=creation_flag
         ).decode("utf-8", "ignore").lower()
@@ -428,7 +435,7 @@ class RustChainMiner:
 
         creation_flag = getattr(subprocess, "CREATE_NO_WINDOW", 0)
         try:
-            output = subprocess.check_output(
+            output = _check_output_with_timeout(
                 ["getmac", "/fo", "csv", "/nh"],
                 stderr=subprocess.DEVNULL,
                 creationflags=creation_flag

--- a/miners/windows/installer/src/test_rustchain_windows_miner.py
+++ b/miners/windows/installer/src/test_rustchain_windows_miner.py
@@ -1,0 +1,39 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_module():
+    module_path = Path(__file__).with_name("rustchain_windows_miner.py")
+    spec = importlib.util.spec_from_file_location("rustchain_windows_miner_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_check_output_helper_adds_timeout(monkeypatch):
+    module = load_module()
+    calls = []
+
+    def fake_check_output(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return b"ok"
+
+    monkeypatch.setattr(module.subprocess, "check_output", fake_check_output)
+
+    assert module._check_output_with_timeout(["wmic", "cpu"]) == b"ok"
+    assert calls[0][1]["timeout"] == module.COMMAND_TIMEOUT_SECONDS
+
+
+def test_check_output_helper_preserves_explicit_timeout(monkeypatch):
+    module = load_module()
+    calls = []
+
+    def fake_check_output(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return b"ok"
+
+    monkeypatch.setattr(module.subprocess, "check_output", fake_check_output)
+
+    module._check_output_with_timeout(["wmic", "cpu"], timeout=1)
+
+    assert calls[0][1]["timeout"] == 1


### PR DESCRIPTION
Clean redo of #7617 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `native_druid_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `miners/windows/installer/src/rustchain_windows_miner.py`
- `miners/windows/installer/src/test_rustchain_windows_miner.py`

Validation:
- `python3 -m py_compile miners/windows/installer/src/rustchain_windows_miner.py -> passed`
- `python3 -m py_compile miners/windows/installer/src/test_rustchain_windows_miner.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
