### PR TITLE
fix(utxo): reject JSON-bomb output metadata (DoS via deep nesting)

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -18,7 +18,7 @@ from utxo_db import (
     UtxoDB, coin_select, compute_box_id, address_to_proposition,
     proposition_to_address, UNIT, DUST_THRESHOLD, MAX_COINBASE_OUTPUT_NRTC,
     MAX_OUTPUTS, MAX_DATA_INPUTS, MAX_SQLITE_INT64, MAX_UTXO_ADDRESS_BYTES,
-    MAX_UTXO_METADATA_BYTES, MAX_MEMPOOL_TX_ID_BYTES,
+    MAX_UTXO_METADATA_BYTES, MAX_UTXO_JSON_DEPTH, MAX_MEMPOOL_TX_ID_BYTES,
 )
 
 
@@ -1811,6 +1811,63 @@ class TestUtxoDB(unittest.TestCase):
                 self.assertFalse(ok)
                 self.assertEqual(db.mempool_get_block_candidates(), [])
                 self.assertFalse(db.mempool_check_double_spend(box['box_id']))
+
+    def test_mempool_rejects_deeply_nested_json_without_locking_input(self):
+        """Reject JSON-bomb output metadata before storing tx_data_json.
+
+        Each payload fits comfortably under MAX_UTXO_METADATA_BYTES yet nests
+        far past MAX_UTXO_JSON_DEPTH, so it would survive the byte check but
+        crash recursive downstream consumers (copy.deepcopy, pure-Python json
+        scanner, etc.) with RecursionError — a remote DoS on block validation.
+        """
+        depth = MAX_UTXO_JSON_DEPTH + 50
+        list_bomb = '[' * depth + ']' * depth          # valid, deeply nested list
+        dict_bomb = '{"a":' * depth + '1' + '}' * depth  # valid, deeply nested object
+        self.assertLessEqual(len(list_bomb), MAX_UTXO_METADATA_BYTES)
+        self.assertLessEqual(len(dict_bomb), MAX_UTXO_METADATA_BYTES)
+
+        cases = [
+            {'address': 'bob', 'value_nrtc': 100 * UNIT, 'tokens_json': list_bomb},
+            {'address': 'bob', 'value_nrtc': 100 * UNIT, 'registers_json': dict_bomb},
+            # bracket inside a string literal must NOT count toward depth:
+            {'address': 'bob', 'value_nrtc': 100 * UNIT,
+             'tokens_json': json.dumps(['[' * depth])},
+        ]
+
+        for idx, output in enumerate(cases):
+            with self.subTest(output=output):
+                db = UtxoDB(self.tmp.name)
+                self.assertTrue(db.apply_transaction({
+                    'tx_type': 'mining_reward',
+                    'inputs': [],
+                    'outputs': [
+                        {'address': f'alice_deep_{idx}',
+                         'value_nrtc': 100 * UNIT}
+                    ],
+                    'fee_nrtc': 0,
+                    'timestamp': int(time.time()) + 100 + idx,
+                    '_allow_minting': True,
+                }, block_height=idx + 1))
+                box = db.get_unspent_for_address(f'alice_deep_{idx}')[0]
+
+                ok = db.mempool_add({
+                    'tx_id': f'jsonbomb{idx}',
+                    'tx_type': 'transfer',
+                    'inputs': [{'box_id': box['box_id']}],
+                    'outputs': [output],
+                    'fee_nrtc': 0,
+                })
+
+                # Case 2 (brackets only inside a string literal) is a
+                # legitimately shallow payload and MUST be accepted; the two
+                # bombs must be rejected without locking the input.
+                if idx == 2:
+                    self.assertTrue(ok)
+                else:
+                    self.assertFalse(ok)
+                    self.assertEqual(db.mempool_get_block_candidates(), [])
+                    self.assertFalse(
+                        db.mempool_check_double_spend(box['box_id']))
 
     def test_apply_transaction_rejects_oversized_output_text(self):
         """Direct block application must reject oversized persisted fields."""

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -47,6 +47,14 @@ MAX_OUTPUTS = 100
 MAX_DATA_INPUTS = 100
 MAX_UTXO_ADDRESS_BYTES = 256
 MAX_UTXO_METADATA_BYTES = 8_192
