### PR TITLE
fix(explorer): render dynamic HTML safely

### DIFF
--- a/explorer/miner-dashboard.html
+++ b/explorer/miner-dashboard.html
@@ -384,17 +384,17 @@
             if (Array.isArray(rewards) && rewards.length > 0) {
                 rewardsBody.innerHTML = rewards.slice(0, 20).map(r => `
                     <tr>
-                        <td>${safeText(r.epoch ?? r.block)}</td>
-                        <td style="color:var(--green);">+${safeText(r.amount ?? r.reward ?? r.value, '?')} RTC</td>
-                        <td><span class="badge badge-green">${safeText(r.type || 'mining')}</span></td>
-                        <td>${safeText(timeAgo(r.timestamp || r.time || r.created_at))}</td>
+                        <td>${escapeHtml(safeText(r.epoch ?? r.block))}</td>
+                        <td style="color:var(--green);">+${escapeHtml(safeText(r.amount ?? r.reward ?? r.value, '?'))} RTC</td>
+                        <td><span class="badge badge-green">${escapeHtml(safeText(r.type || 'mining'))}</span></td>
+                        <td>${escapeHtml(safeText(timeAgo(r.timestamp || r.time || r.created_at)))}</td>
                     </tr>
                 `).join('');
             } else {
                 const epochSummary = epoch.number ?? epoch.id ?? JSON.stringify(epoch).substring(0, 50);
                 rewardsBody.innerHTML = `
                     <tr><td colspan="4" style="text-align:center;color:var(--text-dim);">
-                        No reward data yet. Current epoch: ${safeText(epochSummary)}
+                        No reward data yet. Current epoch: ${escapeHtml(safeText(epochSummary))}
                     </td></tr>`;
             }
         } else {
@@ -407,8 +407,8 @@
             activityBody.innerHTML = `
                 <tr>
                     <td><span class="badge badge-green">Chain Tip</span></td>
-                    <td>Block ${safeText(activityData.height ?? activityData.block_height)}</td>
-                    <td>${safeText(timeAgo(activityData.timestamp))}</td>
+                    <td>Block ${escapeHtml(safeText(activityData.height ?? activityData.block_height))}</td>
+                    <td>${escapeHtml(safeText(timeAgo(activityData.timestamp)))}</td>
                 </tr>`;
         } else {
             activityBody.innerHTML = '<tr><td colspan="3" style="text-align:center;color:var(--text-dim);">No recent activity</td></tr>';
@@ -420,10 +420,10 @@
         if (withdrawals.length > 0) {
             wBody.innerHTML = withdrawals.slice(0, 10).map(w => `
                 <tr>
-                    <td style="font-size:0.75rem;">${safeText(String(w.withdrawal_id || w.id || '--').substring(0, 12))}...</td>
-                    <td>${safeText(w.amount, '?')} RTC</td>
-                    <td><span class="badge ${w.status === 'completed' ? 'badge-green' : w.status === 'pending' ? 'badge-yellow' : 'badge-red'}">${escapeHtml(w.status || 'unknown')}</span></td>
-                    <td>${safeText(timeAgo(w.requested_at || w.created_at || w.timestamp))}</td>
+                    <td style="font-size:0.75rem;">${escapeHtml(safeText(String(w.withdrawal_id || w.id || '--').substring(0, 12)))}...</td>
+                    <td>${escapeHtml(safeText(w.amount, '?'))} RTC</td>
+                    <td><span class="badge ${escapeHtml(w.status === 'completed' ? 'badge-green' : w.status === 'pending' ? 'badge-yellow' : 'badge-red')}">${escapeHtml(w.status || 'unknown')}</span></td>
+                    <td>${escapeHtml(safeText(timeAgo(w.requested_at || w.created_at || w.timestamp)))}</td>
                 </tr>
             `).join('');
         } else {


### PR DESCRIPTION
This is a fresh selector-owned PR from the natural selector scan.

Problem: current-main browser code in `explorer/miner-dashboard.html` writes API-derived values through dynamic `innerHTML` (dynamic_innerHTML@line 385; dynamic_innerHTML@line 395; dynamic_innerHTML@line 401). Bridge, explorer, and wallet UIs should avoid DOM injection when rendering remote data. Fix shape: escape dynamic fields or render with textContent/createElement while preserving the existing UI. Validation expected: focused pytest, py_compile, and git diff --check. Boundaries: no wallet, payout, reward, admin secret, production wallet, or manual crediting changes.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- lgbm_rank: `10`
- native_rank: `22`
- dispatch_arm: `trained_lgbm_selector`

Scoped files:
- `explorer/miner-dashboard.html`

Validation:
- `dynamic_innerhtml static audit for explorer/miner-dashboard.html -> passed`
- `GitHub Contents API path filter -> source file only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No unrelated maintenance, baseline, or consensus-node edits.

@Scottcjn this is a fresh, scoped selector PR with natural attribution preserved as `both_selectors` when both arms found it.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
