### PR TITLE
fix(integrations): render dynamic HTML safely

### DIFF
--- a/integrations/epoch-viz/index.html
+++ b/integrations/epoch-viz/index.html
@@ -334,6 +334,13 @@
     </div>
     
     <script>
+function escapeHtml(value) {
+  const div = document.createElement('div');
+  div.textContent = value == null ? '' : String(value);
+  return div.innerHTML;
+}
+
+
         // Configuration
         // Use relative paths (server proxies to RustChain node)
         // Or set NODE_URL to 'https://50.28.86.131' for direct access (may have CORS issues)
@@ -481,13 +488,13 @@
             const maxWeight = Math.max(modernWeight, vintageWeight, 1);
             
             container.innerHTML = `
-                <div class="weight-bar" style="height: ${(modernWeight / maxWeight) * 150}px;">
-                    <span class="weight-value">${modernWeight.toFixed(1)}x</span>
-                    <span class="weight-label">Modern (${modernCount})</span>
+                <div class="weight-bar" style="height: ${escapeHtml((modernWeight / maxWeight) * 150)}px;">
+                    <span class="weight-value">${escapeHtml(modernWeight.toFixed(1))}x</span>
+                    <span class="weight-label">Modern (${escapeHtml(modernCount)})</span>
                 </div>
-                <div class="weight-bar vintage" style="height: ${(vintageWeight / maxWeight) * 150}px;">
-                    <span class="weight-value">${vintageWeight.toFixed(1)}x</span>
-                    <span class="weight-label">Vintage (${vintageCount})</span>
+                <div class="weight-bar vintage" style="height: ${escapeHtml((vintageWeight / maxWeight) * 150)}px;">
+                    <span class="weight-value">${escapeHtml(vintageWeight.toFixed(1))}x</span>
+                    <span class="weight-label">Vintage (${escapeHtml(vintageCount)})</span>
                 </div>
             `;
         }


### PR DESCRIPTION
This is a fresh selector-owned PR from the natural selector scan.

Problem: current-main browser code in `integrations/epoch-viz/index.html` writes API-derived values through dynamic `innerHTML` (dynamic_innerHTML@line 440; dynamic_innerHTML@line 448). Bridge, explorer, and wallet UIs should avoid DOM injection when rendering remote data. Fix shape: escape dynamic fields or render with textContent/createElement while preserving the existing UI. Validation expected: focused pytest, py_compile, and git diff --check. Boundaries: no wallet, payout, reward, admin secret, production wallet, or manual crediting changes.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- lgbm_rank: `17`
- native_rank: `4`
- dispatch_arm: `native_druid_selector`

Scoped files:
- `integrations/epoch-viz/index.html`

Validation:
- `dynamic_innerhtml static audit for integrations/epoch-viz/index.html -> passed`
- `GitHub Contents API path filter -> source file only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No unrelated maintenance, baseline, or consensus-node edits.

@Scottcjn this is a fresh, scoped selector PR with natural attribution preserved as `both_selectors` when both arms found it.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
