### PR TITLE
fix(sdk): remove insecure non-Ed25519 wallet fallback (closes rustchain-bounties#14544)

### DIFF
--- a/sdk/python/rustchain_sdk/tests/test_wallet.py
+++ b/sdk/python/rustchain_sdk/tests/test_wallet.py
@@ -201,3 +201,44 @@ class TestRustChainWalletExportImport:
         """Invalid word count raises ValueError."""
         with pytest.raises(ValueError, match="Seed phrase must be 12 or 24"):
             RustChainWallet.from_seed_phrase(["abandon"] * 10)
+
+
+class TestRustChainWalletEd25519Integrity:
+    """No insecure fallback: keys/signatures must be real Ed25519.
+
+    Regression coverage for a silent fallback that, when ``cryptography`` was
+    missing, derived a hash-based "public key" and signed with HMAC. That made
+    the same seed phrase resolve to a different address and produced signatures
+    the network rejects.
+    """
+
+    def test_signature_verifies_against_advertised_public_key(self):
+        """Signatures are genuine Ed25519 over the advertised public key."""
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PublicKey,
+        )
+
+        wallet = RustChainWallet.create(strength=128)
+        message = b"transfer payload"
+        signature = wallet.sign(message)
+
+        pub = Ed25519PublicKey.from_public_bytes(
+            bytes.fromhex(wallet.public_key_hex)
+        )
+        # Raises InvalidSignature if the signature is not real Ed25519.
+        pub.verify(signature, message)
+
+    def test_missing_cryptography_raises_instead_of_forging_keys(self, monkeypatch):
+        """Without 'cryptography' the wallet refuses rather than forging keys."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def blocked_import(name, *args, **kwargs):
+            if name.startswith("cryptography"):
+                raise ImportError("simulated missing cryptography")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", blocked_import)
+        with pytest.raises(RuntimeError, match="requires the 'cryptography'"):
+            RustChainWallet.create(strength=128)

--- a/sdk/python/rustchain_sdk/wallet.py
+++ b/sdk/python/rustchain_sdk/wallet.py
@@ -202,6 +202,35 @@ def _hmac_sha512(key: bytes, data: bytes) -> bytes:
     return hmac.new(key, data, hashlib.sha512).digest()
 
 
+def _load_ed25519():
+    """Import the Ed25519 primitives, or raise a clear error if unavailable.
+
+    The wallet MUST use real Ed25519 for key derivation and signing so that
+    addresses and transactions stay compatible with the RustChain network.
+    There is deliberately no hash/HMAC fallback: a silent fallback would derive
+    a *different* address from the same seed (depending only on whether the
+    ``cryptography`` package happens to be installed) and would emit signatures
+    the network rejects, corrupting wallet identity and risking loss of funds.
+    """
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PrivateKey,
+        )
+        from cryptography.hazmat.primitives.serialization import (
+            Encoding,
+            PublicFormat,
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            "RustChainWallet requires the 'cryptography' package for Ed25519 "
+            "key derivation and signing. Install it with "
+            "'pip install cryptography'. A fallback scheme is intentionally not "
+            "provided because it would produce addresses and signatures that are "
+            "incompatible with the RustChain network."
+        ) from exc
+    return Ed25519PrivateKey, Encoding, PublicFormat
+
+
 class RustChainWallet:
     """
     RustChain wallet with BIP39 seed phrase and Ed25519 signing.
@@ -245,20 +274,11 @@ class RustChainWallet:
 
     @staticmethod
     def _derive_public_key(private_key: bytes) -> bytes:
