### PR TITLE
fix(config): tolerate malformed numeric env defaults

### DIFF
--- a/bottube_digest_bot/config.py
+++ b/bottube_digest_bot/config.py
@@ -8,6 +8,22 @@ import os
 from dataclasses import dataclass
 from typing import List, Optional
 
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name, str(default))
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name, str(default))
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 
 @dataclass
 class BotConfig:
@@ -76,23 +92,23 @@ class BotConfig:
             rustchain_node_url=os.getenv(
                 "RUSTCHAIN_NODE_URL", "https://50.28.86.131"
             ),
-            api_timeout=float(os.getenv("RUSTCHAIN_API_TIMEOUT", "15.0")),
+            api_timeout=_env_float("RUSTCHAIN_API_TIMEOUT", 15.0),
             verify_ssl=os.getenv("RUSTCHAIN_VERIFY_SSL", "false").lower() == "true",
             bottube_url=os.getenv("BOTTUBE_URL", "https://bottube.ai"),
-            bottube_api_timeout=float(os.getenv("BOTTUBE_API_TIMEOUT", "10.0")),
+            bottube_api_timeout=_env_float("BOTTUBE_API_TIMEOUT", 10.0),
             discord_webhook_url=os.getenv("DISCORD_WEBHOOK_URL", ""),
             discord_bot_token=os.getenv("DISCORD_BOT_TOKEN", ""),
             discord_channel_id=os.getenv("DISCORD_CHANNEL_ID", ""),
             telegram_bot_token=os.getenv("TELEGRAM_BOT_TOKEN", ""),
             telegram_chat_id=os.getenv("TELEGRAM_CHAT_ID", ""),
             smtp_host=os.getenv("SMTP_HOST", ""),
-            smtp_port=int(os.getenv("SMTP_PORT", "587")),
+            smtp_port=_env_int("SMTP_PORT", 587),
             smtp_user=os.getenv("SMTP_USER", ""),
             smtp_password=os.getenv("SMTP_PASSWORD", ""),
             smtp_from=os.getenv("SMTP_FROM", ""),
             digest_recipients=recipients,
-            digest_top_n=int(os.getenv("DIGEST_TOP_N", "10")),
-            digest_top_videos=int(os.getenv("DIGEST_TOP_VIDEOS", "5")),
+            digest_top_n=_env_int("DIGEST_TOP_N", 10),
+            digest_top_videos=_env_int("DIGEST_TOP_VIDEOS", 5),
             include_epoch_summary=os.getenv("INCLUDE_EPOCH_SUMMARY", "true").lower()
             != "false",
             include_miner_stats=os.getenv("INCLUDE_MINER_STATS", "true").lower()
@@ -103,8 +119,8 @@ class BotConfig:
             != "false",
             schedule_mode=os.getenv("SCHEDULE_MODE", "weekly"),
             schedule_day=os.getenv("SCHEDULE_DAY", "monday"),
-            schedule_hour=int(os.getenv("SCHEDULE_HOUR", "9")),
-            schedule_minute=int(os.getenv("SCHEDULE_MINUTE", "0")),
+            schedule_hour=_env_int("SCHEDULE_HOUR", 9),
+            schedule_minute=_env_int("SCHEDULE_MINUTE", 0),
             log_level=os.getenv("LOG_LEVEL", "INFO"),
             log_file=os.getenv("LOG_FILE", ""),
             dry_run=os.getenv("DRY_RUN", "false").lower() == "true",

--- a/discord_bot/config.py
+++ b/discord_bot/config.py
@@ -7,6 +7,14 @@ Loads settings from environment variables with sensible defaults.
 import os
 from dataclasses import dataclass
 
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name, str(default))
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 
 @dataclass
 class BotConfig:
@@ -36,7 +44,7 @@ class BotConfig:
             rustchain_node_url=os.getenv(
                 "RUSTCHAIN_NODE_URL", "https://rustchain.org"
             ),
