### PR TITLE
fix(integrations): avoid disabled TLS verification by default

### DIFF
--- a/integrations/rustchain-mcp/client.py
+++ b/integrations/rustchain-mcp/client.py
@@ -63,6 +63,7 @@ class RustChainClient:
         timeout: int = REQUEST_TIMEOUT,
         retry_count: int = RETRY_COUNT,
         session: Optional[aiohttp.ClientSession] = None,
+        verify_tls: bool = True,
     ):
         """
         Initialize RustChain client.
@@ -73,12 +74,14 @@ class RustChainClient:
             timeout: Request timeout in seconds
             retry_count: Number of retries on failure
             session: Optional existing aiohttp session
+            verify_tls: Verify TLS certificates by default; set False only for explicit self-signed test endpoints.
         """
         self.base_url = (base_url or RUSTCHAIN_API_BASE).rstrip("/")
         self.node_url = (node_url or RUSTCHAIN_NODE_URL).rstrip("/")
         self.timeout = timeout
         self.retry_count = retry_count
         self._session = session
+        self.verify_tls = verify_tls
         self._owns_session = session is None
 
     async def __aenter__(self) -> "RustChainClient":
@@ -141,7 +144,7 @@ class RustChainClient:
                     url,
                     params=params,
                     json=json_data,
-                    ssl=False,  # Self-signed cert
+                    ssl=self.verify_tls,
                 ) as resp:
                     if resp.status >= 400:
                         error_body = await resp.json()

--- a/integrations/rustchain-mcp/tests/test_client.py
+++ b/integrations/rustchain-mcp/tests/test_client.py
@@ -118,6 +118,46 @@ class TestRustChainClient:
             assert health.is_healthy is True
             assert health.version == "1.0.0"
 
+
+    @pytest.mark.asyncio
+    async def test_requests_verify_tls_by_default(self):
+        """Test request path keeps TLS verification enabled by default."""
+        mock_response = MockResponse({"status": "ok", "timestamp": 1234567890, "service": "test-api"})
+
+        with patch("aiohttp.ClientSession") as MockSession:
+            mock_session = MagicMock()
+            mock_session.request = MagicMock(return_value=AsyncContextManager(mock_response))
+            mock_session.close = AsyncMock()
+            MockSession.return_value = mock_session
+
+            client = RustChainClient(base_url="https://test.example.com")
+            client._session = mock_session
+            client._owns_session = False
+
+            await client.health()
+
+            assert mock_session.request.call_args.kwargs["ssl"] is True
+
+    @pytest.mark.asyncio
+    async def test_requests_allow_explicit_tls_opt_out(self):
+        """Test self-signed endpoints require an explicit TLS opt-out."""
+        mock_response = MockResponse({"status": "ok", "timestamp": 1234567890, "service": "test-api"})
+
+        with patch("aiohttp.ClientSession") as MockSession:
+            mock_session = MagicMock()
+            mock_session.request = MagicMock(return_value=AsyncContextManager(mock_response))
+            mock_session.close = AsyncMock()
+            MockSession.return_value = mock_session
+
+            client = RustChainClient(base_url="https://test.example.com", verify_tls=False)
+            client._session = mock_session
+            client._owns_session = False
+
+            await client.health()
+
+            assert mock_session.request.call_args.kwargs["ssl"] is False
+
+
     @pytest.mark.asyncio
     async def test_health_error(self):
         """Test health check error."""


### PR DESCRIPTION
This is a fresh selector-owned PR from the natural selector scan.

Problem:
- The client disables TLS certificate verification by default (`ssl=False`) on outbound aiohttp requests.

Fix:
- Keep TLS verification enabled by default.
- Preserve an explicit `verify_tls=False` opt-out for self-signed/local endpoints.
- Add regression tests proving the default and opt-out behavior.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- lgbm_rank: `1`
- native_rank: `1`
- dispatch_arm: `native_druid_selector`

Scoped files:
- `integrations/rustchain-mcp/client.py`
- `integrations/rustchain-mcp/tests/test_client.py`

Validation:
- `python3 -m py_compile integrations/rustchain-mcp/client.py -> passed`
- `python3 -m py_compile integrations/rustchain-mcp/tests/test_client.py -> passed`
- `GitHub Contents API path filter -> source/test files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No unrelated maintenance, baseline, or consensus-node edits.

@Scottcjn this is a fresh, scoped selector PR with natural attribution preserved as `both_selectors` when both arms found it.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