-        """Derive public key from private key using Ed25519."""
-        try:
-            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
-            from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
-            import base64
-
-            # Use cryptography library if available
-            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-            priv = Ed25519PrivateKey.from_private_bytes(private_key[:32])
-            pub = priv.public_key()
-            return pub.public_bytes(Encoding.Raw, PublicFormat.Raw)
-        except ImportError:
-            # Fallback: simple hash-based "public key" derivation
-            return _sha256d(b"pubkey" + private_key)[:32]
+        """Derive the Ed25519 public key from the private key."""
+        Ed25519PrivateKey, Encoding, PublicFormat = _load_ed25519()
+        priv = Ed25519PrivateKey.from_private_bytes(private_key[:32])
+        pub = priv.public_key()
+        return pub.public_bytes(Encoding.Raw, PublicFormat.Raw)
 
     @classmethod
     def create(cls, strength: int = 128) -> "RustChainWallet":
@@ -306,11 +326,8 @@ class RustChainWallet:
     @classmethod
     def _generate_address(cls, private_key: bytes) -> str:
         """Generate a wallet address from private key."""
-        # Derive public key
-        if hasattr(cls, "_derive_public_key"):
-            pubkey = cls._derive_public_key(private_key)
-        else:
-            pubkey = _sha256d(b"pubkey" + private_key)[:32]
+        # Derive public key (always real Ed25519; raises if cryptography missing)
+        pubkey = cls._derive_public_key(private_key)
 
         # Hash public key to get address
         addr_hash = _sha256d(b"address" + pubkey)
@@ -359,14 +376,9 @@ class RustChainWallet:
         Returns:
             The Ed25519 signature (64 bytes).
         """
-        try:
-            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-
-            priv = Ed25519PrivateKey.from_private_bytes(self._private_key[:32])
-            return priv.sign(message)
-        except ImportError:
-            # Fallback: HMAC-based signature (not real Ed25519)
-            return _hmac_sha512(self._private_key, message)[:64]
+        Ed25519PrivateKey, _, _ = _load_ed25519()
+        priv = Ed25519PrivateKey.from_private_bytes(self._private_key[:32])
+        return priv.sign(message)
 
     def sign_transfer(
         self,


### PR DESCRIPTION
Closes the SDK wallet cryptographic-inconsistency issue reported in [rustchain-bounties#14544](https://github.com/Scottcjn/rustchain-bounties/issues/14544).

## Problem
`RustChainWallet` had two silent fallbacks that triggered whenever the `cryptography` package was not importable:

- `_derive_public_key` fell back to `_sha256d(b"pubkey" + private_key)[:32]` — a hash, not an Ed25519 public key.
- `sign` fell back to `_hmac_sha512(self._private_key, message)[:64]` — an HMAC, not an Ed25519 signature.

Because the address is derived from the public key, **the same seed phrase produced a different `RTC...` address depending on whether `cryptography` happened to be installed.** A user who created a wallet without the library, then installed it (or vice-versa), would see their address change — losing access to funds. And any transaction signed via the HMAC path is silently rejected by the network, with no error to warn the user.

## Fix
Key derivation and signing now go through a single `_load_ed25519()` helper that raises a clear `RuntimeError` (telling the user to `pip install cryptography`) instead of falling back to an incompatible scheme. There is intentionally no alternate crypto path — the wallet must use real Ed25519 so addresses and signatures stay network-compatible. Also removed the dead hash-fallback branch in `_generate_address` (the `hasattr` guard was always true).

Behaviour is **unchanged** when `cryptography` is installed (the normal case), so this is a fail-closed hardening with no impact on existing users.

## Tests
`python3 -m pytest rustchain_sdk/tests/test_wallet.py -q` → **23 passed**. Two new regression tests:
- a signature produced by `wallet.sign()` verifies against the advertised Ed25519 public key (proves keys/sigs are genuine Ed25519);
- creating a wallet with `cryptography` import blocked raises `RuntimeError` instead of forging a hash-based key.

Diff: 2 files, +80/-27 (`sdk/python/rustchain_sdk/wallet.py`, `sdk/python/rustchain_sdk/tests/test_wallet.py`).

/claim #14544

RTC reward wallet (on merge): `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`