### PR TITLE
Fix macOS serial binding fallback detection

### DIFF
--- a/miners/macos/rustchain_mac_miner_v2.5.py
+++ b/miners/macos/rustchain_mac_miner_v2.5.py
@@ -33,14 +33,15 @@ def warning(msg): return msg
 def success(msg): return msg
 def error(msg): return msg
 
-# Attempt to import requests; provide instructions if missing
+# Attempt to import requests; provide instructions if missing. Keep import
+# side-effect free so tests can load helper functions on minimal systems.
 try:
     import requests
 except ImportError:
-    print("[ERROR] 'requests' module not found.")
-    print("  Install with: pip3 install requests --user")
-    print("  Or: python3 -m pip install requests --user")
-    sys.exit(1)
+    requests = None
+    REQUESTS_IMPORT_ERROR = "'requests' module not found. Install with: pip3 install requests --user"
+else:
+    REQUESTS_IMPORT_ERROR = None
 
 try:
     from nacl.signing import SigningKey
@@ -179,6 +180,8 @@ class NodeTransport:
     """
 
     def __init__(self, node_url, proxy_url):
+        if requests is None:
+            raise RuntimeError(REQUESTS_IMPORT_ERROR)
         self.node_url = node_url.rstrip("/")
         self.proxy_url = proxy_url.rstrip("/") if proxy_url else None
         self.use_proxy = False
@@ -247,47 +250,89 @@ class NodeTransport:
 
 # ── Hardware Detection ──────────────────────────────────────────────
 
-def get_mac_serial():
-    """Get hardware serial number for macOS systems."""
-    try:
-        result = subprocess.run(
-            ['system_profiler', 'SPHardwareDataType'],
-            capture_output=True, text=True, timeout=10
-        )
-        for line in result.stdout.split('\n'):
-            if 'Serial Number' in line:
-                return line.split(':')[1].strip()
-    except Exception:
-        pass
+def _clean_hardware_identifier(value):
+    value = str(value or "").strip()
+    invalid = {
+        "",
+        "none",
+        "unknown",
+        "not available",
+        "not specified",
+        "to be filled by o.e.m.",
+        "system serial number",
+    }
+    if value.lower() in invalid:
+        return None
+    return value
 
-    try:
-        result = subprocess.run(
-            ['ioreg', '-l'],
-            capture_output=True, text=True, timeout=10
-        )
-        for line in result.stdout.split('\n'):
-            if 'IOPlatformSerialNumber' in line:
-                return line.split('"')[-2]
-    except Exception:
-        pass
 
-    try:
-        result = subprocess.run(
-            ['system_profiler', 'SPHardwareDataType'],
-            capture_output=True, text=True, timeout=10
-        )
-        for line in result.stdout.split('\n'):
-            if 'Hardware UUID' in line:
-                return line.split(':')[1].strip()[:16]
-    except Exception:
-        pass
-
+def _extract_system_profiler_value(output, field):
+    prefix = "{}:".format(field).lower()
+    for line in str(output or "").splitlines():
+        stripped = line.strip()
+        if stripped.lower().startswith(prefix):
+            return _clean_hardware_identifier(stripped.split(":", 1)[1])
     return None
+
+
+def _extract_ioreg_serial(output):
+    for line in str(output or "").splitlines():
+        if 'IOPlatformSerialNumber' not in line:
+            continue
+        match = re.search(r'"IOPlatformSerialNumber"\s*=\s*"([^"]+)"', line)
+        if match:
+            return _clean_hardware_identifier(match.group(1))
+    return None
+
+
+def get_mac_identity():
+    """Return macOS hardware identity with serial and UUID kept distinct."""
+    serial = None
+    hardware_uuid = None
+
+    try:
+        result = subprocess.run(
+            ['system_profiler', 'SPHardwareDataType'],
+            capture_output=True, text=True, timeout=10
+        )
+        serial = _extract_system_profiler_value(result.stdout, "Serial Number")
+        hardware_uuid = _extract_system_profiler_value(result.stdout, "Hardware UUID")
+    except Exception:
+        pass
+
+    if not serial:
+        for args in (
+            ['ioreg', '-d2', '-c', 'IOPlatformExpertDevice'],
+            ['ioreg', '-l'],
+        ):
+            try:
+                result = subprocess.run(
+                    args,
+                    capture_output=True, text=True, timeout=10
+                )
+                serial = _extract_ioreg_serial(result.stdout)
+                if serial:
+                    break
+            except Exception:
+                pass
+
+    return {
+        "serial": serial,
+        "hardware_uuid": hardware_uuid,
+        "serial_present": bool(serial),
+        "serial_source": "serial_number" if serial else ("hardware_uuid_fallback" if hardware_uuid else "missing"),
+    }
+
+
+def get_mac_serial():
+    """Get true Mac hardware serial number, not a UUID fallback."""
+    return get_mac_identity()["serial"]
 
 
 def detect_hardware():
     """Auto-detect Mac hardware architecture."""
     machine = platform.machine().lower()
+    identity = get_mac_identity()
 
     hw_info = {
         "family": "unknown",
@@ -299,7 +344,10 @@ def detect_hardware():
         "hostname": platform.node(),
         "mac": "00:00:00:00:00:00",
         "macs": [],
-        "serial": get_mac_serial()
+        "serial": identity["serial"],
+        "hardware_uuid": identity["hardware_uuid"],
+        "serial_present": identity["serial_present"],
+        "serial_source": identity["serial_source"],
     }
 
     # Get MAC addresses
@@ -470,6 +518,27 @@ def add_binding_entropy_aliases(fingerprint_data):
     return fingerprint_data
 
 
+def attach_serial_binding_status(fingerprint_data, hw_info):
+    """Record whether Serial Binding v2.0 has a true hardware serial."""
+    if not isinstance(fingerprint_data, dict):
+        fingerprint_data = {}
+    checks = fingerprint_data.setdefault("checks", {})
+    serial = _clean_hardware_identifier(hw_info.get("serial"))
+    hardware_uuid = _clean_hardware_identifier(hw_info.get("hardware_uuid"))
+    passed = bool(serial)
+    checks["serial_binding"] = {
+        "passed": passed,
+        "data": {
+            "serial_present": passed,
+            "serial_source": hw_info.get("serial_source") or ("serial_number" if passed else "missing"),
+            "hardware_uuid_fallback_present": bool(hardware_uuid and not serial),
+        },
+    }
+    fingerprint_data["serial_binding_passed"] = passed
+    fingerprint_data["all_passed"] = bool(fingerprint_data.get("all_passed")) and passed
+    return fingerprint_data
+
+
 # ── Miner Class ─────────────────────────────────────────────────────
 
 class MacMiner:
@@ -482,10 +551,11 @@ class MacMiner:
         if miner_id:
             self.miner_id = miner_id
         else:
+            stable_id = self.hw_info.get('serial') or self.hw_info.get('hardware_uuid') or 'unknown'
             hw_hash = hashlib.sha256(
                 "{}-{}".format(
                     self.hw_info['hostname'],
-                    self.hw_info['serial'] or 'unknown'
+                    stable_id
                 ).encode()
             ).hexdigest()[:8]
             arch = self.hw_info['arch'].lower().replace(' ', '_')
@@ -555,14 +625,18 @@ class MacMiner:
         print(info("\n[FINGERPRINT] Running hardware fingerprint checks..."))
         try:
             passed, results = validate_all_checks()
-            self.fingerprint_passed = passed
             self.fingerprint_data = add_binding_entropy_aliases(
                 {"checks": results, "all_passed": passed}
             )
-            if passed:
+            self.fingerprint_data = attach_serial_binding_status(
+                self.fingerprint_data,
+                self.hw_info,
+            )
+            self.fingerprint_passed = bool(self.fingerprint_data.get("all_passed"))
+            if self.fingerprint_passed:
                 print(success("[FINGERPRINT] All checks PASSED - eligible for full rewards"))
             else:
-                failed = [k for k, v in results.items() if not v.get("passed")]
+                failed = [k for k, v in self.fingerprint_data.get("checks", {}).items() if not v.get("passed")]
                 print(warning("[FINGERPRINT] FAILED checks: {}".format(failed)))
                 print(warning("[FINGERPRINT] WARNING: May receive reduced/zero rewards"))
         except Exception as e:
@@ -581,6 +655,8 @@ class MacMiner:
             else "DIRECT ({})".format(self.transport.node_url)
         ))
         print("Serial:      {}".format(self.hw_info.get('serial', 'N/A')))
+        if not self.hw_info.get("serial_present"):
+            print("Serial Bind: missing real serial ({})".format(self.hw_info.get("serial_source", "missing")))
         print("-" * 70)
         print("Hardware:    {} / {}".format(self.hw_info['family'], self.hw_info['arch']))
         print("Model:       {}".format(self.hw_info['model']))
@@ -852,6 +928,10 @@ class MacMiner:
 
 if __name__ == "__main__":
     import argparse
+
+    if requests is None:
+        print("[ERROR] {}".format(REQUESTS_IMPORT_ERROR))
+        sys.exit(1)
 
     parser = argparse.ArgumentParser(description="RustChain Mac Miner v{}".format(MINER_VERSION))
     parser.add_argument("--version", "-v", action="version",

--- a/miners/macos/test_rustchain_mac_miner_signing.py
+++ b/miners/macos/test_rustchain_mac_miner_signing.py
@@ -2,6 +2,7 @@ import base64
 import importlib.util
 import json
 import pathlib
+import subprocess
 import unittest
 from tempfile import TemporaryDirectory
 
@@ -161,6 +162,86 @@ class ExtractPkcs8Tests(unittest.TestCase):
         seed = b"\x22" * 32
         der = bytes.fromhex("302e020100300506032b657004220420") + seed
         self.assertEqual(module._extract_pkcs8_ed25519_seed(der), seed)
+
+
+class MacIdentityTests(unittest.TestCase):
+    def test_import_does_not_exit_without_requests(self):
+        module = load_miner_module()
+        self.assertTrue(hasattr(module, "_extract_pkcs8_ed25519_seed"))
+
+    def test_hardware_uuid_is_not_reported_as_serial(self):
+        module = load_miner_module()
+        calls = []
+
+        def fake_run(args, **kwargs):
+            calls.append(args)
+            if args[:2] == ["system_profiler", "SPHardwareDataType"]:
+                return subprocess.CompletedProcess(
+                    args,
+                    0,
+                    stdout="\nHardware:\n    Hardware UUID: 12345678-ABCD-EF00-1111-222222222222\n",
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+        original_run = module.subprocess.run
+        module.subprocess.run = fake_run
+        try:
+            identity = module.get_mac_identity()
+        finally:
+            module.subprocess.run = original_run
+
+        self.assertIsNone(identity["serial"])
+        self.assertEqual(identity["hardware_uuid"], "12345678-ABCD-EF00-1111-222222222222")
+        self.assertFalse(identity["serial_present"])
+        self.assertEqual(identity["serial_source"], "hardware_uuid_fallback")
+
+    def test_ioreg_serial_is_accepted_when_system_profiler_serial_missing(self):
+        module = load_miner_module()
+
+        def fake_run(args, **kwargs):
+            if args[:2] == ["system_profiler", "SPHardwareDataType"]:
+                return subprocess.CompletedProcess(
+                    args,
+                    0,
+                    stdout="\nHardware:\n    Hardware UUID: 12345678-ABCD-EF00-1111-222222222222\n",
+                    stderr="",
+                )
+            if args and args[0] == "ioreg":
+                return subprocess.CompletedProcess(
+                    args,
+                    0,
+                    stdout='    | |   "IOPlatformSerialNumber" = "C02TEST12345"\n',
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+        original_run = module.subprocess.run
+        module.subprocess.run = fake_run
+        try:
+            identity = module.get_mac_identity()
+        finally:
+            module.subprocess.run = original_run
+
+        self.assertEqual(identity["serial"], "C02TEST12345")
+        self.assertTrue(identity["serial_present"])
+        self.assertEqual(identity["serial_source"], "serial_number")
+
+    def test_serial_binding_status_fails_without_real_serial(self):
+        module = load_miner_module()
+        fp = {"checks": {"clock_drift": {"passed": True}}, "all_passed": True}
+        hw = {
+            "serial": None,
+            "hardware_uuid": "12345678-ABCD-EF00-1111-222222222222",
+            "serial_source": "hardware_uuid_fallback",
+        }
+
+        out = module.attach_serial_binding_status(fp, hw)
+
+        self.assertFalse(out["all_passed"])
+        self.assertFalse(out["serial_binding_passed"])
+        self.assertFalse(out["checks"]["serial_binding"]["passed"])
+        self.assertTrue(out["checks"]["serial_binding"]["data"]["hardware_uuid_fallback_present"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- distinguish real IOPlatformSerialNumber values from Hardware UUID fallback values on macOS
- add targeted ioreg fallback parsing for IOPlatformExpertDevice
- expose serial binding status so fingerprint checks fail closed when no true serial is available
- keep the miner module importable when optional requests dependency is unavailable

## Issue
Addresses macOS serial binding fallback handling discussed in #7478.

## Validation
- PYTHONPYCACHEPREFIX=/Users/qiann/Documents/Codex/2026-06-16/github/work/pycache python3 -m unittest miners.macos.test_rustchain_mac_miner_signing -v
- PYTHONPYCACHEPREFIX=/Users/qiann/Documents/Codex/2026-06-16/github/work/pycache python3 -m py_compile miners/macos/rustchain_mac_miner_v2.5.py miners/macos/test_rustchain_mac_miner_signing.py