-            api_timeout=float(os.getenv("RUSTCHAIN_API_TIMEOUT", "10.0")),
+            api_timeout=_env_float("RUSTCHAIN_API_TIMEOUT", 10.0),
             prefix=os.getenv("BOT_PREFIX", "!"),
             owner_id=os.getenv("BOT_OWNER_ID", ""),
             log_level=os.getenv("LOG_LEVEL", "INFO"),

--- a/explorer/explorer_websocket_server.py
+++ b/explorer/explorer_websocket_server.py
@@ -32,6 +32,22 @@ import sys
 from flask import Flask, Blueprint, jsonify, request
 from datetime import datetime
 
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name, str(default))
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, str(default))
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 try:
     from node.tls_config import get_ssl_context
 except ModuleNotFoundError:
@@ -51,10 +67,10 @@ except ImportError:
     print("Warning: flask-socketio not installed. Run: pip install flask-socketio")
 
 # ─── Configuration ─────────────────────────────────────────────────────────── #
-EXPLORER_PORT = int(os.environ.get('EXPLORER_PORT', 8080))
+EXPLORER_PORT = _env_int('EXPLORER_PORT', 8080)
 NODE_URL = os.environ.get('RUSTCHAIN_NODE_URL', os.environ.get('RUSTCHAIN_API_BASE', 'https://rustchain.org'))
-API_TIMEOUT = float(os.environ.get('API_TIMEOUT', '8'))
-POLL_INTERVAL = float(os.environ.get('POLL_INTERVAL', '5'))  # seconds between polls
+API_TIMEOUT = _env_float('API_TIMEOUT', 8.0)
+POLL_INTERVAL = _env_float('POLL_INTERVAL', 5.0)  # seconds between polls
 HEARTBEAT_S = 30  # ping/pong interval for connection health
 MAX_QUEUE = 100  # max buffered events per client (backpressure)
 SOCKETIO_CORS_ORIGINS = parse_socketio_cors_origins(local_port=EXPLORER_PORT)

--- a/health-dashboard/server.py
+++ b/health-dashboard/server.py
@@ -21,6 +21,14 @@ import threading
 import requests
 from flask import Flask, jsonify, render_template_string, send_from_directory
 
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, str(default))
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -36,7 +44,7 @@ DATA_DIR = BASE_DIR / 'data'
 DATA_DIR.mkdir(exist_ok=True)
 
 DB_PATH = DATA_DIR / 'health_history.db'
-POLLING_INTERVAL = int(os.environ.get('POLLING_INTERVAL', 60))  # 60 seconds
+POLLING_INTERVAL = _env_int('POLLING_INTERVAL', 60)  # 60 seconds
 HISTORY_RETENTION_HOURS = 24
 
 # Node configuration from issue #2300
@@ -1244,7 +1252,7 @@ def main():
     poll_nodes()
     
     # Start Flask server
-    port = int(os.environ.get('PORT', 5000))
+    port = _env_int('PORT', 5000)
     logger.info(f"Starting web server on port {port}")
     
     app.run(host='0.0.0.0', port=port, debug=False, threaded=True)

--- a/tools/discord-bot/bot.py
+++ b/tools/discord-bot/bot.py
@@ -28,6 +28,14 @@ import httpx
 from discord import app_commands
 from discord.ext import commands
 
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name, str(default))
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 try:
     from dotenv import load_dotenv
     load_dotenv()
@@ -42,7 +50,7 @@ log = logging.getLogger("rustchain-bot")
 
 RUSTCHAIN_URL = os.getenv("RUSTCHAIN_NODE_URL", "https://rustchain.org").rstrip("/")
 DISCORD_TOKEN = os.getenv("DISCORD_TOKEN", "")
-API_TIMEOUT = float(os.getenv("API_TIMEOUT", "10"))
+API_TIMEOUT = _env_float("API_TIMEOUT", 10.0)
 
 
 def _format_uptime(value) -> str:

