### PR TITLE
fix(node): tolerate malformed numeric env

### DIFF
--- a/node/sophia_governor_inbox.py
+++ b/node/sophia_governor_inbox.py
@@ -106,6 +106,13 @@ def _env_truthy(name: str, default: str = "false") -> bool:
     return str(os.getenv(name, default)).strip().lower() in TRUE_VALUES
 
 
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 def _text_excerpt(text: Any, limit: int = 600) -> str:
     if text is None:
         return ""
@@ -190,8 +197,8 @@ def _auto_forward_enabled() -> bool:
 
 
 def _forward_timeouts() -> tuple[float, float]:
-    connect_timeout = float(os.getenv("SOPHIA_GOVERNOR_INBOX_FORWARD_CONNECT_TIMEOUT_SEC", "4"))
-    read_timeout = float(os.getenv("SOPHIA_GOVERNOR_INBOX_FORWARD_READ_TIMEOUT_SEC", "90"))
+    connect_timeout = _float_env("SOPHIA_GOVERNOR_INBOX_FORWARD_CONNECT_TIMEOUT_SEC", 4.0)
+    read_timeout = _float_env("SOPHIA_GOVERNOR_INBOX_FORWARD_READ_TIMEOUT_SEC", 90.0)
     return max(1.0, connect_timeout), max(5.0, read_timeout)
 
 

--- a/node/tests/test_sophia_governor_inbox.py
+++ b/node/tests/test_sophia_governor_inbox.py
@@ -58,6 +58,20 @@ def client(app):
     return app.test_client()
 
 
+def test_forward_timeouts_fall_back_on_malformed_env(monkeypatch):
+    monkeypatch.setenv("SOPHIA_GOVERNOR_INBOX_FORWARD_CONNECT_TIMEOUT_SEC", "not-a-float")
+    monkeypatch.setenv("SOPHIA_GOVERNOR_INBOX_FORWARD_READ_TIMEOUT_SEC", "also-bad")
+
+    assert sophia_governor_inbox._forward_timeouts() == (4.0, 90.0)
+
+
+def test_forward_timeouts_clamp_low_values(monkeypatch):
+    monkeypatch.setenv("SOPHIA_GOVERNOR_INBOX_FORWARD_CONNECT_TIMEOUT_SEC", "0.1")
+    monkeypatch.setenv("SOPHIA_GOVERNOR_INBOX_FORWARD_READ_TIMEOUT_SEC", "1.5")
+
+    assert sophia_governor_inbox._forward_timeouts() == (1.0, 5.0)
+
+
 def _sample_envelope():
     return {
         "event_id": 42,


### PR DESCRIPTION
Clean redo of #7576 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `native_druid_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `node/sophia_governor_inbox.py`
- `node/tests/test_sophia_governor_inbox.py`

Validation:
- `python3 -m py_compile node/sophia_governor_inbox.py -> passed`
- `python3 -m py_compile node/tests/test_sophia_governor_inbox.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
