### PR TITLE
fix(node): tolerate malformed numeric env

### DIFF
--- a/node/sophia_governor.py
+++ b/node/sophia_governor.py
@@ -119,6 +119,20 @@ def _env_truthy(name: str, default: str = "false") -> bool:
     return str(os.getenv(name, default)).strip().lower() in TRUE_VALUES
 
 
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 def _governor_llm_mode() -> str:
     return str(os.getenv("SOPHIA_GOVERNOR_ENABLE_LLM", "auto")).strip().lower()
 
@@ -133,15 +147,15 @@ def _llm_enabled() -> bool:
 
 
 def _transfer_warning_rtc() -> float:
-    return float(os.getenv("SOPHIA_GOVERNOR_TRANSFER_WARNING_RTC", "1000"))
+    return _float_env("SOPHIA_GOVERNOR_TRANSFER_WARNING_RTC", 1000.0)
 
 
 def _transfer_critical_rtc() -> float:
-    return float(os.getenv("SOPHIA_GOVERNOR_TRANSFER_CRITICAL_RTC", "10000"))
+    return _float_env("SOPHIA_GOVERNOR_TRANSFER_CRITICAL_RTC", 10000.0)
 
 
 def _max_recent_rows() -> int:
-    return max(1, min(int(os.getenv("SOPHIA_GOVERNOR_MAX_RECENT", "50")), 200))
+    return max(1, min(_int_env("SOPHIA_GOVERNOR_MAX_RECENT", 50), 200))
 
 
 def _parse_recent_limit(value: Any, default: int = 20) -> int:
@@ -174,8 +188,8 @@ def _phone_home_targets() -> list[str]:
 
 
 def _phone_home_timeouts() -> tuple[float, float]:
-    connect_timeout = float(os.getenv("SOPHIA_GOVERNOR_PHONE_HOME_CONNECT_TIMEOUT_SEC", "4"))
-    read_timeout = float(os.getenv("SOPHIA_GOVERNOR_PHONE_HOME_READ_TIMEOUT_SEC", "120"))
+    connect_timeout = _float_env("SOPHIA_GOVERNOR_PHONE_HOME_CONNECT_TIMEOUT_SEC", 4.0)
+    read_timeout = _float_env("SOPHIA_GOVERNOR_PHONE_HOME_READ_TIMEOUT_SEC", 120.0)
     return max(1.0, connect_timeout), max(5.0, read_timeout)
 
 

--- a/node/tests/test_sophia_governor.py
+++ b/node/tests/test_sophia_governor.py
@@ -63,6 +63,28 @@ def client(app):
     return app.test_client()
 
 
+def test_numeric_env_helpers_fall_back_on_malformed_values(monkeypatch):
+    monkeypatch.setenv("SOPHIA_GOVERNOR_TRANSFER_WARNING_RTC", "not-a-float")
+    monkeypatch.setenv("SOPHIA_GOVERNOR_TRANSFER_CRITICAL_RTC", "also-bad")
+    monkeypatch.setenv("SOPHIA_GOVERNOR_MAX_RECENT", "not-an-int")
+    monkeypatch.setenv("SOPHIA_GOVERNOR_PHONE_HOME_CONNECT_TIMEOUT_SEC", "bad-connect")
+    monkeypatch.setenv("SOPHIA_GOVERNOR_PHONE_HOME_READ_TIMEOUT_SEC", "bad-read")
+
+    assert sophia_governor._transfer_warning_rtc() == 1000.0
+    assert sophia_governor._transfer_critical_rtc() == 10000.0
+    assert sophia_governor._max_recent_rows() == 50
+    assert sophia_governor._phone_home_timeouts() == (4.0, 120.0)
+
+
+def test_numeric_env_helpers_clamp_bounds(monkeypatch):
+    monkeypatch.setenv("SOPHIA_GOVERNOR_MAX_RECENT", "500")
+    monkeypatch.setenv("SOPHIA_GOVERNOR_PHONE_HOME_CONNECT_TIMEOUT_SEC", "0.1")
+    monkeypatch.setenv("SOPHIA_GOVERNOR_PHONE_HOME_READ_TIMEOUT_SEC", "1.5")
+
+    assert sophia_governor._max_recent_rows() == 200
+    assert sophia_governor._phone_home_timeouts() == (1.0, 5.0)
+
+
 def test_low_risk_governance_stays_local(tmp_db):
     result = review_rustchain_event(
         event_type="governance_proposal",


### PR DESCRIPTION
Clean redo of #7577 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `native_druid_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `node/sophia_governor.py`
- `node/tests/test_sophia_governor.py`

Validation:
- `python3 -m py_compile node/sophia_governor.py -> passed`
- `python3 -m py_compile node/tests/test_sophia_governor.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
