### PR TITLE
feat: add public consolidated Hall of Fame API and stats endpoints (Closes #7181)

### DIFF
--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -660,7 +660,7 @@ def api_hall_of_fame_machine():
                     'rust_score': machine.get('rust_score'),
                     'samples': int(r['attestations'] or 0),
                 }
-                for r in c.fetchall()  # fetchall-ok: bounded-by-time-range (GROUP BY day)
+                for r in c.fetchall()  # fetchall-ok: bounded-by-schema (GROUP BY day, time-range scoped)
             ]
         elif _table_exists(c, 'rust_score_history'):
             c.execute(
@@ -682,7 +682,7 @@ def api_hall_of_fame_machine():
                     'samples': int(r['samples'] or 0),
                     'attestations': int(r['samples'] or 0),
                 }
-                for r in c.fetchall()  # fetchall-ok: bounded-by-time-range (GROUP BY day)
+                for r in c.fetchall()  # fetchall-ok: bounded-by-schema (GROUP BY day, time-range scoped)
             ]
 
         # Reward participation (best-effort) from enrollments + pending ledger credits.

--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -777,7 +777,7 @@ def api_hall_of_fame():
             ORDER BY rust_score DESC
             LIMIT 10
         """)
-        ancient_iron = [dict(row) for row in c.fetchall()]
+        ancient_iron = [dict(row) for row in c.fetchall()]  # fetchall-ok: already-paginated
 
         # Categories - Exotic Arch (Top 10 arch by count)
         c.execute("""
@@ -793,7 +793,7 @@ def api_hall_of_fame():
             LIMIT 10
         """)
         exotic_arch = []
-        for r in c.fetchall():
+        for r in c.fetchall():  # fetchall-ok: already-paginated
             exotic_arch.append({
                 'device_arch': r['device_arch'],
                 'machine_count': r['machine_count'],

--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -323,7 +323,7 @@ def rust_leaderboard():
             LIMIT ?
         """, (limit,))
         
-        rows = c.fetchall()
+        rows = c.fetchall()  # fetchall-ok: already-paginated (LIMIT ?)
         conn.close()
         
         leaderboard = []
@@ -580,7 +580,7 @@ def api_hall_of_fame_leaderboard():
             """,
             params + [limit],
         )
-        rows = c.fetchall()
+        rows = c.fetchall()  # fetchall-ok: already-paginated (LIMIT ?)
         conn.close()
 
         leaderboard = []
@@ -660,7 +660,7 @@ def api_hall_of_fame_machine():
                     'rust_score': machine.get('rust_score'),
                     'samples': int(r['attestations'] or 0),
                 }
-                for r in c.fetchall()
+                for r in c.fetchall()  # fetchall-ok: bounded-by-time-range (GROUP BY day)
             ]
         elif _table_exists(c, 'rust_score_history'):
             c.execute(
@@ -682,7 +682,7 @@ def api_hall_of_fame_machine():
                     'samples': int(r['samples'] or 0),
                     'attestations': int(r['samples'] or 0),
                 }
-                for r in c.fetchall()
+                for r in c.fetchall()  # fetchall-ok: bounded-by-time-range (GROUP BY day)
             ]
 
         # Reward participation (best-effort) from enrollments + pending ledger credits.
@@ -960,7 +960,7 @@ def fleet_breakdown():
         """)
         
         breakdown = []
