### PR TITLE
fix(static): render dynamic HTML safely

### DIFF
--- a/static/bridge/index.html
+++ b/static/bridge/index.html
@@ -202,11 +202,11 @@
                 const targetChain = safeClassToken(tx.target_chain, ['solana', 'base'], 'solana');
                 const state = safeClassToken(tx.state, ['complete', 'pending', 'confirmed', 'requested'], 'pending');
                 row.innerHTML = `
-                    <td style="font-family:monospace; color:#888">${lockId}...</td>
+                    <td style="font-family:monospace; color:#888">${escapeHtml(lockId)}...</td>
                     <td>${escapeHtml(tx.sender_wallet)}</td>
                     <td style="color:white; font-weight:bold">${escapeHtml(safeNumber(tx.amount_rtc))}</td>
                     <td><span style="color:var(--solana)">${escapeHtml(targetChain.toUpperCase())}</span></td>
-                    <td><span class="state-tag ${state}">${escapeHtml(state.toUpperCase())}</span></td>
+                    <td><span class="state-tag ${escapeHtml(state)}">${escapeHtml(state.toUpperCase())}</span></td>
                 `;
                 body.appendChild(row);
             });


### PR DESCRIPTION
This is a fresh selector-owned PR from the natural selector scan.

Problem: current-main browser code in `static/bridge/index.html` writes API-derived values through dynamic `innerHTML` (dynamic_innerHTML@line 204). Bridge, explorer, and wallet UIs should avoid DOM injection when rendering remote data. Fix shape: escape dynamic fields or render with textContent/createElement while preserving the existing UI. Validation expected: focused pytest, py_compile, and git diff --check. Boundaries: no wallet, payout, reward, admin secret, production wallet, or manual crediting changes.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- lgbm_rank: `8`
- native_rank: `16`
- dispatch_arm: `trained_lgbm_selector`

Scoped files:
- `static/bridge/index.html`

Validation:
- `dynamic_innerhtml static audit for static/bridge/index.html -> passed`
- `GitHub Contents API path filter -> source file only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No unrelated maintenance, baseline, or consensus-node edits.

@Scottcjn this is a fresh, scoped selector PR with natural attribution preserved as `both_selectors` when both arms found it.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
