### PR TITLE
fix(passport): render dynamic HTML safely

### DIFF
--- a/passport/templates/passport_index.html
+++ b/passport/templates/passport_index.html
@@ -70,7 +70,7 @@ function render(list) {
       <div class="name">${escapeHtml(p.name || String(p.machine_id || '').substring(0,12)+'...')}</div>
       <div class="arch">${escapeHtml(p.architecture || 'Unknown')} &middot; ${escapeHtml(p.manufacture_year || '?')}</div>
       <div class="meta">
-        <span class="tier-badge tier-${safeTier(p.tier)}">${escapeHtml(p.tier || 'modern')}</span>
+        <span class="tier-badge tier-${escapeHtml(safeTier(p.tier))}">${escapeHtml(p.tier || 'modern')}</span>
         &middot; ${escapeHtml(p.total_epochs || 0)} epochs &middot; ${escapeHtml(p.total_rtc || 0)} RTC earned
       </div>
     </div>


### PR DESCRIPTION
This is a fresh selector-owned PR from the natural selector scan.

Problem: current-main browser code in `passport/templates/passport_index.html` writes API-derived values through dynamic `innerHTML` (dynamic_innerHTML@line 67; dynamic_innerHTML@line 68). Bridge, explorer, and wallet UIs should avoid DOM injection when rendering remote data. Fix shape: escape dynamic fields or render with textContent/createElement while preserving the existing UI. Validation expected: focused pytest, py_compile, and git diff --check. Boundaries: no wallet, payout, reward, admin secret, production wallet, or manual crediting changes.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- lgbm_rank: `25`
- native_rank: `31`
- dispatch_arm: `trained_lgbm_selector`

Scoped files:
- `passport/templates/passport_index.html`

Validation:
- `dynamic_innerhtml static audit for passport/templates/passport_index.html -> passed`
- `GitHub Contents API path filter -> source file only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No unrelated maintenance, baseline, or consensus-node edits.

@Scottcjn this is a fresh, scoped selector PR with natural attribution preserved as `both_selectors` when both arms found it.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
