### PR TITLE
fix(static): render dynamic HTML safely

### DIFF
--- a/static/bcos/badge-generator.html
+++ b/static/bcos/badge-generator.html
@@ -811,6 +811,13 @@
 </footer>
 
 <script>
+function escapeHtml(value) {
+  const div = document.createElement('div');
+  div.textContent = value == null ? '' : String(value);
+  return div.innerHTML;
+}
+
+
 /* ─── State ────────────────────────────────────────────────────── */
 const NODE = window.location.origin && (window.location.origin.includes('127.0.0.1') || window.location.origin.includes('localhost'))
     ? window.location.origin
@@ -872,7 +879,7 @@ function renderDirectory() {
         <div class="dir-card" data-cert-id="${escAttr(c.cert_id)}" title="${escAttr(c.cert_id)}">
             <div class="dir-card-repo">${escHtml(c.repo)}</div>
             <div class="dir-card-meta">
-                <span class="tier-badge ${tierClass(c.tier)}">${escHtml(normalizeTier(c.tier))}</span>
+                <span class="tier-badge ${escapeHtml(tierClass(c.tier))}">${escHtml(normalizeTier(c.tier))}</span>
                 <span>${escHtml(formatTrustScore(c.trust_score))}/100</span>
             </div>
         </div>
@@ -944,7 +951,7 @@ function renderAC(listId, items, renderFn, onSelect) {
     const list = document.getElementById(listId);
     if (!items.length) { closeAC(listId); return; }
     list.innerHTML = items.map((item, i) => `
-        <div class="autocomplete-item" data-i="${i}">${renderFn(item)}</div>
+        <div class="autocomplete-item" data-i="${escapeHtml(i)}">${escapeHtml(renderFn(item))}</div>
     `).join('');
     list.querySelectorAll('.autocomplete-item').forEach((el, i) => {
         el.addEventListener('mousedown', e => { e.preventDefault(); onSelect(items[i]); });
@@ -1095,7 +1102,7 @@ function renderOutput(cert, certId) {
         <div class="cert-field"><span class="cert-key">tier</span><span class="cert-val amber">${escHtml(tier)}</span></div>
         <div class="cert-field"><span class="cert-key">trust_score</span><span class="cert-val">${escHtml(scoreLabel)}/100</span></div>
         <div class="cert-field"><span class="cert-key">reviewer</span><span class="cert-val">${escHtml(rev)}</span></div>
-        <div class="cert-field"><span class="cert-key">anchored</span><span class="cert-val">${ts}</span></div>
+        <div class="cert-field"><span class="cert-key">anchored</span><span class="cert-val">${escapeHtml(ts)}</span></div>
         <div class="cert-field"><span class="cert-key">verify_url</span><span class="cert-val"><a href="${escAttr(verifyUrl)}" target="_blank" style="color:var(--green);text-decoration:none;">${escHtml(verifyUrl)}</a></span></div>
     `;
 


### PR DESCRIPTION
This is a fresh selector-owned PR from the natural selector scan.

Problem: current-main browser code in `static/bcos/badge-generator.html` writes API-derived values through dynamic `innerHTML` (dynamic_innerHTML@line 871; dynamic_innerHTML@line 946). Bridge, explorer, and wallet UIs should avoid DOM injection when rendering remote data. Fix shape: escape dynamic fields or render with textContent/createElement while preserving the existing UI. Validation expected: focused pytest, py_compile, and git diff --check. Boundaries: no wallet, payout, reward, admin secret, production wallet, or manual crediting changes.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- lgbm_rank: `2`
- native_rank: `26`
- dispatch_arm: `trained_lgbm_selector`

Scoped files:
- `static/bcos/badge-generator.html`

Validation:
- `dynamic_innerhtml static audit for static/bcos/badge-generator.html -> passed`
- `GitHub Contents API path filter -> source file only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No unrelated maintenance, baseline, or consensus-node edits.

@Scottcjn this is a fresh, scoped selector PR with natural attribution preserved as `both_selectors` when both arms found it.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
