### PR TITLE
fix(explorer): render dynamic HTML safely

### DIFF
--- a/explorer/patched/enhanced-explorer.html
+++ b/explorer/patched/enhanced-explorer.html
@@ -556,10 +556,10 @@
                     <tr>
                         <td><strong>${escapeHtml(miner.miner_id || 'Unknown')}</strong></td>
                         <td><span class="arch-badge">${escapeHtml(miner.architecture || miner.device_arch || 'Unknown')}</span></td>
-                        <td><span class="multiplier">x${miner.multiplier || miner.antiquity_multiplier || '1.0'}</span></td>
+                        <td><span class="multiplier">x${escapeHtml(miner.multiplier || miner.antiquity_multiplier || '1.0')}</span></td>
                         <td><span class="badge badge-success">Online</span></td>
-                        <td>${formatTime(miner.last_attestation || miner.last_seen)}</td>
-                        <td>${(miner.earnings || miner.total_earned || 0).toFixed(2)} RTC</td>
+                        <td>${escapeHtml(formatTime(miner.last_attestation || miner.last_seen))}</td>
+                        <td>${escapeHtml((miner.earnings || miner.total_earned || 0).toFixed(2))} RTC</td>
                     </tr>
                 `).join('');
 
@@ -569,11 +569,11 @@
                     <tr>
                         <td><strong>${escapeHtml(miner.miner_id || 'Unknown')}</strong></td>
                         <td><span class="arch-badge">${escapeHtml(miner.architecture || miner.device_arch || 'Unknown')}</span></td>
-                        <td><span class="multiplier">x${miner.multiplier || miner.antiquity_multiplier || '1.0'}</span></td>
+                        <td><span class="multiplier">x${escapeHtml(miner.multiplier || miner.antiquity_multiplier || '1.0')}</span></td>
                         <td><span class="badge badge-success">Online</span></td>
-                        <td>${formatTime(miner.last_attestation || miner.last_seen)}</td>
+                        <td>${escapeHtml(formatTime(miner.last_attestation || miner.last_seen))}</td>
                         <td><code>${escapeHtml(miner.wallet || miner.wallet_address || 'N/A')}</code></td>
-                        <td>${(miner.earnings || miner.total_earned || 0).toFixed(2)} RTC</td>
+                        <td>${escapeHtml((miner.earnings || miner.total_earned || 0).toFixed(2))} RTC</td>
                     </tr>
                 `).join('');
             }
@@ -603,9 +603,9 @@
                         <td><code>${escapeHtml(tx.hash || tx.tx_hash || 'N/A')}</code></td>
                         <td><code>${escapeHtml(tx.from || 'N/A')}</code></td>
                         <td><code>${escapeHtml(tx.to || 'N/A')}</code></td>
-                        <td>${(tx.amount / 1000000 || 0).toFixed(2)} RTC</td>
-                        <td>${(tx.fee / 1000000 || 0).toFixed(4)} RTC</td>
-                        <td>${formatTime(tx.timestamp)}</td>
+                        <td>${escapeHtml((tx.amount / 1000000 || 0).toFixed(2))} RTC</td>
+                        <td>${escapeHtml((tx.fee / 1000000 || 0).toFixed(4))} RTC</td>
+                        <td>${escapeHtml(formatTime(tx.timestamp))}</td>
                         <td><span class="badge badge-success">Confirmed</span></td>
                     </tr>
                 `).join('');


### PR DESCRIPTION
This is a fresh selector-owned PR from the natural selector scan.

Problem: current-main browser code in `explorer/patched/enhanced-explorer.html` writes API-derived values through dynamic `innerHTML` (dynamic_innerHTML@line 601). Bridge, explorer, and wallet UIs should avoid DOM injection when rendering remote data. Fix shape: escape dynamic fields or render with textContent/createElement while preserving the existing UI. Validation expected: focused pytest, py_compile, and git diff --check. Boundaries: no wallet, payout, reward, admin secret, production wallet, or manual crediting changes.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- lgbm_rank: `19`
- native_rank: `2`
- dispatch_arm: `native_druid_selector`

Scoped files:
- `explorer/patched/enhanced-explorer.html`

Validation:
- `dynamic_innerhtml static audit for explorer/patched/enhanced-explorer.html -> passed`
- `GitHub Contents API path filter -> source file only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No unrelated maintenance, baseline, or consensus-node edits.

@Scottcjn this is a fresh, scoped selector PR with natural attribution preserved as `both_selectors` when both arms found it.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
