### PR TITLE
fix(tools): tolerate malformed numeric env

### DIFF
--- a/tools/telegram-bot/bot.py
+++ b/tools/telegram-bot/bot.py
@@ -28,10 +28,25 @@ from telegram.ext import Application, CommandHandler, ContextTypes
 # Configuration
 # ---------------------------------------------------------------------------
 
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 RUSTCHAIN_API = os.getenv("RUSTCHAIN_API_URL", "https://rustchain.org")
 BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
-RATE_LIMIT_RPM = int(os.getenv("RATE_LIMIT_PER_MINUTE", "10"))
-RTC_PRICE_USD = float(os.getenv("RTC_PRICE_USD", "0.10"))
+RATE_LIMIT_RPM = _int_env("RATE_LIMIT_PER_MINUTE", 10)
+RTC_PRICE_USD = _float_env("RTC_PRICE_USD", 0.10)
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO").upper(),

--- a/tools/telegram-bot/test_bot.py
+++ b/tools/telegram-bot/test_bot.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("bot.py")
+
+
+def install_telegram_stubs(monkeypatch):
+    telegram = types.ModuleType("telegram")
+
+    class BotCommand:
+        def __init__(self, name, description):
+            self.name = name
+            self.description = description
+
+    class Update:
+        ALL_TYPES = object()
+
+    telegram.BotCommand = BotCommand
+    telegram.Update = Update
+
+    telegram_ext = types.ModuleType("telegram.ext")
+
+    class _Builder:
+        def token(self, _token):
+            return self
+
+        def build(self):
+            return object()
+
+    class Application:
+        @classmethod
+        def builder(cls):
+            return _Builder()
+
+    class CommandHandler:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    class ContextTypes:
+        DEFAULT_TYPE = object()
+
+    telegram_ext.Application = Application
+    telegram_ext.CommandHandler = CommandHandler
+    telegram_ext.ContextTypes = ContextTypes
+    monkeypatch.setitem(sys.modules, "telegram", telegram)
+    monkeypatch.setitem(sys.modules, "telegram.ext", telegram_ext)
+
+
+def load_bot_module(monkeypatch):
+    install_telegram_stubs(monkeypatch)
+    module_name = "test_tools_telegram_bot_module"
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+    return module
+
+
+def test_malformed_numeric_env_falls_back(monkeypatch):
+    monkeypatch.setenv("RATE_LIMIT_PER_MINUTE", "not-an-int")
+    monkeypatch.setenv("RTC_PRICE_USD", "not-a-float")
+
+    module = load_bot_module(monkeypatch)
+
+    assert module.RATE_LIMIT_RPM == 10
+    assert module.RTC_PRICE_USD == 0.10
+
+
+def test_valid_numeric_env_is_preserved(monkeypatch):
+    monkeypatch.setenv("RATE_LIMIT_PER_MINUTE", "42")
+    monkeypatch.setenv("RTC_PRICE_USD", "0.25")
+
+    module = load_bot_module(monkeypatch)
+
+    assert module.RATE_LIMIT_RPM == 42
+    assert module.RTC_PRICE_USD == 0.25


### PR DESCRIPTION
Clean redo of #7591 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `native_druid_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `tools/telegram-bot/bot.py`
- `tools/telegram-bot/test_bot.py`

Validation:
- `python3 -m py_compile tools/telegram-bot/bot.py -> passed`
- `python3 -m py_compile tools/telegram-bot/test_bot.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
