### PR TITLE
fix: add /network/info endpoint for wallet queries (Closes #7094)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -7457,10 +7457,14 @@ def get_stats():
 @app.route('/network/info', methods=['GET'])
 def get_network_info():
     """Get network information for wallet clients"""
-    with sqlite3.connect(DB_PATH) as db:
-        # Get current block height
-        row = db.execute("SELECT MAX(height) FROM blocks").fetchone()
-        block_height = row[0] if (row and row[0] is not None) else 0
+    # Get current block height safely
+    block_height = 0
+    try:
+        with sqlite3.connect(DB_PATH) as db:
+            row = db.execute("SELECT MAX(height) FROM blocks").fetchone()
+            block_height = row[0] if (row and row[0] is not None) else 0
+    except Exception:
+        pass
 
     # Get peer count safely
     peer_count = 0

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -7454,6 +7454,33 @@ def get_stats():
     })
 
 
+@app.route('/network/info', methods=['GET'])
+def get_network_info():
+    """Get network information for wallet clients"""
+    with sqlite3.connect(DB_PATH) as db:
+        # Get current block height
+        row = db.execute("SELECT MAX(height) FROM blocks").fetchone()
+        block_height = row[0] if (row and row[0] is not None) else 0
+
+    # Get peer count safely
+    peer_count = 0
+    try:
+        if 'peer_manager' in globals() and peer_manager is not None:
+            stats = peer_manager.get_network_stats()
+            peer_count = stats.get('active_peers', 0)
+    except Exception:
+        pass
+
+    return jsonify({
+        "chain_id": CHAIN_ID,
+        "network": "testnet" if "testnet" in CHAIN_ID.lower() else "mainnet",
+        "block_height": block_height,
+        "peer_count": peer_count,
+        "min_fee": 1000,
+        "version": "2.2.1-security-hardened"
+    })
+
+
 # ---------- RIP-0200b: Deflationary Bounty Decay ----------
 # Half-life model: bounty multiplier = 0.5^(total_paid / HALF_LIFE)
 # As more RTC is paid from community fund, bounties shrink automatically.

--- a/node/tests/test_explorer_api_routes.py
+++ b/node/tests/test_explorer_api_routes.py
@@ -279,6 +279,23 @@ class TestExplorerApiRoutes(unittest.TestCase):
         self.assertEqual(body["min_fee"], 1000)
         self.assertEqual(body["version"], "2.2.1-security-hardened")
 
+    def test_network_info_endpoint_missing_table(self):
+        import tempfile
+        import os
+        fd, db_path = tempfile.mkstemp()
+        os.close(fd)
+        try:
+            old_db_path = self.mod.DB_PATH
+            self.mod.DB_PATH = db_path
+            resp = self.client.get("/network/info")
+            self.assertEqual(resp.status_code, 200)
+            body = resp.get_json()
+            self.assertEqual(body["block_height"], 0)
+        finally:
+            self.mod.DB_PATH = old_db_path
+            if os.path.exists(db_path):
+                os.remove(db_path)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/node/tests/test_explorer_api_routes.py
+++ b/node/tests/test_explorer_api_routes.py
@@ -242,6 +242,43 @@ class TestExplorerApiRoutes(unittest.TestCase):
         self.assertEqual(tx_resp.status_code, 400)
         self.assertEqual(tx_resp.get_json(), {"ok": False, "error": "offset must be an integer"})
 
+    def test_network_info_endpoint(self):
+        # Create blocks table and insert a block to mock block height
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS blocks (
+                    height INTEGER PRIMARY KEY,
+                    block_hash TEXT NOT NULL,
+                    prev_hash TEXT NOT NULL,
+                    timestamp INTEGER NOT NULL,
+                    merkle_root TEXT NOT NULL,
+                    state_root TEXT NOT NULL,
+                    producer TEXT NOT NULL,
+                    tx_count INTEGER NOT NULL,
+                    body_json TEXT NOT NULL,
+                    created_at INTEGER NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO blocks
+                (height, block_hash, prev_hash, timestamp, merkle_root, state_root,
+                 producer, tx_count, body_json, created_at)
+                VALUES (5, 'hash5', 'prev4', 500, 'm5', 's5', 'miner5', 1, '{"tx_count": 1}', 510)
+                """
+            )
+
+        resp = self.client.get("/network/info")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.get_json()
+        self.assertEqual(body["block_height"], 5)
+        self.assertEqual(body["chain_id"], self.mod.CHAIN_ID)
+        self.assertEqual(body["network"], "testnet" if "testnet" in self.mod.CHAIN_ID.lower() else "mainnet")
+        self.assertEqual(body["min_fee"], 1000)
+        self.assertEqual(body["version"], "2.2.1-security-hardened")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds the missing /network/info endpoint to the Flask node. This resolves issue #7094, allowing the rtc-wallet network command to fetch network metadata successfully. Tested and verified with pytest.