+# Cap JSON nesting depth in output metadata.  The byte cap above still admits a
+# "JSON bomb" — e.g. `[`*4096 + `]`*4096 is exactly 8 KiB yet parses to a list
+# nested 4096 deep.  json.loads tolerates that, but any downstream recursive
+# consumer (copy.deepcopy, the pure-Python json scanner on builds without the C
+# extension, equality, re-serialization) blows the interpreter recursion limit
+# (default 1000) with RecursionError — a cheap remote DoS on block validation.
+# Legitimate token lists / register maps are shallow (depth 1-3); 32 is roomy.
+MAX_UTXO_JSON_DEPTH = 32
 MAX_MEMPOOL_TX_ID_BYTES = 128
 MAX_TX_AGE_SECONDS = 3_600  # 1 hour mempool expiry
 MAX_TX_DATA_JSON_BYTES = 262_144  # 256KB max serialized tx size
@@ -77,6 +85,40 @@ def _utf8_len(value: str) -> Optional[int]:
         return len(value.encode('utf-8'))
     except UnicodeEncodeError:
         return None
+
+
+def _json_max_depth(text: str) -> int:
+    """Return the maximum `[`/`{` nesting depth of a JSON string.
+
+    Scans the raw text in a single O(n) pass *without* building the object, so
+    it never recurses and cannot itself be the DoS it guards against.  Brackets
+    inside string literals are ignored (escapes honoured) so a token value like
+    "[[[" cannot inflate the count.  Used to reject deeply nested payloads
+    before json.loads / downstream recursive processing can hit RecursionError.
+    """
+    depth = 0
+    max_depth = 0
+    in_string = False
+    escaped = False
+    for ch in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == '\\':
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == '[' or ch == '{':
+            depth += 1
+            if depth > max_depth:
+                max_depth = depth
+        elif ch == ']' or ch == '}':
+            if depth > 0:
+                depth -= 1
+    return max_depth
 
 
 # ---------------------------------------------------------------------------
@@ -527,6 +569,13 @@ class UtxoDB:
             if tokens_len is None or tokens_len > MAX_UTXO_METADATA_BYTES:
                 return None
             if registers_len is None or registers_len > MAX_UTXO_METADATA_BYTES:
+                return None
+            # Reject JSON bombs (deeply nested arrays/objects) before parsing:
+            # they fit under the byte cap but crash recursive downstream
+            # consumers with RecursionError (DoS).
+            if _json_max_depth(tokens_json) > MAX_UTXO_JSON_DEPTH:
+                return None
+            if _json_max_depth(registers_json) > MAX_UTXO_JSON_DEPTH:
                 return None
             try:
                 tokens = json.loads(tokens_json)


### PR DESCRIPTION
## Problem

`tokens_json` / `registers_json` on transaction outputs are bounded by a byte cap (`MAX_UTXO_METADATA_BYTES = 8192`) but **not** by nesting depth. That leaves a JSON-bomb DoS open: a payload such as `'[' * 4096 + ']' * 4096` is **exactly 8 KiB** (passes the byte check) yet parses to a list nested 4096 levels deep.

`json.loads` (C scanner) tolerates that, but any **recursive downstream consumer** of the resulting object blows the interpreter recursion limit (default 1000) with `RecursionError`:

```python
s = '[' * 4096 + ']' * 4096          # 8192 bytes — under the cap
obj = json.loads(s)                  # OK on CPython C scanner
copy.deepcopy(obj)                   # RecursionError  ← DoS
```

The same crash hits the **pure-Python json scanner** (used on builds without the C extension), re-serialization, equality walks, etc. An attacker can park such a box and crash/stall nodes during block validation — the vector reported in Scottcjn/rustchain-bounties#14440.

## Fix

- Add `MAX_UTXO_JSON_DEPTH = 32`. Legitimate token lists / register maps are shallow (depth 1–3), so 32 is roomy headroom while still well under the recursion limit.
- Add `_json_max_depth(text)` — a single-pass **O(n)** scanner that measures bracket/brace nesting *without building the object* (so the guard itself can never recurse), and ignores brackets inside string literals (escapes honoured) so a token value like `"[[["` can't inflate the count.
- `_normalize_outputs` now rejects over-deep `tokens_json`/`registers_json` **before** `json.loads` runs — every output path (`apply_transaction`, `mempool_add`) funnels through this one validator, so the whole surface is covered.

## Tests

`test_mempool_rejects_deeply_nested_json_without_locking_input` mirrors the existing oversized-text test: a deep **list** bomb and a deep **object** bomb are rejected without locking the input, while a payload whose brackets live only inside a string literal is correctly accepted (shallow). Full suite: **101 passed** (`python3 -m pytest node/test_utxo_db.py -q`).

Closes the DoS described in #14440.
