### PR TITLE
fix(node): tolerate malformed numeric env

### DIFF
--- a/node/sophia_governor_review_service.py
+++ b/node/sophia_governor_review_service.py
@@ -76,6 +76,13 @@ def _safe_json_dumps(value: Any) -> str:
     return json.dumps(value, sort_keys=True, default=str)
 
 
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 def _text_excerpt(text: Any, limit: int = 800) -> str:
     if text is None:
         return ""
@@ -783,7 +790,7 @@ def queue_scott_notification():
 
 def main():
     init_db()
-    port = int(os.getenv("SOPHIA_GOVERNOR_REVIEW_PORT", "8091"))
+    port = _int_env("SOPHIA_GOVERNOR_REVIEW_PORT", 8091)
     host = os.getenv("SOPHIA_GOVERNOR_REVIEW_HOST", "0.0.0.0")
     app.run(host=host, port=port, debug=False)
 

--- a/node/tests/test_sophia_governor_review_service.py
+++ b/node/tests/test_sophia_governor_review_service.py
@@ -54,6 +54,18 @@ def _payload():
     }
 
 
+def test_review_port_env_falls_back_on_malformed_value(monkeypatch):
+    monkeypatch.setenv("SOPHIA_GOVERNOR_REVIEW_PORT", "not-an-int")
+
+    assert review_service._int_env("SOPHIA_GOVERNOR_REVIEW_PORT", 8091) == 8091
+
+
+def test_review_port_env_accepts_valid_value(monkeypatch):
+    monkeypatch.setenv("SOPHIA_GOVERNOR_REVIEW_PORT", "8092")
+
+    assert review_service._int_env("SOPHIA_GOVERNOR_REVIEW_PORT", 8091) == 8092
+
+
 def test_review_requires_auth(client):
     response = client.post("/review", json=_payload())
     assert response.status_code == 401


### PR DESCRIPTION
Clean redo of #7578 after Scott's scope-hygiene feedback.

This branch intentionally keeps the original technical fix small and excludes the unrelated shared CI/baseline/consensus-node edits that caused the previous PR to be closed.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- dispatch_arm: `native_druid_selector`
- selector_run_id: `6ac915456973ebaf`

Scoped files:
- `node/sophia_governor_review_service.py`
- `node/tests/test_sophia_governor_review_service.py`

Validation:
- `python3 -m py_compile node/sophia_governor_review_service.py -> passed`
- `python3 -m py_compile node/tests/test_sophia_governor_review_service.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No `node/rustchain_v2_integrated_v2.2.1_rip200.py` or `scripts/baselines/*` maintenance diff.

@Scottcjn this is the clean, scoped redo of the earlier closed PR.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