-        for row in c.fetchall():
+        for row in c.fetchall():  # fetchall-ok: bounded-by-schema (GROUP BY device_arch, finite set)
             breakdown.append({
                 'architecture': row[0],
                 'count': row[1],
@@ -1003,7 +1003,7 @@ def hall_timeline():
         """)
         
         timeline = []
-        for row in c.fetchall():
+        for row in c.fetchall():  # fetchall-ok: already-paginated (LIMIT 30)
             timeline.append({
                 'date': row[0],
                 'machines_joined': row[1],

--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -427,8 +427,8 @@ def hall_stats():
         c.execute("SELECT COUNT(*) FROM hall_of_rust WHERE capacitor_plague = 1")
         stats['capacitor_plague_survivors'] = c.fetchone()[0]
         
-        # Oldest machine
-        c.execute("SELECT miner_id, manufacture_year FROM hall_of_rust ORDER BY manufacture_year ASC LIMIT 1")
+        # Oldest machine (exclude null and zero years)
+        c.execute("SELECT miner_id, manufacture_year FROM hall_of_rust WHERE manufacture_year IS NOT NULL AND manufacture_year > 0 ORDER BY manufacture_year ASC LIMIT 1")
         oldest = c.fetchone()
         if oldest:
             stats['oldest_machine'] = {'miner_id': oldest[0], 'year': oldest[1]}
@@ -729,6 +729,135 @@ def api_hall_of_fame_machine():
     except Exception:
         return _internal_error_response("api_hall_of_fame_machine")
 
+
+@hall_bp.route('/api/hall_of_fame', methods=['GET'])
+def api_hall_of_fame():
+    """Public consolidated Hall of Fame API — returns stats and top categories."""
+    try:
+        from flask import current_app
+        db_path = current_app.config.get('DB_PATH', '/root/rustchain/rustchain_v2.db')
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        c = conn.cursor()
+
+        # Stats
+        c.execute("SELECT COUNT(*) FROM hall_of_rust WHERE device_arch NOT IN ('unknown', 'default')")
+        total_machines = c.fetchone()[0]
+
+        c.execute("SELECT COUNT(*) FROM hall_of_rust WHERE is_deceased = 1")
+        deceased_machines = c.fetchone()[0]
+
+        c.execute("SELECT SUM(total_attestations) FROM hall_of_rust WHERE device_arch NOT IN ('unknown', 'default')")
+        total_attestations = c.fetchone()[0] or 0
+
+        c.execute("SELECT MAX(rust_score) FROM hall_of_rust")
+        highest_rust_score = c.fetchone()[0] or 0
+
+        # Oldest machine year
+        c.execute("SELECT MIN(manufacture_year) FROM hall_of_rust WHERE manufacture_year IS NOT NULL AND manufacture_year > 0")
+        row = c.fetchone()
+        oldest_year = row[0] if row and row[0] is not None else 0
+
+        stats = {
+            'total_machines': total_machines,
+            'deceased_machines': deceased_machines,
+            'total_attestations': total_attestations,
+            'highest_rust_score': highest_rust_score,
+            'oldest_machine_year': oldest_year,
+            'oldest_year': oldest_year,
+            'generated_at': int(time.time())
+        }
+
+        # Categories - Ancient Iron (Top 10 sorted by rust_score desc)
+        c.execute("""
+            SELECT fingerprint_hash, miner_id, device_family, device_arch,
+                   device_model, manufacture_year, rust_score, total_attestations,
+                   capacitor_plague, is_deceased, nickname
+            FROM hall_of_rust
+            ORDER BY rust_score DESC
+            LIMIT 10
+        """)
+        ancient_iron = [dict(row) for row in c.fetchall()]
+
+        # Categories - Exotic Arch (Top 10 arch by count)
+        c.execute("""
+            SELECT device_arch, 
+                   COUNT(*) as machine_count, 
+                   MIN(manufacture_year) as oldest_year,
+                   MAX(rust_score) as top_rust_score,
+                   SUM(total_attestations) as total_attestations
+            FROM hall_of_rust 
+            WHERE device_arch NOT IN ('unknown', 'default')
+            GROUP BY device_arch 
+            ORDER BY machine_count DESC
+            LIMIT 10
+        """)
+        exotic_arch = []
+        for r in c.fetchall():
+            exotic_arch.append({
+                'device_arch': r['device_arch'],
+                'machine_count': r['machine_count'],
+                'oldest_year': r['oldest_year'],
+                'top_rust_score': r['top_rust_score'],
+                'total_attestations': r['total_attestations']
+            })
+
+        conn.close()
+
+        return jsonify({
+            'stats': stats,
+            'categories': {
+                'ancient_iron': ancient_iron,
+                'exotic_arch': exotic_arch
+            }
+        })
+    except Exception:
+        return _internal_error_response("api_hall_of_fame")
+
+
+@hall_bp.route('/api/hall_of_fame/stats', methods=['GET'])
+def api_hall_of_fame_stats():
+    """Public stats endpoint."""
+    try:
+        from flask import current_app
+        db_path = current_app.config.get('DB_PATH', '/root/rustchain/rustchain_v2.db')
+        conn = sqlite3.connect(db_path)
+        c = conn.cursor()
+        
+        stats = {}
+        
+        c.execute("""SELECT COUNT(*) FROM hall_of_rust WHERE device_arch NOT IN ('unknown', 'default')""")
+        stats['total_machines'] = c.fetchone()[0]
+        
+        c.execute("SELECT COUNT(*) FROM hall_of_rust WHERE is_deceased = 1")
+        stats['deceased_machines'] = c.fetchone()[0]
+        
+        c.execute("""SELECT SUM(total_attestations) FROM hall_of_rust WHERE device_arch NOT IN ('unknown', 'default')""")
+        stats['total_attestations'] = c.fetchone()[0] or 0
+        
+        c.execute("""SELECT AVG(rust_score) FROM hall_of_rust WHERE device_arch NOT IN ('unknown', 'default')""")
+        stats['average_rust_score'] = round(c.fetchone()[0] or 0, 2)
+        
+        c.execute("SELECT MAX(rust_score) FROM hall_of_rust")
+        stats['highest_rust_score'] = c.fetchone()[0] or 0
+        
+        c.execute("SELECT COUNT(*) FROM hall_of_rust WHERE capacitor_plague = 1")
+        stats['capacitor_plague_survivors'] = c.fetchone()[0]
+        
+        # Oldest machine (exclude null and zero years)
+        c.execute("SELECT miner_id, manufacture_year FROM hall_of_rust WHERE manufacture_year IS NOT NULL AND manufacture_year > 0 ORDER BY manufacture_year ASC LIMIT 1")
+        oldest = c.fetchone()
+        if oldest:
+            stats['oldest_machine'] = {'miner_id': oldest[0], 'year': oldest[1]}
+            stats['oldest_machine_year'] = oldest[1]
+            stats['oldest_year'] = oldest[1]
+        
+        conn.close()
+        return jsonify(stats)
+    except Exception:
+        return _internal_error_response("api_hall_of_fame_stats")
+
+
 def register_hall_endpoints(app, db_path):
     """Register Hall of Rust endpoints with Flask app."""
     app.config['DB_PATH'] = db_path
@@ -821,7 +950,7 @@ def fleet_breakdown():
         c.execute("""
             SELECT device_arch, 
                    COUNT(*) as count, 
-                   MIN(manufacture_year) as oldest_year,
+                   MIN(CASE WHEN manufacture_year IS NOT NULL AND manufacture_year > 0 THEN manufacture_year END) as oldest_year,
                    MAX(rust_score) as top_score,
                    AVG(rust_score) as avg_score
             FROM hall_of_rust 

--- a/node/tests/test_api_hall_of_fame.py
+++ b/node/tests/test_api_hall_of_fame.py
@@ -1,0 +1,65 @@
+from flask import Flask
+import sqlite3
+import time
+
+from node.hall_of_rust import hall_bp, init_hall_tables
+
+
+def _app_with_hall_db(tmp_path):
+    db_path = tmp_path / "hall.db"
+    init_hall_tables(str(db_path))
+
+    # Seed the db with a sample machine
+    conn = sqlite3.connect(str(db_path))
+    c = conn.cursor()
+    c.execute("""
+        INSERT INTO hall_of_rust (
+            fingerprint_hash, miner_id, device_family, device_arch,
+            device_model, manufacture_year, rust_score, total_attestations,
+            capacitor_plague, is_deceased, nickname, first_attestation, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """, ("hash123", "miner123", "family123", "ppc", "model123", 2002, 120.5, 50, 1, 0, "nick123", 1000, 1000))
+    conn.commit()
+    conn.close()
+
+    app = Flask(__name__)
+    app.config["DB_PATH"] = str(db_path)
+    app.register_blueprint(hall_bp)
+    return app
+
+
+def test_api_hall_of_fame_summary(tmp_path):
+    app = _app_with_hall_db(tmp_path)
+    client = app.test_client()
+
+    response = client.get("/api/hall_of_fame")
+    assert response.status_code == 200
+    data = response.get_json()
+
+    assert "stats" in data
+    assert "categories" in data
+    assert data["stats"]["total_machines"] == 1
+    assert data["stats"]["highest_rust_score"] == 120.5
+    assert data["stats"]["oldest_year"] == 2002
+
+    assert "ancient_iron" in data["categories"]
+    assert len(data["categories"]["ancient_iron"]) == 1
+    assert data["categories"]["ancient_iron"][0]["miner_id"] == "miner123"
+
+    assert "exotic_arch" in data["categories"]
+    assert len(data["categories"]["exotic_arch"]) == 1
+    assert data["categories"]["exotic_arch"][0]["device_arch"] == "ppc"
+
+
+def test_api_hall_of_fame_stats(tmp_path):
+    app = _app_with_hall_db(tmp_path)
+    client = app.test_client()
+
+    response = client.get("/api/hall_of_fame/stats")
+    assert response.status_code == 200
+    data = response.get_json()
+
+    assert data["total_machines"] == 1
+    assert data["total_attestations"] == 50
+    assert data["highest_rust_score"] == 120.5
+    assert data["capacitor_plague_survivors"] == 1

--- a/node/tests/test_hall_of_rust_error_responses.py
+++ b/node/tests/test_hall_of_rust_error_responses.py
@@ -11,6 +11,10 @@ sys.path.insert(0, str(ROOT / "node"))
 import hall_of_rust  # noqa: E402
 
 
+ADMIN_KEY = "0123456789abcdef0123456789abcdef"
+_HEADERS = {"X-Admin-Key": ADMIN_KEY}
+
+
 def _client_for(db_path):
     app = Flask(__name__)
     app.config["DB_PATH"] = str(db_path)
@@ -18,12 +22,13 @@ def _client_for(db_path):
     return app.test_client()
 
 
-def test_hall_stats_hides_sqlite_error_details(tmp_path):
+def test_hall_stats_hides_sqlite_error_details(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", ADMIN_KEY)
     db_path = tmp_path / "missing_schema.db"
     sqlite3.connect(db_path).close()
     client = _client_for(db_path)
 
-    response = client.get("/hall/stats")
+    response = client.get("/hall/stats", headers=_HEADERS)
 
     assert response.status_code == 500
     assert response.get_json() == {"error": "internal_error"}
@@ -32,12 +37,13 @@ def test_hall_stats_hides_sqlite_error_details(tmp_path):
     assert "hall_of_rust" not in body
 
 
-def test_hall_stats_still_returns_valid_empty_stats(tmp_path):
+def test_hall_stats_still_returns_valid_empty_stats(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", ADMIN_KEY)
     db_path = tmp_path / "hall.db"
     hall_of_rust.init_hall_tables(str(db_path))
     client = _client_for(db_path)
 
-    response = client.get("/hall/stats")
+    response = client.get("/hall/stats", headers=_HEADERS)
 
     assert response.status_code == 200
     body = response.get_json()
@@ -57,18 +63,20 @@ def test_induct_rejects_non_object_json(tmp_path):
     assert response.get_json() == {"error": "JSON object required"}
 
 
-def test_eulogy_rejects_non_object_json(tmp_path):
+def test_eulogy_rejects_non_object_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", ADMIN_KEY)
     db_path = tmp_path / "hall.db"
     hall_of_rust.init_hall_tables(str(db_path))
     client = _client_for(db_path)
 
-    response = client.post("/hall/eulogy/fingerprint-1", json=["nickname"])
+    response = client.post("/hall/eulogy/fingerprint-1", json=["nickname"], headers=_HEADERS)
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "JSON object required"}
 
 
-def test_eulogy_rejects_structured_nickname(tmp_path):
+def test_eulogy_rejects_structured_nickname(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", ADMIN_KEY)
     db_path = tmp_path / "hall.db"
     hall_of_rust.init_hall_tables(str(db_path))
     client = _client_for(db_path)
@@ -76,13 +84,15 @@ def test_eulogy_rejects_structured_nickname(tmp_path):
     response = client.post(
         "/hall/eulogy/fingerprint-1",
         json={"nickname": {"name": "Old Reliable"}},
+        headers=_HEADERS,
     )
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "nickname must be a string"}
 
 
-def test_eulogy_rejects_structured_eulogy(tmp_path):
+def test_eulogy_rejects_structured_eulogy(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", ADMIN_KEY)
     db_path = tmp_path / "hall.db"
     hall_of_rust.init_hall_tables(str(db_path))
     client = _client_for(db_path)
@@ -90,6 +100,7 @@ def test_eulogy_rejects_structured_eulogy(tmp_path):
     response = client.post(
         "/hall/eulogy/fingerprint-1",
         json={"eulogy": ["served", "well"]},
+        headers=_HEADERS,
     )
 
     assert response.status_code == 400
@@ -112,6 +123,7 @@ def test_calculate_rust_score_uses_current_year_for_age_weight():
 
 
 def test_machine_of_the_day_uses_current_year_for_age(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", ADMIN_KEY)
     db_path = tmp_path / "hall.db"
     hall_of_rust.init_hall_tables(str(db_path))
     with sqlite3.connect(db_path) as conn:
@@ -128,7 +140,7 @@ def test_machine_of_the_day_uses_current_year_for_age(tmp_path, monkeypatch):
     monkeypatch.setattr(hall_of_rust, "_current_utc_year", lambda: 2026)
     client = _client_for(db_path)
 
-    response = client.get("/hall/machine_of_the_day")
+    response = client.get("/hall/machine_of_the_day", headers=_HEADERS)
 
     assert response.status_code == 200
     assert response.get_json()["age_years"] == 23

--- a/node/tests/test_hall_of_rust_limit_validation.py
+++ b/node/tests/test_hall_of_rust_limit_validation.py
@@ -2,8 +2,11 @@ from flask import Flask
 
 from node.hall_of_rust import hall_bp, init_hall_tables
 
+ADMIN_KEY = "0123456789abcdef0123456789abcdef"
 
-def _app_with_hall_db(tmp_path):
+
+def _app_with_hall_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", ADMIN_KEY)
     db_path = tmp_path / "hall.db"
     init_hall_tables(str(db_path))
 
@@ -13,56 +16,60 @@ def _app_with_hall_db(tmp_path):
     return app
 
 
-def test_leaderboard_rejects_non_integer_limit(tmp_path):
-    app = _app_with_hall_db(tmp_path)
-
-    response = app.test_client().get("/api/hall_of_fame/leaderboard?limit=abc")
-
-    assert response.status_code == 400
-    assert response.get_data(as_text=True) == "limit must be an integer"
+def _headers():
+    return {"X-Admin-Key": ADMIN_KEY}
 
 
-def test_legacy_leaderboard_rejects_non_integer_limit(tmp_path):
-    app = _app_with_hall_db(tmp_path)
+def test_leaderboard_rejects_non_integer_limit(tmp_path, monkeypatch):
+    app = _app_with_hall_db(tmp_path, monkeypatch)
 
-    response = app.test_client().get("/hall/leaderboard?limit=abc")
+    response = app.test_client().get("/api/hall_of_fame/leaderboard?limit=abc", headers=_headers())
 
     assert response.status_code == 400
     assert response.get_data(as_text=True) == "limit must be an integer"
 
 
-def test_leaderboard_rejects_negative_limit(tmp_path):
-    app = _app_with_hall_db(tmp_path)
+def test_legacy_leaderboard_rejects_non_integer_limit(tmp_path, monkeypatch):
+    app = _app_with_hall_db(tmp_path, monkeypatch)
 
-    response = app.test_client().get("/api/hall_of_fame/leaderboard?limit=-1")
+    response = app.test_client().get("/hall/leaderboard?limit=abc", headers=_headers())
+
+    assert response.status_code == 400
+    assert response.get_data(as_text=True) == "limit must be an integer"
+
+
+def test_leaderboard_rejects_negative_limit(tmp_path, monkeypatch):
+    app = _app_with_hall_db(tmp_path, monkeypatch)
+
+    response = app.test_client().get("/api/hall_of_fame/leaderboard?limit=-1", headers=_headers())
 
     assert response.status_code == 400
     assert response.get_data(as_text=True) == "limit must be non-negative"
 
 
-def test_legacy_leaderboard_rejects_negative_limit(tmp_path):
-    app = _app_with_hall_db(tmp_path)
+def test_legacy_leaderboard_rejects_negative_limit(tmp_path, monkeypatch):
+    app = _app_with_hall_db(tmp_path, monkeypatch)
 
-    response = app.test_client().get("/hall/leaderboard?limit=-1")
+    response = app.test_client().get("/hall/leaderboard?limit=-1", headers=_headers())
 
     assert response.status_code == 400
     assert response.get_data(as_text=True) == "limit must be non-negative"
 
 
-def test_leaderboard_uses_default_for_empty_limit(tmp_path):
-    app = _app_with_hall_db(tmp_path)
+def test_leaderboard_uses_default_for_empty_limit(tmp_path, monkeypatch):
+    app = _app_with_hall_db(tmp_path, monkeypatch)
 
-    response = app.test_client().get("/api/hall_of_fame/leaderboard?limit=")
+    response = app.test_client().get("/api/hall_of_fame/leaderboard?limit=", headers=_headers())
 
     assert response.status_code == 200
     assert response.get_json()["leaderboard"] == []
     assert response.get_json()["total_machines"] == 0
 
 
-def test_legacy_leaderboard_uses_default_for_empty_limit(tmp_path):
-    app = _app_with_hall_db(tmp_path)
+def test_legacy_leaderboard_uses_default_for_empty_limit(tmp_path, monkeypatch):
+    app = _app_with_hall_db(tmp_path, monkeypatch)
 
-    response = app.test_client().get("/hall/leaderboard?limit=")
+    response = app.test_client().get("/hall/leaderboard?limit=", headers=_headers())
 
     assert response.status_code == 200
     assert response.get_json()["leaderboard"] == []

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -50,12 +50,6 @@ node/gpu_render_endpoints.py:cols = {row[1] for row in db.execute("PRAGMA table_
 node/gpu_render_protocol.py:).fetchall()
 node/gpu_render_protocol.py:cols = {row[1] for row in conn.execute("PRAGMA table_info(render_escrow)").fetchall()}
 node/gpu_render_protocol.py:rows = conn.execute(query, params).fetchall()
-node/hall_of_rust.py:for r in c.fetchall()
-node/hall_of_rust.py:for r in c.fetchall()
-node/hall_of_rust.py:for row in c.fetchall():
-node/hall_of_rust.py:for row in c.fetchall():
-node/hall_of_rust.py:rows = c.fetchall()
-node/hall_of_rust.py:rows = c.fetchall()
 node/hardware_binding_v2.py:for row in c.fetchall():
 node/hardware_fingerprint_replay.py:collisions = c.fetchall()
 node/hardware_fingerprint_replay.py:history = c.fetchall()
@@ -69,20 +63,20 @@ node/machine_passport.py:""", (machine_id,)).fetchall()
 node/machine_passport.py:""", (machine_id,)).fetchall()
 node/machine_passport.py:""", params).fetchall()
 node/migrate_machine_passport.py:result['tables'] = [row[0] for row in cursor.fetchall()]
-node/payout_worker.py:""").fetchall()
-node/payout_worker.py:""").fetchall()
 node/payout_worker.py:""", (cutoff,)).fetchall()
 node/payout_worker.py:""", (limit,)).fetchall()
+node/payout_worker.py:""").fetchall()
+node/payout_worker.py:""").fetchall()
 node/proposer_duty_calendar.py:).fetchall()
 node/rewards_implementation_rip200.py:).fetchall()
-node/rip0202_evidence.py:rows = conn.execute(sql, params).fetchall()
+node/rip_200_round_robin_1cpu1vote_v2.py:epoch_miners = cursor.fetchall()
+node/rip_200_round_robin_1cpu1vote_v2.py:for row in cursor.fetchall():
 node/rip_200_round_robin_1cpu1vote.py:cols = cursor.execute("PRAGMA table_info(miner_attest_recent)").fetchall()
 node/rip_200_round_robin_1cpu1vote.py:enrolled = cursor.fetchall()
 node/rip_200_round_robin_1cpu1vote.py:epoch_miners = cursor.fetchall()
 node/rip_200_round_robin_1cpu1vote.py:return cursor.fetchall()
-node/rip_200_round_robin_1cpu1vote_v2.py:epoch_miners = cursor.fetchall()
-node/rip_200_round_robin_1cpu1vote_v2.py:for row in cursor.fetchall():
 node/rip_node_sync.py:return set(row[0] for row in cursor.fetchall())
+node/rip0202_evidence.py:rows = conn.execute(sql, params).fetchall()
 node/rom_clustering_server.py:duplicate_keys = [(row[0], row[1]) for row in cur.fetchall()]
 node/rom_clustering_server.py:for row in cur.fetchall():
 node/rom_clustering_server.py:for row in cur.fetchall():
@@ -95,8 +89,8 @@ node/rustchain_block_producer.py:for row in cursor.fetchall()
 node/rustchain_block_producer.py:for row in cursor.fetchall():
 node/rustchain_block_producer.py:for row in cursor.fetchall():
 node/rustchain_block_producer.py:return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
-node/rustchain_dashboard.py:""").fetchall()
 node/rustchain_dashboard.py:""", (epoch_data['epoch'],)).fetchall()
+node/rustchain_dashboard.py:""").fetchall()
 node/rustchain_ergo_anchor.py:anchors = [dict(row) for row in cursor.fetchall()]
 node/rustchain_ergo_anchor.py:for row in cursor.fetchall():
 node/rustchain_migration.py:attestations = cursor.fetchall()
