### PR TITLE
fix(passport): render dynamic HTML safely

### DIFF
--- a/passport/templates/passport_view.html
+++ b/passport/templates/passport_view.html
@@ -80,7 +80,7 @@ async function load() {
     <div class="passport-header">
       <div class="machine-name">${escapeHtml(p.name || 'Unnamed Machine')}</div>
       <div class="machine-id">${escapeHtml(p.machine_id || '')}</div>
-      <div class="tier-badge tier-${safeTier(p.tier)}">${escapeHtml(p.tier || 'modern')} &middot; ${escapeHtml(p.hardware_age || 0)} years old</div>
+      <div class="tier-badge tier-${escapeHtml(safeTier(p.tier))}">${escapeHtml(p.tier || 'modern')} &middot; ${escapeHtml(p.hardware_age || 0)} years old</div>
     </div>
 
     <div class="section">
@@ -107,7 +107,7 @@ async function load() {
         <div class="repair-entry">
           <div class="repair-date">${escapeHtml(r.date || '')}</div>
           <div class="repair-desc">${escapeHtml(r.description || '')}</div>
-          ${r.parts && r.parts.length ? `<div style="font-size:0.8em;color:var(--muted)">Parts: ${formatParts(r.parts)}</div>` : ''}
+          ${r.parts && r.parts.length ? `<div style="font-size:0.8em;color:var(--muted)">Parts: ${escapeHtml(formatParts(r.parts))}</div>` : ''}
         </div>
       `).join('') : '<div class="empty">No repairs logged yet</div>'}
     </div>


### PR DESCRIPTION
This is a fresh selector-owned PR from the natural selector scan.

Problem: current-main browser code in `passport/templates/passport_view.html` writes API-derived values through dynamic `innerHTML` (dynamic_innerHTML@line 75; dynamic_innerHTML@line 79). Bridge, explorer, and wallet UIs should avoid DOM injection when rendering remote data. Fix shape: escape dynamic fields or render with textContent/createElement while preserving the existing UI. Validation expected: focused pytest, py_compile, and git diff --check. Boundaries: no wallet, payout, reward, admin secret, production wallet, or manual crediting changes.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- lgbm_rank: `23`
- native_rank: `29`
- dispatch_arm: `trained_lgbm_selector`

Scoped files:
- `passport/templates/passport_view.html`

Validation:
- `dynamic_innerhtml static audit for passport/templates/passport_view.html -> passed`
- `GitHub Contents API path filter -> source file only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No unrelated maintenance, baseline, or consensus-node edits.

@Scottcjn this is a fresh, scoped selector PR with natural attribution preserved as `both_selectors` when both arms found it.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
