### PR TITLE
fix(mcp): avoid disabled TLS verification by default

### DIFF
--- a/rustchain-bounties-mcp/rustchain_bounties_mcp/client.py
+++ b/rustchain-bounties-mcp/rustchain_bounties_mcp/client.py
@@ -63,11 +63,13 @@ class RustChainClient:
         timeout: int = REQUEST_TIMEOUT,
         retry_count: int = RETRY_COUNT,
         session: Optional[aiohttp.ClientSession] = None,
+        verify_tls: bool = True,
     ):
         self.node_url = (node_url or DEFAULT_NODE_URL).rstrip("/")
         self.timeout = timeout
         self.retry_count = retry_count
         self._session = session
+        self.verify_tls = verify_tls
         self._owns_session = session is None
 
     async def __aenter__(self) -> "RustChainClient":
@@ -98,7 +100,7 @@ class RustChainClient:
         params: Optional[dict[str, Any]] = None,
         json_data: Optional[dict[str, Any]] = None,
     ) -> Any:
-        """HTTP request with retry and self-signed-cert handling."""
+        """HTTP request with retry handling."""
         await self._ensure_session()
         url = f"{self.node_url}{path}"
         last_err: Optional[Exception] = None
@@ -106,7 +108,7 @@ class RustChainClient:
         for attempt in range(self.retry_count + 1):
             try:
                 async with self._session.request(
-                    method, url, params=params, json=json_data, ssl=False,
+                    method, url, params=params, json=json_data, ssl=self.verify_tls,
                 ) as resp:
                     body = await resp.json()
                     if resp.status >= 400:
@@ -282,7 +284,7 @@ class RustChainClient:
         headers = {"Accept": "application/vnd.github.v3+json", "User-Agent": "RustChain-Bounties-MCP/0.1"}
 
         try:
-            async with self._session.get(url, params=params, headers=headers, ssl=False) as resp:
+            async with self._session.get(url, params=params, headers=headers, ssl=self.verify_tls) as resp:
                 if resp.status >= 400:
                     body = await resp.text()
                     logger.warning("GitHub API returned %d: %s", resp.status, body[:200])

--- a/rustchain-bounties-mcp/tests/test_client_miners.py
+++ b/rustchain-bounties-mcp/tests/test_client_miners.py
@@ -33,12 +33,12 @@ class MockResponse:
         return self._data
 
 
-def client_for_response(data) -> RustChainClient:
+def client_for_response(data, *, verify_tls: bool = True) -> RustChainClient:
     response = MockResponse(data)
     session = MagicMock()
     session.request = MagicMock(return_value=AsyncContextManager(response))
 
-    client = RustChainClient(node_url="https://node.example")
+    client = RustChainClient(node_url="https://node.example", verify_tls=verify_tls)
     client._session = session
     client._owns_session = False
     return client
@@ -62,6 +62,36 @@ def test_numeric_env_overrides_are_preserved(monkeypatch):
 
     assert module.REQUEST_TIMEOUT == 12
     assert module.RETRY_COUNT == 4
+
+
+@pytest.mark.asyncio
+async def test_node_requests_verify_tls_by_default():
+    client = client_for_response({"miners": []})
+
+    await client.miners()
+
+    assert client._session.request.call_args.kwargs["ssl"] is True
+
+
+@pytest.mark.asyncio
+async def test_node_requests_allow_explicit_tls_opt_out():
+    client = client_for_response({"miners": []}, verify_tls=False)
+
+    await client.miners()
+
+    assert client._session.request.call_args.kwargs["ssl"] is False
+
+
+@pytest.mark.asyncio
+async def test_github_bounty_fetch_verifies_tls_by_default():
+    response = MockResponse([])
+    session = MagicMock()
+    session.get = MagicMock(return_value=AsyncContextManager(response))
+    client = RustChainClient(node_url="https://node.example", session=session)
+
+    await client._fetch_bounties_from_github()
+
+    assert session.get.call_args.kwargs["ssl"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This is a fresh selector-owned PR from the natural selector scan.

Problem:
- The client disables TLS certificate verification by default (`ssl=False`) on outbound aiohttp requests.

Fix:
- Keep TLS verification enabled by default.
- Preserve an explicit `verify_tls=False` opt-out for self-signed/local endpoints.
- Add regression tests proving the default and opt-out behavior.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- lgbm_rank: `2`
- native_rank: `2`
- dispatch_arm: `trained_lgbm_selector`

Scoped files:
- `rustchain-bounties-mcp/rustchain_bounties_mcp/client.py`
- `rustchain-bounties-mcp/tests/test_client_miners.py`

Validation:
- `python3 -m py_compile rustchain-bounties-mcp/rustchain_bounties_mcp/client.py -> passed`
- `python3 -m py_compile rustchain-bounties-mcp/tests/test_client_miners.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No unrelated maintenance, baseline, or consensus-node edits.

@Scottcjn this is a fresh, scoped selector PR with natural attribution preserved as `both_selectors` when both arms found it.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