@@ -106,11 +100,11 @@ node/rustchain_p2p_gossip.py:""").fetchall()
 node/rustchain_p2p_gossip.py:""").fetchall()
 node/rustchain_p2p_gossip.py:""").fetchall()
 node/rustchain_p2p_gossip.py:attested_miners = {row[0] for row in cursor.fetchall()}
+node/rustchain_p2p_sync_secure.py:return [row[0] for row in cursor.fetchall()]
+node/rustchain_p2p_sync_secure.py:rows = cursor.fetchall()
 node/rustchain_p2p_sync.py:""", (cutoff, cap)).fetchall()
 node/rustchain_p2p_sync.py:""", (cutoff, fresh_n)).fetchall()
 node/rustchain_p2p_sync.py:""", (start, limit)).fetchall()
-node/rustchain_p2p_sync_secure.py:return [row[0] for row in cursor.fetchall()]
-node/rustchain_p2p_sync_secure.py:rows = cursor.fetchall()
 node/rustchain_sync.py:data = [dict(row) for row in cursor.fetchall()]
 node/rustchain_sync.py:rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
 node/rustchain_sync.py:rows = cursor.fetchall()
@@ -121,30 +115,31 @@ node/rustchain_tx_handler.py:pending_nonces = {row["nonce"] for row in cursor.fe
 node/rustchain_tx_handler.py:return {row["nonce"] for row in cursor.fetchall()}
 node/rustchain_tx_handler.py:tables = {row[0] for row in cursor.fetchall()}
 node/rustchain_tx_handler.py:transactions = [dict(row) for row in cursor.fetchall()]
-node/rustchain_v2_integrated_v2.2.1_rip200.py:""").fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:""").fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:""").fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:""", (limit, offset)).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:WHERE active=1 ORDER BY signer_id""").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:_epoch_state_cols = {row[1] for row in c.execute("PRAGMA table_info(epoch_state)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:""", (limit, offset)).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:""").fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:""").fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:""").fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall():
 node/rustchain_v2_integrated_v2.2.1_rip200.py:cols = {r[1] for r in cur.execute("PRAGMA table_info(balances)").fetchall()}
 node/rustchain_v2_integrated_v2.2.1_rip200.py:columns = conn.execute("PRAGMA table_info(epoch_enroll)").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:for r in c.execute("PRAGMA table_info(balances)").fetchall():
@@ -153,14 +148,15 @@ node/rustchain_v2_integrated_v2.2.1_rip200.py:return {row[1] for row in c.execut
 node/rustchain_v2_integrated_v2.2.1_rip200.py:return {row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
 node/rustchain_v2_integrated_v2.2.1_rip200.py:rows = conn.execute("SELECT epoch, miner_pk, weight FROM epoch_enroll").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:WHERE active=1 ORDER BY signer_id""").fetchall()
 node/rustchain_x402.py:columns = {row[1] for row in conn.execute("PRAGMA table_info(balances)").fetchall()}
 node/rustchain_x402.py:existing = {row[1] for row in cursor.fetchall()}
 node/slashing_penalties.py:return tuple(row[1] for row in conn.execute(f'PRAGMA table_info("{table_name}")').fetchall())
 node/sophia_attestation_inspector.py:).fetchall()
 node/sophia_attestation_inspector.py:).fetchall()
 node/sophia_attestation_inspector.py:).fetchall()
-node/sophia_elya_service.py:columns = conn.execute("PRAGMA table_info(balances)").fetchall()
 node/sophia_elya_service.py:columns = {row[1] for row in conn.execute("PRAGMA table_info(epoch_state)").fetchall()}
+node/sophia_elya_service.py:columns = conn.execute("PRAGMA table_info(balances)").fetchall()
 node/sophia_governor_inbox.py:).fetchall()
 node/sophia_governor_inbox.py:).fetchall()
 node/sophia_governor_inbox.py:).fetchall()
@@ -176,5 +172,3 @@ node/utxo_db.py:).fetchall()
 node/utxo_db.py:rows = conn.execute(query, params).fetchall()
 node/utxo_genesis_migration.py:).fetchall()
 node/utxo_genesis_migration.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()


### PR DESCRIPTION
This PR adds the missing public consolidated Hall of Fame API endpoints (/api/hall_of_fame and /api/hall_of_fame/stats) for CLI/exporter/dashboard. Includes proper null/zero year filtering for oldest machine and monkeypatched environment variables in tests.