### PR TITLE
harden CSV export against spreadsheet formula injection

### DIFF
--- a/rustchain_export.py
+++ b/rustchain_export.py
@@ -297,16 +297,34 @@ DEFAULT_HEADERS = {
 }
 
 
+def _sanitize_csv_value(value: Any) -> Any:
+    """Neutralize spreadsheet formula injection in CSV cell values.
+
+    Only string cells are affected. When the first non-whitespace character is a
+    formula trigger (=, +, -, @) or the value leads with a tab or carriage
+    return, it is prefixed with a single quote so spreadsheet software treats it
+    as text. Non-string values and JSON/JSONL output are left untouched.
+    """
+    if not isinstance(value, str):
+        return value
+    if value[:1] in ("\t", "\r") or value.lstrip()[:1] in ("=", "+", "-", "@"):
+        return "'" + value
+    return value
+
+
 def write_csv(path: Path, rows: list[dict[str, Any]], default_headers: list[str] | None = None) -> None:
     if rows:
         fieldnames = sorted({key for row in rows for key in row.keys()})
     else:
         fieldnames = sorted(default_headers) if default_headers else []
+    safe_rows = [
+        {key: _sanitize_csv_value(value) for key, value in row.items()} for row in rows
+    ]
     with path.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(handle, fieldnames=fieldnames)
         if fieldnames:
             writer.writeheader()
-        writer.writerows(rows)
+        writer.writerows(safe_rows)
 
 
 def write_json(path: Path, rows: list[dict[str, Any]]) -> None:

--- a/tests/test_rustchain_export.py
+++ b/tests/test_rustchain_export.py
@@ -156,6 +156,43 @@ class RustChainExportTests(unittest.TestCase):
         self.assertEqual(exporter.balance_amount_rtc({"balance_urtc": 999_999}), 0.999999)
         self.assertEqual(exporter.balance_amount_rtc({"balance_rtc": 0.5}), 0.5)
 
+    def test_csv_export_neutralizes_formula_injection(self):
+        rows = [
+            {
+                "miner_id": "=cmd|'/c calc'!A0",
+                "device_arch": "+SUM(A1:A2)",
+                "hardware_type": "-2+3",
+                "reason": "@SUM(1)",
+                "tabbed": "\tlead",
+                "safe": "PowerPC G4",
+                "amount": 1.25,
+                "none_field": None,
+                "empty_field": "",
+                "already_quoted": "'safe",
+            }
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            csv_path = Path(tmp) / "rows.csv"
+            exporter.write_csv(csv_path, rows)
+            with csv_path.open(newline="", encoding="utf-8") as handle:
+                out = list(csv.DictReader(handle))[0]
+            self.assertEqual(out["miner_id"], "'=cmd|'/c calc'!A0")
+            self.assertEqual(out["device_arch"], "'+SUM(A1:A2)")
+            self.assertEqual(out["hardware_type"], "'-2+3")
+            self.assertEqual(out["reason"], "'@SUM(1)")
+            self.assertEqual(out["tabbed"], "'\tlead")
+            self.assertEqual(out["safe"], "PowerPC G4")
+            self.assertEqual(out["amount"], "1.25")
+            self.assertEqual(out["none_field"], "")
+            self.assertEqual(out["empty_field"], "")
+            self.assertEqual(out["already_quoted"], "'safe")
+
+            json_path = Path(tmp) / "rows.json"
+            exporter.write_json(json_path, rows)
+            loaded = json.loads(json_path.read_text(encoding="utf-8"))
+            self.assertEqual(loaded[0]["miner_id"], "=cmd|'/c calc'!A0")
+            self.assertEqual(loaded[0]["device_arch"], "+SUM(A1:A2)")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`write_csv()` in `rustchain_export.py` wrote raw values straight to `csv.DictWriter`, so a cell whose value begins with `=`, `+`, `-`, `@`, or a leading tab/CR could be interpreted as a formula when the exported CSV is opened in Excel or LibreOffice. Miner-self-reported fields such as `device_arch` and `hardware_type` flow into the export, so the trigger value can be attacker-influenced.

## Fix

- Add `_sanitize_csv_value()` that prefixes a single quote to formula-leading string cells, applied per cell in `write_csv()`.
- Non-string values are untouched. JSON and JSONL output keep raw values (that is the path for programmatic consumers that need exact bytes).
- Regression test covering each trigger, leading tab, the safe/non-trigger case, None, empty string, an already-quoted value, and JSON raw-value preservation.

## Testing

```
python -m pytest tests/test_rustchain_export.py -q
5 passed
```

## Scope note

This is the hardening discussed in #7224, applied as routine maintainer hygiene. Per the triage there, the export utility is not a deployed production surface, so the issue itself stays out of paid-bounty scope; this change is just good housekeeping on the export path.