### PR TITLE
[UTXO-BUG] Fix dual-write rollback and mempool transaction storage

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8305,7 +8305,7 @@ def _pending_ledger_explorer_transactions(db, limit):
         LIMIT ?
         """,
         (limit,),
-    ).fetchall()
+    ).fetchall()  # fetchall-ok: already-paginated
 
     transactions = []
     for row in rows:
@@ -8369,7 +8369,7 @@ def _ledger_explorer_transactions(db, limit):
         LIMIT ?
         """,
         (limit,),
-    ).fetchall()
+    ).fetchall()  # fetchall-ok: already-paginated
     transactions = []
     for row in rows:
         amount_i64 = int(row["delta_i64"])

--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -1812,6 +1812,59 @@ class TestUtxoDB(unittest.TestCase):
                 self.assertEqual(db.mempool_get_block_candidates(), [])
                 self.assertFalse(db.mempool_check_double_spend(box['box_id']))
 
+    def test_mempool_persists_only_normalized_transaction_intent(self):
+        """Caller-controlled extras and proofs must not be stored in mempool."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        box = self.db.get_unspent_for_address('alice')[0]
+
+        ok = self.db.mempool_add({
+            'tx_id': 'normalized-intent',
+            'tx_type': 'transfer',
+            'inputs': [{
+                'box_id': box['box_id'],
+                'spending_proof': 'S' * 100_000,
+                'attacker_note': 'do not persist me',
+            }],
+            'outputs': [{
+                'address': 'bob',
+                'value_nrtc': 90 * UNIT,
+                'ignored_output_field': 'do not persist me',
+            }],
+            'fee_nrtc': 10 * UNIT,
+            'timestamp': 12345,
+            '_allow_minting': True,
+            'garbage': 'X' * 20_000,
+            'nested_spam': {'payload': ['x'] * 1000},
+        })
+
+        self.assertTrue(ok)
+
+        conn = self.db._conn()
+        try:
+            row = conn.execute(
+                "SELECT tx_data_json FROM utxo_mempool WHERE tx_id = ?",
+                ('normalized-intent',),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        stored = json.loads(row['tx_data_json'])
+        self.assertEqual(set(stored), {
+            'tx_id', 'tx_type', 'inputs', 'outputs', 'fee_nrtc',
+            'timestamp',
+        })
+        self.assertEqual(stored['inputs'], [{'box_id': box['box_id']}])
+        self.assertEqual(stored['outputs'], [{
+            'address': 'bob',
+            'value_nrtc': 90 * UNIT,
+            'tokens_json': '[]',
+            'registers_json': '{}',
+        }])
+        self.assertNotIn('_allow_minting', stored)
+        self.assertNotIn('garbage', stored)
+        self.assertNotIn('spending_proof', json.dumps(stored))
+        self.assertLess(len(row['tx_data_json']), 1000)
+
     def test_apply_transaction_rejects_oversized_output_text(self):
         """Direct block application must reject oversized persisted fields."""
         self._apply_coinbase('alice', 100 * UNIT)

--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -345,7 +345,7 @@ class TestUtxoEndpoints(unittest.TestCase):
         sender = 'RTC_test_aabbccdd'
         self._seed_coinbase(sender, 100 * UNIT)
 
-        for bad_nonce in (-1, 'abc', '12.5'):
+        for bad_nonce in (-1, 'abc', '12.5', 1 << 80, '9' * 1000):
             with self.subTest(nonce=bad_nonce):
                 r = self.client.post('/utxo/transfer', json={
                     'from_address': sender,
@@ -358,7 +358,10 @@ class TestUtxoEndpoints(unittest.TestCase):
                 self.assertEqual(r.status_code, 400)
                 data = r.get_json()
                 self.assertEqual(data['code'], 'INVALID_NONCE')
-                self.assertIn('greater than or equal to 0', data['error'])
+                self.assertTrue(
+                    'greater than or equal to 0' in data['error']
+                    or 'signed 64-bit integer range' in data['error']
+                )
 
     def test_transfer_rejects_stale_nonce_after_newer_nonce(self):
         sender = 'RTC_test_aabbccdd'
@@ -924,6 +927,58 @@ class TestUtxoDualWrite(unittest.TestCase):
             self._account_balance(sender),
             100 * utxo_endpoints.ACCOUNT_UNIT,
         )
+
+    def test_dual_write_shadow_insufficient_rolls_back_utxo_state(self):
+        """A shadow-balance failure must not leave a committed UTXO transfer.
+
+        Before the fix, the endpoint committed the UTXO spend, then skipped the
+        account shadow write when balances.amount_i64 was too low, returning
+        ok=True with /utxo/integrity permanently diverged.
+        """
+        sender = 'RTC_test_aabbccdd'
+        recipient = 'bob'
+        self.utxo_db.apply_transaction({
+            'tx_type': 'mining_reward',
+            'inputs': [],
+            'outputs': [{'address': sender, 'value_nrtc': 100 * UNIT}],
+            'timestamp': int(time.time()),
+            '_allow_minting': True,
+        }, block_height=1)
+
+        import sqlite3
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute(
+                "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+                (sender, 50 * utxo_endpoints.ACCOUNT_UNIT),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        r = self.client.post('/utxo/transfer', json={
+            'from_address': sender,
+            'to_address': recipient,
+            'amount_rtc': 90.0,
+            'fee_rtc': 1.0,
+            'public_key': 'aabbccdd' * 8,
+            'signature': 'sig' * 22,
+            'nonce': int(time.time() * 1000),
+        })
+        data = r.get_json()
+
+        self.assertEqual(r.status_code, 409, data)
+        self.assertEqual(data['code'], 'DUAL_WRITE_SHADOW_BALANCE')
+        self.assertEqual(self.utxo_db.get_balance(sender), 100 * UNIT)
+        self.assertEqual(self.utxo_db.get_balance(recipient), 0)
+        self.assertEqual(
+            self._account_balance(sender),
+            50 * utxo_endpoints.ACCOUNT_UNIT,
+        )
+        integrity = self.client.get('/utxo/integrity').get_json()
+        self.assertFalse(integrity['models_agree'])
+        self.assertEqual(integrity['total_unspent_nrtc'], 100 * UNIT)
+        self.assertEqual(integrity['account_total_nrtc'], 50 * UNIT)
 
 
 if __name__ == '__main__':

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -538,10 +538,12 @@ class UtxoDB:
             if not isinstance(registers, dict):
                 return None
 
-            record = dict(out)
-            record['tokens_json'] = tokens_json
-            record['registers_json'] = registers_json
-            normalized.append(record)
+            normalized.append({
+                'address': address,
+                'value_nrtc': val,
+                'tokens_json': tokens_json,
+                'registers_json': registers_json,
+            })
 
         return normalized
 
@@ -1220,7 +1222,25 @@ class UtxoDB:
             # With IGNORE, a duplicate tx_id silently skips the insert but
             # execution continues to claim inputs — creating orphan entries
             # that lock UTXOs with no corresponding mempool transaction.
-            tx_data_json = json.dumps(tx)
+            # Store only the normalized transaction intent.  Persisting the
+            # caller's raw dict lets arbitrary fields, internal flags, and
+            # giant spending proofs bloat tx_data_json and confuse block
+            # candidate consumers; apply_transaction only needs box IDs.
+            tx_for_mempool = {
+                'tx_id': tx_id,
+                'tx_type': tx_type,
+                'inputs': [{'box_id': inp['box_id']} for inp in inputs],
+                'outputs': outputs,
+                'fee_nrtc': fee,
+                'timestamp': timestamp,
+            }
+            if data_inputs:
+                tx_for_mempool['data_inputs'] = data_inputs
+            tx_data_json = json.dumps(
+                tx_for_mempool,
+                sort_keys=True,
+                separators=(',', ':'),
+            )
             if len(tx_data_json) > MAX_TX_DATA_JSON_BYTES:
                 if manage_tx:
                     conn.execute("ROLLBACK")

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -41,6 +41,7 @@ _BOXES_MAX_LIMIT = 500
 # Cursor values are bound to SQLite's signed 64-bit integer range; values past it
 # would raise OverflowError at parameter binding (a 500) instead of a clean 400.
 _INT64_MAX = (1 << 63) - 1
+_NONCE_MAX_DIGITS = len(str(_INT64_MAX))
 
 
 def _parse_rtc_amount(raw) -> Decimal:
@@ -233,12 +234,16 @@ def _parse_transfer_nonce(nonce_raw):
         nonce_text = nonce_raw.strip()
         if not nonce_text.isdigit():
             raise ValueError('nonce must be an integer greater than or equal to 0')
+        if len(nonce_text) > _NONCE_MAX_DIGITS:
+            raise ValueError('nonce exceeds signed 64-bit integer range')
         nonce_int = int(nonce_text)
     else:
         raise ValueError('nonce must be an integer greater than or equal to 0')
 
     if nonce_int < 0:
         raise ValueError('nonce must be an integer greater than or equal to 0')
+    if nonce_int > _INT64_MAX:
+        raise ValueError('nonce exceeds signed 64-bit integer range')
 
     return str(nonce_int), nonce_int
 
@@ -735,6 +740,48 @@ def utxo_transfer():
             conn.rollback()
             return jsonify({'error': 'UTXO transaction failed (race condition or validation)'}), 500
 
+        if _dual_write:
+            amount_i64 = amount_i64_for_dual_write
+            fee_i64 = effective_fee_i64_for_dual_write
+            debit_i64 = amount_i64 + fee_i64
+
+            # Keep the UTXO state transition and shadow account write atomic.
+            # If the shadow model cannot mirror the spend, roll back the UTXO
+            # application too; otherwise /utxo/integrity reports success-path
+            # divergence while the endpoint still returns ok=True.
+            shadow_row = conn.execute(
+                "SELECT amount_i64 FROM balances WHERE miner_id = ?",
+                (from_address,),
+            ).fetchone()
+            shadow_balance = shadow_row[0] if shadow_row else 0
+            if shadow_balance < debit_i64:
+                conn.rollback()
+                return jsonify({
+                    'error': 'Insufficient dual-write shadow balance',
+                    'code': 'DUAL_WRITE_SHADOW_BALANCE',
+                    'shadow_balance_i64': shadow_balance,
+                    'required_i64': debit_i64,
+                }), 409
+
+            conn.execute("INSERT OR IGNORE INTO balances (miner_id, amount_i64) VALUES (?, 0)",
+                         (to_address,))
+            conn.execute("UPDATE balances SET amount_i64 = amount_i64 - ? WHERE miner_id = ?",
+                         (debit_i64, from_address))
+            conn.execute("UPDATE balances SET amount_i64 = amount_i64 + ? WHERE miner_id = ?",
+                         (amount_i64, to_address))
+            now = int(time.time())
+            slot = _current_slot_fn()
+            conn.execute(
+                "INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason) VALUES (?,?,?,?,?)",
+                (now, slot, from_address, -debit_i64,
+                 f"utxo_transfer_out:{to_address[:20]}:fee={fee_i64}:{memo[:30]}")
+            )
+            conn.execute(
+                "INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason) VALUES (?,?,?,?,?)",
+                (now, slot, to_address, amount_i64,
+                 f"utxo_transfer_in:{from_address[:20]}:{memo[:30]}")
+            )
+
         conn.commit()
     except Exception:
         try:
@@ -744,55 +791,6 @@ def utxo_transfer():
         raise
     finally:
         conn.close()
-
-    # --- dual-write to account model ----------------------------------------
-
-    if _dual_write:
-        try:
-            conn = sqlite3.connect(_db_path)
-            c = conn.cursor()
-            amount_i64 = amount_i64_for_dual_write
-            fee_i64 = effective_fee_i64_for_dual_write
-            debit_i64 = amount_i64 + fee_i64
-
-            # Re-check sender shadow-balance before debit (security: prevent
-            # negative-balance minting when account-model diverges from UTXO
-            # due to non-UTXO writes, prior dual-write failures, or races).
-            c.execute("SELECT amount_i64 FROM balances WHERE miner_id = ?",
-                      (from_address,))
-            shadow_row = c.fetchone()
-            shadow_balance = shadow_row[0] if shadow_row else 0
-            if shadow_balance < debit_i64:
-                conn.close()
-                print(
-                    f"[UTXO] WARNING: dual-write skipped — insufficient "
-                    f"shadow balance for {from_address[:20]}... "
-                    f"(have {shadow_balance}, need {debit_i64})"
-                )
-            else:
-                c.execute("INSERT OR IGNORE INTO balances (miner_id, amount_i64) VALUES (?, 0)",
-                          (to_address,))
-                c.execute("UPDATE balances SET amount_i64 = amount_i64 - ? WHERE miner_id = ?",
-                          (debit_i64, from_address))
-                c.execute("UPDATE balances SET amount_i64 = amount_i64 + ? WHERE miner_id = ?",
-                          (amount_i64, to_address))
-                now = int(time.time())
-                slot = _current_slot_fn()
-                c.execute(
-                    "INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason) VALUES (?,?,?,?,?)",
-                    (now, slot, from_address, -debit_i64,
-                     f"utxo_transfer_out:{to_address[:20]}:fee={fee_i64}:{memo[:30]}")
-                )
-                c.execute(
-                    "INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason) VALUES (?,?,?,?,?)",
-                    (now, slot, to_address, amount_i64,
-                     f"utxo_transfer_in:{from_address[:20]}:{memo[:30]}")
-                )
-            conn.commit()
-            conn.close()
-        except Exception as e:
-            # Log but don't fail — UTXO is primary, account is shadow
-            print(f"[UTXO] WARNING: dual-write to account model failed: {e}")
 
     # --- response -----------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- keep UTXO dual-write shadow account updates inside the same rollback path as nonce reservation and UTXO application
- reject transfer nonces above SQLite signed int64 bounds
- persist only normalized mempool transaction intent, stripping caller-controlled/internal fields and large proofs

## Issue
Addresses UTXO Red Team bounty #2819.

## Validation
- PYTHONPATH=/Users/qiann/Documents/Codex/2026-06-16/github/work/pydeps:node PYTHONPYCACHEPREFIX=/Users/qiann/Documents/Codex/2026-06-16/github/work/pycache python3 node/test_utxo_endpoints.py
- PYTHONPYCACHEPREFIX=/Users/qiann/Documents/Codex/2026-06-16/github/work/pycache python3 node/test_utxo_db.py
- PYTHONPYCACHEPREFIX=/Users/qiann/Documents/Codex/2026-06-16/github/work/pycache python3 -m py_compile node/utxo_db.py node/test_utxo_db.py node/utxo_endpoints.py node/test_utxo_endpoints.py