### PR TITLE
fix(explorer): render dynamic HTML safely

### DIFF
--- a/explorer/static/js/explorer.js
+++ b/explorer/static/js/explorer.js
@@ -419,13 +419,13 @@ function renderStatusBar() {
     
     container.innerHTML = `
         <div class="status-indicator">
-            <span class="status-dot ${statusClass}"></span>
-            <span>${statusText}</span>
+            <span class="status-dot ${escapeHtml(statusClass)}"></span>
+            <span>${escapeHtml(statusText)}</span>
         </div>
         <div class="status-info mono">
             ${state.health ? `v${escapeHtml(state.health.version || '2.2.1')}` : ''}
-            ${state.health && state.health.uptime ? `| Uptime: ${formatUptime(state.health.uptime)}` : ''}
-            ${state.lastUpdate ? `| Updated: ${formatRelativeTime(state.lastUpdate)}` : ''}
+            ${state.health && state.health.uptime ? `| Uptime: ${escapeHtml(formatUptime(state.health.uptime))}` : ''}
+            ${state.lastUpdate ? `| Updated: ${escapeHtml(formatRelativeTime(state.lastUpdate))}` : ''}
         </div>
     `;
 }
@@ -458,24 +458,24 @@ function renderEpochStats() {
     container.innerHTML = `
         <div class="card">
             <div class="card-title">Current Epoch</div>
-            <div class="card-value text-accent">#${formatNumber(epoch.epoch, 0)}</div>
+            <div class="card-value text-accent">#${escapeHtml(formatNumber(epoch.epoch, 0))}</div>
             <div class="card-label">Epoch Number</div>
         </div>
         <div class="card">
             <div class="card-title">Epoch Pot</div>
-            <div class="card-value text-success">${formatNumber(epoch.pot)} RTC</div>
+            <div class="card-value text-success">${escapeHtml(formatNumber(epoch.pot))} RTC</div>
             <div class="card-label">Reward Pool</div>
         </div>
         <div class="card">
             <div class="card-title">Active Miners</div>
-            <div class="card-value text-info">${state.miners.length}</div>
+            <div class="card-value text-info">${escapeHtml(state.miners.length)}</div>
             <div class="card-label">Enrolled</div>
         </div>
         <div class="card">
             <div class="card-title">Progress</div>
-            <div class="card-value">${formatNumber(slot, 0)}/${formatNumber(blocksPerEpoch, 0)}</div>
+            <div class="card-value">${escapeHtml(formatNumber(slot, 0))}/${escapeHtml(formatNumber(blocksPerEpoch, 0))}</div>
             <div class="progress-bar">
-                <div class="progress-fill" style="width: ${progress}%"></div>
+                <div class="progress-fill" style="width: ${escapeHtml(progress)}%"></div>
             </div>
         </div>
     `;
@@ -657,8 +657,8 @@ function renderTransactionsTable() {
             <td class="mono">${escapeHtml(tx.type || 'transfer')}</td>
             <td class="mono" title="${escapeHtml(tx.from)}">${escapeHtml(shortenAddress(tx.from || '0x'))}</td>
             <td class="mono" title="${escapeHtml(tx.to)}">${escapeHtml(shortenAddress(tx.to || '0x'))}</td>
-            <td class="text-success">${formatNumber(tx.amount || 0, 6)} RTC</td>
-            <td class="mono">${formatRelativeTime(tx.timestamp)}</td>
+            <td class="text-success">${escapeHtml(formatNumber(tx.amount || 0, 6))} RTC</td>
+            <td class="mono">${escapeHtml(formatRelativeTime(tx.timestamp))}</td>
         </tr>
     `).join('');
 }
@@ -733,7 +733,7 @@ function renderHallOfRust() {
             const profileUrl = '/hall-of-fame/machine.html?id=' + encodeURIComponent(fp);
             const machineName = escapeHtml(machine.nickname || (fp ? fp.slice(0, 14) + '…' : 'Unknown'));
             return `
-            <a href="${profileUrl}" style="display: flex; align-items: center; gap: 12px; padding: 12px; background: var(--bg-secondary); border-radius: 8px; margin-bottom: 8px; text-decoration: none; color: inherit; transition: background 0.15s;" onmouseover="this.style.background='var(--bg-tertiary,#1e293b)'" onmouseout="this.style.background='var(--bg-secondary)'">
+            <a href="${escapeHtml(profileUrl)}" style="display: flex; align-items: center; gap: 12px; padding: 12px; background: var(--bg-secondary); border-radius: 8px; margin-bottom: 8px; text-decoration: none; color: inherit; transition: background 0.15s;" onmouseover="this.style.background='var(--bg-tertiary,#1e293b)'" onmouseout="this.style.background='var(--bg-secondary)'">
                 <span style="font-size: 1.5rem; font-weight: bold; color: ${index === 0 ? '#f59e0b' : index === 1 ? '#94a3b8' : index === 2 ? '#b45309' : '#64748b'};">#${index + 1}</span>
                 <div style="flex: 1;">
                     <div class="mono" style="font-size: 0.9rem;">${machineName}</div>
@@ -778,7 +778,7 @@ function renderSearchResults() {
     
     container.innerHTML = `
         <div class="section-title" style="margin-bottom: 16px;">
-            Search Results: ${matchingMiners.length} found
+            Search Results: ${escapeHtml(matchingMiners.length)} found
         </div>
         <div class="table-container">
             <table>
@@ -798,10 +798,10 @@ function renderSearchResults() {
                         return `
                             <tr>
                                 <td class="mono" title="${escapeHtml(miner.miner_id)}">${escapeHtml(shortenAddress(miner.miner_id || 'unknown'))}</td>
-                                <td><span class="badge ${badgeClass}">${escapeHtml(miner.device_arch || 'Unknown')}</span></td>
-                                <td><span class="badge badge-${tier}">${tier.toUpperCase()}</span></td>
-                                <td class="text-accent">${formatNumber(miner.multiplier || 1.0, 2)}x</td>
-                                <td class="text-success">${formatNumber(miner.balance || 0, 6)} RTC</td>
+                                <td><span class="badge ${escapeHtml(badgeClass)}">${escapeHtml(miner.device_arch || 'Unknown')}</span></td>
+                                <td><span class="badge badge-${escapeHtml(tier)}">${escapeHtml(tier.toUpperCase())}</span></td>
+                                <td class="text-accent">${escapeHtml(formatNumber(miner.multiplier || 1.0, 2))}x</td>
+                                <td class="text-success">${escapeHtml(formatNumber(miner.balance || 0, 6))} RTC</td>
                             </tr>
                         `;
                     }).join('')}


### PR DESCRIPTION
This is a fresh selector-owned PR from the natural selector scan.

Problem: current-main browser code in `explorer/static/js/explorer.js` writes API-derived values through dynamic `innerHTML` (dynamic_innerHTML@line 412; dynamic_innerHTML@line 420; dynamic_innerHTML@line 444). Bridge, explorer, and wallet UIs should avoid DOM injection when rendering remote data. Fix shape: escape dynamic fields or render with textContent/createElement while preserving the existing UI. Validation expected: focused pytest, py_compile, and git diff --check. Boundaries: no wallet, payout, reward, admin secret, production wallet, or manual crediting changes.

Selector provenance:
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- selected_by_lgbm: `True`
- selected_by_native: `True`
- lgbm_rank: `14`
- native_rank: `12`
- dispatch_arm: `native_druid_selector`

Scoped files:
- `explorer/static/js/explorer.js`

Validation:
- `dynamic_innerhtml static audit for explorer/static/js/explorer.js -> passed`
- `GitHub Contents API path filter -> source file only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No unrelated maintenance, baseline, or consensus-node edits.

@Scottcjn this is a fresh, scoped selector PR with natural attribution preserved as `both_selectors` when both arms found it.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