--- a/tools/sync_committee_tracker/sync_committee_tracker.py
+++ b/tools/sync_committee_tracker/sync_committee_tracker.py
@@ -22,10 +22,18 @@ from typing import Any
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name, str(default))
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 DEFAULT_NODE_URL = os.getenv("RUSTCHAIN_NODE_URL", "https://rustchain.org").rstrip("/")
 DEFAULT_DB_PATH = Path(os.getenv("SYNC_COMMITTEE_DB", "sync_committee_history.db"))
-DEFAULT_COMMITTEE_SIZE = int(os.getenv("SYNC_COMMITTEE_SIZE", "8"))
-DEFAULT_ROTATION_EPOCHS = int(os.getenv("SYNC_COMMITTEE_ROTATION_EPOCHS", "1"))
+DEFAULT_COMMITTEE_SIZE = _env_int("SYNC_COMMITTEE_SIZE", 8)
+DEFAULT_ROTATION_EPOCHS = _env_int("SYNC_COMMITTEE_ROTATION_EPOCHS", 1)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
@Scottcjn consolidated selector resubmission after your reviewability feedback.

This is one coherent PR for runtime config/env numeric parsing selected by both arms. It replaces the old one-file wave shape with a grouped, CI-friendly patch.

Problem:
- The natural selector scan still found these current-main risks after already-open/closed/covered candidates were filtered out.
- Both selectors nominated every included candidate, so this is recorded as `both_selectors` rather than assigned to only one arm.

Fix:
- Keep each fix bounded to the selected source files.
- Avoid unrelated baseline, consensus-node, or shared CI edits.

Selector provenance:
- selected_by_lgbm: `true`
- selected_by_native: `true`
- natural_owner: `both_selectors`
- selection_bucket: `both_selectors`
- dispatch_arm: `consolidated_selector_bundle`
- queue_candidate_ids: `b648f33bc155b317`, `c55d1678269e6161`, `70bb5b5fb708b309`, `1594f085b2e85a5c`, `5c4e5b88c34ddd39`, `a7d54e0bc37e05cd`

Selected source paths:
- `discord_bot/config.py`
- `tools/discord-bot/bot.py`
- `health-dashboard/server.py`
- `bottube_digest_bot/config.py`
- `explorer/explorer_websocket_server.py`
- `tools/sync_committee_tracker/sync_committee_tracker.py`

Scoped changed files:
- `bottube_digest_bot/config.py`
- `discord_bot/config.py`
- `explorer/explorer_websocket_server.py`
- `health-dashboard/server.py`
- `tools/discord-bot/bot.py`
- `tools/sync_committee_tracker/sync_committee_tracker.py`

Validation:
- `numeric env static audit for discord_bot/config.py -> passed`
- `numeric env static audit for tools/discord-bot/bot.py -> passed`
- `numeric env static audit for health-dashboard/server.py -> passed`
- `numeric env static audit for bottube_digest_bot/config.py -> passed`
- `numeric env static audit for explorer/explorer_websocket_server.py -> passed`
- `numeric env static audit for tools/sync_committee_tracker/sync_committee_tracker.py -> passed`
- `python3 -m py_compile discord_bot/config.py -> passed`
- `python3 -m py_compile tools/discord-bot/bot.py -> passed`
- `python3 -m py_compile health-dashboard/server.py -> passed`
- `python3 -m py_compile bottube_digest_bot/config.py -> passed`
- `python3 -m py_compile explorer/explorer_websocket_server.py -> passed`
- `python3 -m py_compile tools/sync_committee_tracker/sync_committee_tracker.py -> passed`
- `GitHub Contents API path filter -> source files only`

Boundaries:
- No payout amount changes.
- No admin keys or production wallet changes.
- No manual wallet crediting.
- No unrelated maintenance, baseline, or consensus-node edits.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
