### PR TITLE
fix: harden claims page, miner setup wizard, and bridge dashboard DOM rendering (#7204, #7191, #7127)

### DIFF
--- a/docs/miner-setup-wizard/index.html
+++ b/docs/miner-setup-wizard/index.html
@@ -94,6 +94,37 @@ function h(value){
     .replace(/'/g,'&#39;');
 }
 
+/**
+ * Creates a status pill span + optional preformatted text block via DOM API.
+ * No innerHTML on caller-supplied text — prevents node-response XSS (#7191).
+ * @param {'ok'|'bad'|'warn'} pillClass - CSS class for the pill.
+ * @param {string} pillText - Text label inside the pill.
+ * @param {string} [preText] - Optional text to show in a <pre> block.
+ * @param {string} [noteText] - Optional muted note below the pre block.
+ * @returns {DocumentFragment}
+ */
+function makePillFragment(pillClass, pillText, preText, noteText){
+  const frag = document.createDocumentFragment();
+  const pill = document.createElement('span');
+  pill.className = 'pill ' + pillClass;
+  pill.textContent = pillText;
+  frag.appendChild(pill);
+  if(preText !== undefined){
+    const spacer = document.createTextNode(' ');
+    frag.appendChild(spacer);
+    const pre = document.createElement('pre');
+    pre.textContent = preText;
+    frag.appendChild(pre);
+  }
+  if(noteText){
+    const note = document.createElement('p');
+    note.className = 'muted';
+    note.textContent = noteText;
+    frag.appendChild(note);
+  }
+  return frag;
+}
+
 function detectPlatform(){
   const ua=navigator.userAgent.toLowerCase();
   state.platform = ua.includes('mac')?'macOS':ua.includes('win')?'Windows':ua.includes('linux')?'Linux':'Unknown';
@@ -213,13 +244,19 @@ function renderPanel(){
       <div id='testOut' class='check muted'>No test run yet.</div>
       <div class='row'><button class='btn' onclick="markDone('connect')">Done</button></div>`;
     setTimeout(()=>{
-      document.getElementById('testBtn').onclick = async ()=>{
+        document.getElementById('testBtn').onclick = async ()=>{
         const url = document.getElementById('testNodeUrl').value.trim();
         state.nodeUrl = url;
         const r = await testNode(url);
-        document.getElementById('testOut').innerHTML = r.ok
-          ? `<span class='pill ok'>Reachable</span> <pre>${h(r.text)}</pre>`
-          : `<span class='pill bad'>Failed</span> <pre>${h(r.text)}</pre><p class='muted'>If this is a CORS error, test with terminal: curl -sk ${h(url.replace(/\/$/,''))}/health</p>`;
+        // Render via DOM API — no innerHTML on node response text (issue #7191)
+        const testOut = document.getElementById('testOut');
+        testOut.textContent = '';
+        if(r.ok){
+          testOut.appendChild(makePillFragment('ok','Reachable', r.text));
+        } else {
+          const curlNote = `If this is a CORS error, test with terminal: curl -sk ${url.replace(/\/$/,'')}/health`;
+          testOut.appendChild(makePillFragment('bad','Failed', r.text, curlNote));
+        }
       }
     },0);
     return;
@@ -239,15 +276,34 @@ function renderPanel(){
       document.getElementById('checkMinerBtn').onclick = async ()=>{
         const q = document.getElementById('minerLookup').value.trim().toLowerCase();
         try{
-          const r = await fetch(state.nodeUrl.replace(/\/$/,'') + '/api/miners',{cache:'no-store'});
+          const r = await fetch(state.nodeUrl.replace(/\/$/, '') + '/api/miners',{cache:'no-store'});
           const data = await r.json();
           const arr = Array.isArray(data)?data:(data.miners||[]);
           const hit = arr.find(x=>JSON.stringify(x).toLowerCase().includes(q));
-          document.getElementById('minerOut').innerHTML = hit
-            ? `<span class='pill ok'>Found</span><pre>${h(JSON.stringify(hit,null,2))}</pre>`
-            : `<span class='pill warn'>Not found yet</span> <span class='muted'>Miner may still be attesting/enrolling.</span>`;
+          // Render via DOM API — no innerHTML on API response data (issue #7191)
+          const minerOut = document.getElementById('minerOut');
+          minerOut.textContent = '';
+          if(hit){
+            minerOut.appendChild(makePillFragment('ok','Found', JSON.stringify(hit,null,2)));
+          } else {
+            const frag = document.createDocumentFragment();
+            const warnPill = document.createElement('span');
+            warnPill.className = 'pill warn';
+            warnPill.textContent = 'Not found yet';
+            frag.appendChild(warnPill);
+            const spacer = document.createTextNode(' ');
+            frag.appendChild(spacer);
+            const note = document.createElement('span');
+            note.className = 'muted';
+            note.textContent = 'Miner may still be attesting/enrolling.';
+            frag.appendChild(note);
+            minerOut.appendChild(frag);
+          }
         }catch(e){
-          document.getElementById('minerOut').innerHTML = `<span class='pill bad'>Check failed</span><pre>${h(String(e))}</pre>`;
+          // Render error via DOM API — no innerHTML on exception text (issue #7191)
+          const minerOut = document.getElementById('minerOut');
+          minerOut.textContent = '';
+          minerOut.appendChild(makePillFragment('bad','Check failed', String(e)));
         }
       }
     },0);

--- a/docs/miner-setup-wizard/index.html
+++ b/docs/miner-setup-wizard/index.html
@@ -244,7 +244,7 @@ function renderPanel(){
       <div id='testOut' class='check muted'>No test run yet.</div>
       <div class='row'><button class='btn' onclick="markDone('connect')">Done</button></div>`;
     setTimeout(()=>{
-        document.getElementById('testBtn').onclick = async ()=>{
+      document.getElementById('testBtn').onclick = async ()=>{
         const url = document.getElementById('testNodeUrl').value.trim();
         state.nodeUrl = url;
         const r = await testNode(url);

--- a/static/bridge/dashboard.html
+++ b/static/bridge/dashboard.html
@@ -892,104 +892,47 @@
             return MOCK_DATA.price;
         }
 
-        // ─── Bridge API + Wallet Fallback (issue #7127) ──────────────────────
-        // When the native bridge API routes 404, fall back to the public wallet
-        // endpoints (GET /wallet/balance and /wallet/history) which ARE live.
-        // Never fall back to mock/demo data — show a degraded state instead.
-        const WALLET_API_BASE = 'https://rustchain.org';
-        const BRIDGE_ESCROW_ID = 'bridge-escrow';
-
-        /**
-         * Fetches bridge stats from the native API.
-         * Falls back to the public wallet/balance endpoint for escrow totals.
-         * Returns null if both sources are unavailable (triggers degraded UI).
-         * @returns {Promise<Object|null>}
-         */
         async function fetchBridgeStats() {
-            // 1) Try native bridge API
             try {
                 const resp = await fetch(`${CONFIG.BRIDGE_API}/stats`);
-                if (resp.ok) {
-                    const data = await resp.json();
-                    data._source = 'bridge-api';
-                    return data;
+                if (!resp.ok) {
+                    console.warn('Bridge API returned', resp.status);
+                    return MOCK_DATA.stats;
                 }
-            } catch (_) { /* fall through */ }
-
-            // 2) Fall back to /wallet/balance for escrow totals
-            try {
-                const resp = await fetch(
-                    `${WALLET_API_BASE}/wallet/balance?miner_id=${encodeURIComponent(BRIDGE_ESCROW_ID)}`
-                );
-                if (resp.ok) {
-                    const data = await resp.json();
-                    const balance = parseFloat(data.balance || data.confirmed_balance || 0);
-                    return {
-                        total_locked_rtc: balance,
-                        circulating_wrtc: balance,
-                        wrap_volume: parseFloat(data.total_received || 0),
-                        unwrap_volume: parseFloat(data.total_sent || 0),
-                        total_fees: 0,
-                        wrap_fees: 0,
-                        unwrap_fees: 0,
-                        _source: 'wallet-fallback',
-                    };
+                const ct = resp.headers.get('content-type') || '';
+                if (!ct.includes('application/json')) {
+                    console.warn('Bridge API returned non-JSON, using mock');
+                    return MOCK_DATA.stats;
                 }
-            } catch (_) { /* fall through */ }
-
-            return null;  // both sources unavailable
+                return await resp.json();
+            } catch (e) {
+                console.log('Bridge API unavailable, using mock data');
+                return MOCK_DATA.stats;
+            }
         }
 
-        /**
-         * Fetches the bridge ledger (transaction list).
-         * Falls back to /wallet/history for the escrow miner ID.
-         * Returns null if both sources are unavailable.
-         * @returns {Promise<Object|null>}
-         */
         async function fetchBridgeLedger() {
-            // 1) Try native bridge ledger API
             try {
                 const resp = await fetch(`${CONFIG.BRIDGE_API}/ledger?limit=50`);
-                if (resp.ok) {
-                    const data = await resp.json();
-                    data._source = 'bridge-api';
-                    return data;
+                if (!resp.ok) {
+                    console.warn('Bridge ledger returned', resp.status);
+                    return { locks: MOCK_DATA.transactions };
                 }
-            } catch (_) { /* fall through */ }
-
-            // 2) Fall back to /wallet/history for bridge escrow wallet
-            try {
-                const resp = await fetch(
-                    `${WALLET_API_BASE}/wallet/history?miner_id=${encodeURIComponent(BRIDGE_ESCROW_ID)}&limit=50`
-                );
-                if (resp.ok) {
-                    const hist = await resp.json();
-                    const entries = hist.history || hist.transactions || [];
-                    // Normalise wallet history entries to bridge lock schema
-                    const locks = entries.map(tx => ({
-                        lock_id: tx.tx_hash || tx.id || '',
-                        type: parseFloat(tx.amount || 0) > 0 ? 'wrap' : 'unwrap',
-                        sender: tx.from_miner || tx.miner_id || 'unknown',
-                        amount: Math.abs(parseFloat(tx.amount || 0)),
-                        target_chain: 'solana',
-                        state: tx.status || 'complete',
-                        timestamp: tx.timestamp || tx.created_at || Date.now(),
-                    }));
-                    return { locks, _source: 'wallet-fallback' };
+                const ct = resp.headers.get('content-type') || '';
+                if (!ct.includes('application/json')) {
+                    console.warn('Bridge ledger returned non-JSON, using mock');
+                    return { locks: MOCK_DATA.transactions };
                 }
-            } catch (_) { /* fall through */ }
-
-            return null;  // both sources unavailable
+                return await resp.json();
+            } catch (e) {
+                console.log('Bridge ledger unavailable, using mock data');
+                return { locks: MOCK_DATA.transactions };
+            }
         }
 
-        /**
-         * Fetches wRTC circulating supply.
-         * Currently sourced from bridge stats; expands to Solana RPC in future.
-         * @returns {Promise<number>}
-         */
         async function fetchwRTCSupply() {
-            // Placeholder — in production query Solana RPC for token supply
-            return 0;
+            // In production, this would query Solana RPC for token supply
+            return MOCK_DATA.stats.circulating_wrtc;
         }
 
         // 鈹€鈹€鈹€ UI Update Functions 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
@@ -1177,33 +1120,6 @@
             return allowed.includes(token) ? token : fallback;
         }
 
-        /**
-         * Shows or hides the degraded-state banner.
-         * @param {boolean} show - True to show degraded banner.
-         * @param {string} [reason] - Optional reason text.
-         */
-        function setDegradedBanner(show, reason) {
-            let banner = document.getElementById('degraded-banner');
-            if (!banner) {
-                banner = document.createElement('div');
-                banner.id = 'degraded-banner';
-                banner.setAttribute('style',
-                    'background:#7c2d12;color:#fef3c7;padding:10px 16px;border-radius:8px;' +
-                    'margin:8px 0 16px;font-size:13px;display:none;');
-                const container = document.querySelector('.dashboard-container') ||
-                                  document.querySelector('.container') ||
-                                  document.body.firstElementChild;
-                if (container) container.prepend(banner);
-            }
-            if (show) {
-                banner.textContent = '⚠ Bridge API unavailable' + (reason ? ` — ${reason}` : '') +
-                    '. Showing live escrow wallet data. Transaction history may be incomplete.';
-                banner.style.display = 'block';
-            } else {
-                banner.style.display = 'none';
-            }
-        }
-
         function formatNumber(num) {
             return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(num || 0);
         }
@@ -1237,9 +1153,8 @@
         }
 
         /**
-         * Main data refresh — fetches real data and updates all UI sections.
-         * Falls back to wallet endpoints when bridge API routes 404.
-         * Never renders mock/demo data — shows a degraded state instead.
+         * Main data refresh — fetches data and updates all UI sections.
+         * Uses mock data when bridge API is unavailable.
          */
         async function refreshAll() {
             try {
@@ -1249,36 +1164,14 @@
                     fetchBridgeLedger()
                 ]);
 
-                const statsAvailable = stats !== null;
-                const ledgerAvailable = ledger !== null;
-                const usingFallback = (stats && stats._source === 'wallet-fallback') ||
-                                     (ledger && ledger._source === 'wallet-fallback');
-
-                if (!statsAvailable && !ledgerAvailable) {
-                    setDegradedBanner(true, 'bridge escrow wallet data also unavailable');
-                } else if (usingFallback) {
-                    setDegradedBanner(true, 'showing escrow wallet fallback data');
-                } else {
-                    setDegradedBanner(false);
-                }
-
-                // Only update UI sections when real data is available
-                if (statsAvailable) {
-                    updateStats(stats);
-                    updateFees(stats);
-                }
-
+                updateStats(stats);
+                updateFees(stats);
                 updatePriceInfo(price);
-                updateHealth(null);  // health endpoints not available; show unknown state
-
-                if (ledgerAvailable) {
-                    updateTransactions(ledger.locks || []);
-                }
-
+                updateHealth(null);
+                updateTransactions(ledger.locks || []);
                 updateLastRefresh();
             } catch (e) {
                 console.error('Refresh error:', e);
-                setDegradedBanner(true, e.message);
             }
         }
 

--- a/static/bridge/dashboard.html
+++ b/static/bridge/dashboard.html
@@ -892,29 +892,104 @@
             return MOCK_DATA.price;
         }
 
+        // ─── Bridge API + Wallet Fallback (issue #7127) ──────────────────────
+        // When the native bridge API routes 404, fall back to the public wallet
+        // endpoints (GET /wallet/balance and /wallet/history) which ARE live.
+        // Never fall back to mock/demo data — show a degraded state instead.
+        const WALLET_API_BASE = 'https://rustchain.org';
+        const BRIDGE_ESCROW_ID = 'bridge-escrow';
+
+        /**
+         * Fetches bridge stats from the native API.
+         * Falls back to the public wallet/balance endpoint for escrow totals.
+         * Returns null if both sources are unavailable (triggers degraded UI).
+         * @returns {Promise<Object|null>}
+         */
         async function fetchBridgeStats() {
+            // 1) Try native bridge API
             try {
                 const resp = await fetch(`${CONFIG.BRIDGE_API}/stats`);
-                return await resp.json();
-            } catch (e) {
-                console.log('Bridge API unavailable, using mock data');
-                return MOCK_DATA.stats;
-            }
+                if (resp.ok) {
+                    const data = await resp.json();
+                    data._source = 'bridge-api';
+                    return data;
+                }
+            } catch (_) { /* fall through */ }
+
+            // 2) Fall back to /wallet/balance for escrow totals
+            try {
+                const resp = await fetch(
+                    `${WALLET_API_BASE}/wallet/balance?miner_id=${encodeURIComponent(BRIDGE_ESCROW_ID)}`
+                );
+                if (resp.ok) {
+                    const data = await resp.json();
+                    const balance = parseFloat(data.balance || data.confirmed_balance || 0);
+                    return {
+                        total_locked_rtc: balance,
+                        circulating_wrtc: balance,
+                        wrap_volume: parseFloat(data.total_received || 0),
+                        unwrap_volume: parseFloat(data.total_sent || 0),
+                        total_fees: 0,
+                        wrap_fees: 0,
+                        unwrap_fees: 0,
+                        _source: 'wallet-fallback',
+                    };
+                }
+            } catch (_) { /* fall through */ }
+
+            return null;  // both sources unavailable
         }
 
+        /**
+         * Fetches the bridge ledger (transaction list).
+         * Falls back to /wallet/history for the escrow miner ID.
+         * Returns null if both sources are unavailable.
+         * @returns {Promise<Object|null>}
+         */
         async function fetchBridgeLedger() {
+            // 1) Try native bridge ledger API
             try {
                 const resp = await fetch(`${CONFIG.BRIDGE_API}/ledger?limit=50`);
-                return await resp.json();
-            } catch (e) {
-                console.log('Bridge ledger unavailable, using mock data');
-                return { locks: MOCK_DATA.transactions };
-            }
+                if (resp.ok) {
+                    const data = await resp.json();
+                    data._source = 'bridge-api';
+                    return data;
+                }
+            } catch (_) { /* fall through */ }
+
+            // 2) Fall back to /wallet/history for bridge escrow wallet
+            try {
+                const resp = await fetch(
+                    `${WALLET_API_BASE}/wallet/history?miner_id=${encodeURIComponent(BRIDGE_ESCROW_ID)}&limit=50`
+                );
+                if (resp.ok) {
+                    const hist = await resp.json();
+                    const entries = hist.history || hist.transactions || [];
+                    // Normalise wallet history entries to bridge lock schema
+                    const locks = entries.map(tx => ({
+                        lock_id: tx.tx_hash || tx.id || '',
+                        type: parseFloat(tx.amount || 0) > 0 ? 'wrap' : 'unwrap',
+                        sender: tx.from_miner || tx.miner_id || 'unknown',
+                        amount: Math.abs(parseFloat(tx.amount || 0)),
+                        target_chain: 'solana',
+                        state: tx.status || 'complete',
+                        timestamp: tx.timestamp || tx.created_at || Date.now(),
+                    }));
+                    return { locks, _source: 'wallet-fallback' };
+                }
+            } catch (_) { /* fall through */ }
+
+            return null;  // both sources unavailable
         }
 
+        /**
+         * Fetches wRTC circulating supply.
+         * Currently sourced from bridge stats; expands to Solana RPC in future.
+         * @returns {Promise<number>}
+         */
         async function fetchwRTCSupply() {
-            // In production, this would query Solana RPC for token supply
-            return MOCK_DATA.stats.circulating_wrtc;
+            // Placeholder — in production query Solana RPC for token supply
+            return 0;
         }
 
         // 鈹€鈹€鈹€ UI Update Functions 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
@@ -1102,6 +1177,33 @@
             return allowed.includes(token) ? token : fallback;
         }
 
+        /**
+         * Shows or hides the degraded-state banner.
+         * @param {boolean} show - True to show degraded banner.
+         * @param {string} [reason] - Optional reason text.
+         */
+        function setDegradedBanner(show, reason) {
+            let banner = document.getElementById('degraded-banner');
+            if (!banner) {
+                banner = document.createElement('div');
+                banner.id = 'degraded-banner';
+                banner.setAttribute('style',
+                    'background:#7c2d12;color:#fef3c7;padding:10px 16px;border-radius:8px;' +
+                    'margin:8px 0 16px;font-size:13px;display:none;');
+                const container = document.querySelector('.dashboard-container') ||
+                                  document.querySelector('.container') ||
+                                  document.body.firstElementChild;
+                if (container) container.prepend(banner);
+            }
+            if (show) {
+                banner.textContent = '⚠ Bridge API unavailable' + (reason ? ` — ${reason}` : '') +
+                    '. Showing live escrow wallet data. Transaction history may be incomplete.';
+                banner.style.display = 'block';
+            } else {
+                banner.style.display = 'none';
+            }
+        }
+
         function formatNumber(num) {
             return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(num || 0);
         }
@@ -1134,7 +1236,11 @@
             document.getElementById('lastUpdate').textContent = 'Last sync: ' + now.toLocaleTimeString();
         }
 
-        // 鈹€鈹€鈹€ Main Refresh Function 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
+        /**
+         * Main data refresh — fetches real data and updates all UI sections.
+         * Falls back to wallet endpoints when bridge API routes 404.
+         * Never renders mock/demo data — shows a degraded state instead.
+         */
         async function refreshAll() {
             try {
                 const [price, stats, ledger] = await Promise.all([
@@ -1143,15 +1249,36 @@
                     fetchBridgeLedger()
                 ]);
 
-                updateStats(MOCK_DATA.stats);
+                const statsAvailable = stats !== null;
+                const ledgerAvailable = ledger !== null;
+                const usingFallback = (stats && stats._source === 'wallet-fallback') ||
+                                     (ledger && ledger._source === 'wallet-fallback');
+
+                if (!statsAvailable && !ledgerAvailable) {
+                    setDegradedBanner(true, 'bridge escrow wallet data also unavailable');
+                } else if (usingFallback) {
+                    setDegradedBanner(true, 'showing escrow wallet fallback data');
+                } else {
+                    setDegradedBanner(false);
+                }
+
+                // Only update UI sections when real data is available
+                if (statsAvailable) {
+                    updateStats(stats);
+                    updateFees(stats);
+                }
+
                 updatePriceInfo(price);
-                updateFees(MOCK_DATA.stats);
-                updateHealth(MOCK_DATA.health);
-                updateTransactions(ledger.locks || MOCK_DATA.transactions);
+                updateHealth(null);  // health endpoints not available; show unknown state
+
+                if (ledgerAvailable) {
+                    updateTransactions(ledger.locks || []);
+                }
 
                 updateLastRefresh();
             } catch (e) {
                 console.error('Refresh error:', e);
+                setDegradedBanner(true, e.message);
             }
         }
 

--- a/tests/test_claims_dom_hardening_7204.py
+++ b/tests/test_claims_dom_hardening_7204.py
@@ -1,0 +1,151 @@
+"""
+Tests for Claims Page DOM rendering security hardening (Issue #7204).
+
+Verifies that web/claims/claims.js v2 (post-hardening):
+- No longer uses innerHTML template literals for API-sourced dynamic values
+- Uses DOM API helpers: makeEl, makeSummaryRow, makeCheckItem
+- CSV export quotes cells to prevent formula injection
+
+SPDX-License-Identifier: MIT
+"""
+
+import re
+import subprocess
+import pytest
+from pathlib import Path
+
+
+CLAIMS_JS = Path(__file__).resolve().parents[1] / "web" / "claims" / "claims.js"
+
+
+@pytest.fixture(scope="module")
+def claims_js_source():
+    """Read the claims.js source once for all tests in this module."""
+    return CLAIMS_JS.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. No dynamic innerHTML sinks on API data
+# ---------------------------------------------------------------------------
+
+class TestClaimsJsDomSafety:
+    """Verify claims.js uses DOM API, not innerHTML, for API-sourced data."""
+
+    def test_no_dynamic_innerhtml_template_literal(self, claims_js_source):
+        """
+        No .innerHTML = `...${...}...` pattern should exist in claims.js.
+
+        Such patterns route API response values through the HTML parser, creating
+        a DOM XSS sink regardless of manual escaping.
+        """
+        dynamic_sink = re.compile(r'\.innerHTML\s*=\s*`[^`]*\$\{', re.MULTILINE)
+        matches = dynamic_sink.findall(claims_js_source)
+        assert not matches, (
+            f"Found {len(matches)} dynamic innerHTML template literal(s):\n"
+            + "\n".join(repr(m) for m in matches[:5])
+        )
+
+    def test_dom_helpers_defined(self, claims_js_source):
+        """Safe DOM builder functions must be defined."""
+        assert "function makeEl(" in claims_js_source, "makeEl() helper missing"
+        assert "function makeSummaryRow(" in claims_js_source, "makeSummaryRow() helper missing"
+        assert "function makeCheckItem(" in claims_js_source, "makeCheckItem() helper missing"
+
+    def test_eligibility_result_cleared_safely(self, claims_js_source):
+        """renderEligibilityResult() clears its container via textContent."""
+        assert "eligibilityResult.textContent = ''" in claims_js_source
+
+    def test_claim_history_cleared_safely(self, claims_js_source):
+        """renderClaimHistory() clears tbody via textContent."""
+        assert "tbody.textContent = ''" in claims_js_source
+
+    def test_claim_summary_cleared_safely(self, claims_js_source):
+        """renderClaimSummary() clears its container via textContent."""
+        assert "claimSummary.textContent = ''" in claims_js_source
+
+    def test_submit_success_no_dynamic_innerhtml(self, claims_js_source):
+        """handleSubmitClaim() must not use innerHTML for the success message."""
+        # Verify the function exists in the file
+        assert "async function handleSubmitClaim()" in claims_js_source, \
+            "handleSubmitClaim() not found in claims.js"
+
+        # Check that the successEl / submitSuccess block doesn't use innerHTML
+        # with dynamic template literals anywhere in the file
+        dynamic_sink = re.compile(r'submitSuccess.*?\.innerHTML\s*=\s*`[^`]*\$\{', re.DOTALL)
+        matches = dynamic_sink.findall(claims_js_source)
+        assert not matches, \
+            "submitSuccess element still uses dynamic innerHTML template literal"
+
+    def test_history_cells_use_textcontent(self, claims_js_source):
+        """Table cells in renderClaimHistory() use textContent, not innerHTML."""
+        assert "tdId.textContent" in claims_js_source or \
+               "td.textContent" in claims_js_source, \
+            "History table cells should set text via .textContent"
+
+
+# ---------------------------------------------------------------------------
+# 2. Epoch select built via DOM API
+# ---------------------------------------------------------------------------
+
+class TestEpochSelectSafety:
+    """Epoch <select> populated via createElement, not innerHTML strings."""
+
+    def test_epoch_options_via_createelement(self, claims_js_source):
+        """renderEpochSelect() creates <option> via createElement."""
+        assert "createElement('option')" in claims_js_source or \
+               'createElement("option")' in claims_js_source, \
+            "Epoch options should be created with createElement('option')"
+
+    def test_epoch_option_text_via_textcontent(self, claims_js_source):
+        """Option label is assigned via textContent."""
+        assert re.search(r'opt\.textContent\s*=', claims_js_source), \
+            "Epoch option text should be set via opt.textContent"
+
+    def test_reset_form_clears_options_safely(self, claims_js_source):
+        """resetForm() rebuilds default option via createElement, not innerHTML."""
+        fn_match = re.search(
+            r'function resetForm\(\)(.*?)^\}',
+            claims_js_source,
+            re.DOTALL | re.MULTILINE,
+        )
+        if fn_match:
+            fn_body = fn_match.group(1)
+            # Must NOT use innerHTML to set epoch options
+            assert ".innerHTML = '<option" not in fn_body and \
+                   '.innerHTML = "<option' not in fn_body, \
+                "resetForm() should not use innerHTML to set the epoch placeholder option"
+
+
+# ---------------------------------------------------------------------------
+# 3. CSV formula injection prevention
+# ---------------------------------------------------------------------------
+
+class TestClaimsJsCsvSafety:
+    """CSV export quotes cells to prevent spreadsheet formula injection."""
+
+    def test_csv_escape_function_present(self, claims_js_source):
+        """A CSV cell-quoting escape helper must exist in handleExportHistory()."""
+        assert "const escape = v =>" in claims_js_source or \
+               "const escape=v=>" in claims_js_source, \
+            "CSV escape helper missing in handleExportHistory()"
+
+    def test_csv_double_quote_escape(self, claims_js_source):
+        """Embedded double-quotes must be doubled for RFC 4180 compliance."""
+        assert '.replace(/"/g, \'""\')'  in claims_js_source or \
+               '.replace(/"/g,\'""\')'  in claims_js_source, \
+            "CSV escape must double embedded double-quotes"
+
+
+# ---------------------------------------------------------------------------
+# 4. Syntax validity via Node.js
+# ---------------------------------------------------------------------------
+
+def test_claims_js_syntax_valid():
+    """node --check must pass (no JS parse errors)."""
+    result = subprocess.run(
+        ["node", "--check", str(CLAIMS_JS)],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert result.returncode == 0, (
+        f"node --check claims.js failed:\n{result.stderr}"
+    )

--- a/tests/test_claims_frontend_security.py
+++ b/tests/test_claims_frontend_security.py
@@ -1,49 +1,187 @@
+"""
+Tests for claims page DOM-rendering security (issue #7204).
+
+The implementation was upgraded from innerHTML + escapeHtml() helper to a
+full DOM-API approach (createElement / textContent / appendChild). These
+tests assert the *security property* — no innerHTML sink on dynamic API data
+— rather than the specific helper function that was in the old implementation.
+"""
+
+import re
 from pathlib import Path
 
 
-def test_claims_page_escapes_api_and_user_fields_before_inner_html():
-    claims_js = Path(__file__).resolve().parents[1] / "web" / "claims" / "claims.js"
-    script = claims_js.read_text(encoding="utf-8")
+CLAIMS_JS = Path(__file__).resolve().parents[1] / "web" / "claims" / "claims.js"
 
-    assert "function escapeHtml(value)" in script
-    assert "function safeCssClass(value)" in script
-    assert "function safeNumber(value, fallback = 0)" in script
-    assert "function safeInteger(value, fallback = 0)" in script
 
-    safe_patterns = [
-        "${escapeHtml(eligibility.miner_id)}",
-        "${escapeHtml(eligibility.attestation?.device_arch || 'N/A')}",
-        "${escapeHtml(eligibility.wallet_address || 'Not registered')}",
-        "Reason: ${escapeHtml(eligibility.reason || 'Unknown')}",
-        "${escapeHtml(formatCheckName(check))}",
-        'value="${safeInteger(epoch.epoch)}"',
-        'data-reward="${safeInteger(epoch.reward_urtc)}"',
-        "${escapeHtml(minerId)}",
-        "${escapeHtml(walletAddress)}",
-        "${escapeHtml(claim.claim_id)}",
-        'class="status-badge ${safeCssClass(claim.status)}"',
-        "${escapeHtml(claim.status)}",
-        "${escapeHtml(result.claim_id)}",
+def _source():
+    """Return the current claims.js source text."""
+    return CLAIMS_JS.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. No dynamic innerHTML sinks on API-sourced data
+# ---------------------------------------------------------------------------
+
+
+def test_claims_page_no_dynamic_innerHTML_template_literals():
+    """
+    Asserts that no innerHTML template-literal sinks exist in claims.js.
+
+    A pattern like:
+        someEl.innerHTML = `...${apiField}...`
+    routes API response values through the HTML parser regardless of escaping,
+    creating a DOM XSS sink. The rewrite eliminates this entirely by using
+    createElement/textContent/appendChild instead.
+    """
+    source = _source()
+    dynamic_sink = re.compile(r"\.innerHTML\s*=\s*`[^`]*\$\{", re.MULTILINE)
+    matches = dynamic_sink.findall(source)
+    assert not matches, (
+        f"Found {len(matches)} dynamic innerHTML template literal(s) in claims.js. "
+        "All dynamic data from API responses must be rendered via the DOM API "
+        "(createElement / textContent / appendChild)."
+    )
+
+
+def test_claims_page_no_concat_innerHTML_on_api_data():
+    """
+    Asserts there are no string-concatenation innerHTML sinks for API data.
+
+    e.g.  el.innerHTML += "..." + apiValue  is forbidden.
+    """
+    source = _source()
+    # Look for innerHTML += or innerHTML = "..." + variable patterns
+    concat_sink = re.compile(r"\.innerHTML\s*\+?=\s*[\"'][^\"']*[\"']\s*\+", re.MULTILINE)
+    matches = concat_sink.findall(source)
+    assert not matches, (
+        f"Found {len(matches)} string-concatenation innerHTML sink(s) in claims.js."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. DOM-API rendering helpers are present
+# ---------------------------------------------------------------------------
+
+
+def test_claims_page_dom_helper_makeEl_defined():
+    """The makeEl() DOM builder helper must be defined."""
+    assert "function makeEl(" in _source(), \
+        "makeEl() DOM helper is missing from claims.js"
+
+
+def test_claims_page_dom_helper_makeSummaryRow_defined():
+    """The makeSummaryRow() DOM builder helper must be defined."""
+    assert "function makeSummaryRow(" in _source(), \
+        "makeSummaryRow() DOM helper is missing from claims.js"
+
+
+def test_claims_page_dom_helper_makeCheckItem_defined():
+    """The makeCheckItem() DOM builder helper must be defined."""
+    assert "function makeCheckItem(" in _source(), \
+        "makeCheckItem() DOM helper is missing from claims.js"
+
+
+# ---------------------------------------------------------------------------
+# 3. Specific render functions use DOM API (no innerHTML on containers)
+# ---------------------------------------------------------------------------
+
+
+def test_claims_page_eligibility_cleared_via_textcontent():
+    """renderEligibilityResult() clears its container via textContent, not innerHTML."""
+    assert "eligibilityResult.textContent = ''" in _source(), \
+        "renderEligibilityResult() must clear container via textContent"
+
+
+def test_claims_page_claim_summary_cleared_via_textcontent():
+    """renderClaimSummary() clears its container via textContent, not innerHTML."""
+    assert "claimSummary.textContent = ''" in _source(), \
+        "renderClaimSummary() must clear container via textContent"
+
+
+def test_claims_page_history_tbody_cleared_via_textcontent():
+    """renderClaimHistory() clears the table body via textContent, not innerHTML."""
+    assert "tbody.textContent = ''" in _source(), \
+        "renderClaimHistory() must clear tbody via textContent"
+
+
+# ---------------------------------------------------------------------------
+# 4. Epoch <select> populated via DOM API
+# ---------------------------------------------------------------------------
+
+
+def test_claims_page_epoch_option_via_createElement():
+    """
+    Epoch <option> elements must be created via createElement, not via an
+    innerHTML string that embeds epoch numbers from the API response.
+    """
+    source = _source()
+    assert "createElement('option')" in source or 'createElement("option")' in source, \
+        "Epoch options must be created with createElement('option')"
+
+
+def test_claims_page_epoch_option_text_via_textcontent():
+    """Epoch option text must be assigned via textContent."""
+    assert re.search(r"opt\.textContent\s*=", _source()), \
+        "Epoch option text should be set via opt.textContent"
+
+
+# ---------------------------------------------------------------------------
+# 5. No unescaped API fields directly in unsafe sinks
+# ---------------------------------------------------------------------------
+
+
+def test_claims_page_no_bare_api_fields_in_innerHTML():
+    """
+    Asserts the specific unsafe bare-interpolation patterns from the original
+    implementation are no longer used **inside innerHTML template literals**.
+
+    Template literals used with textContent are safe and allowed.
+    Only innerHTML sinks that embed raw API values are forbidden.
+
+    Previously unsafe (removed in the DOM-API rewrite):
+        someEl.innerHTML = `...${eligibility.miner_id}...`
+        someEl.innerHTML = `...${claim.claim_id}...`
+    """
+    source = _source()
+
+    # Regex: find innerHTML = `...pattern...` contexts
+    # We look for .innerHTML = ` ... ` blocks containing the raw field names
+    inner_html_blocks = re.findall(r"\.innerHTML\s*=\s*`[^`]*`", source, re.DOTALL)
+
+    unsafe_fields_in_html = [
+        "eligibility.miner_id",
+        "eligibility.attestation",
+        "eligibility.wallet_address",
+        "eligibility.reason",
+        "epoch.epoch",
+        "epoch.reward_urtc",
+        "claim.claim_id",
+        "claim.status",
+        "result.claim_id",
     ]
 
-    for pattern in safe_patterns:
-        assert pattern in script
+    for block in inner_html_blocks:
+        for field in unsafe_fields_in_html:
+            assert field not in block, (
+                f"API field {field!r} found directly inside an innerHTML template literal — "
+                "use createElement/textContent instead."
+            )
 
-    unsafe_patterns = [
-        "${eligibility.miner_id}",
-        "${eligibility.attestation?.device_arch || 'N/A'}",
-        "${eligibility.wallet_address || 'Not registered'}",
-        "Reason: ${eligibility.reason || 'Unknown'}",
-        "${check.replace(/_/g, ' ').replace(/\\b\\w/g, l => l.toUpperCase())}",
-        'value="${epoch.epoch}"',
-        'data-reward="${epoch.reward_urtc}"',
-        "${minerId}</span>",
-        "${walletAddress}</span>",
-        "${claim.claim_id}",
-        'class="status-badge ${claim.status}"',
-        "${claim.status}</span>",
-        "${result.claim_id}</code>",
-    ]
 
-    for pattern in unsafe_patterns:
-        assert pattern not in script
+# ---------------------------------------------------------------------------
+# 6. CSV export quotes cells (formula injection prevention)
+# ---------------------------------------------------------------------------
+
+
+def test_claims_page_csv_cells_quoted():
+    """handleExportHistory() must quote CSV cells to prevent formula injection."""
+    source = _source()
+    assert "const escape = v =>" in source or "const escape=v=>" in source, \
+        "CSV export must have a cell-quoting escape function"
+
+
+def test_claims_page_csv_double_quotes_escaped():
+    """Embedded double-quotes in CSV must be doubled for RFC 4180 compliance."""
+    assert '.replace(/"/g, \'""\')' in _source() or ".replace(/\"/g,'\"\"')" in _source(), \
+        "CSV escape must double embedded double-quotes"

--- a/tests/test_miner_setup_docs_wizard_dom_hardening_7191.py
+++ b/tests/test_miner_setup_docs_wizard_dom_hardening_7191.py
@@ -1,0 +1,184 @@
+"""
+Tests for Miner Setup Wizard DOM rendering security hardening (Issue #7191).
+
+Verifies that docs/miner-setup-wizard/index.html:
+- Introduces the makePillFragment() DOM helper for node response rendering
+- Does not use innerHTML to render remote node /health or /api/miners responses
+- Uses textContent/createElement for testOut and minerOut panels
+
+SPDX-License-Identifier: MIT
+"""
+
+import re
+import subprocess
+import pytest
+from pathlib import Path
+
+
+WIZARD_HTML = (
+    Path(__file__).resolve().parents[1]
+    / "docs"
+    / "miner-setup-wizard"
+    / "index.html"
+)
+
+
+@pytest.fixture(scope="module")
+def wizard_source():
+    """Read the wizard HTML source once for all tests in this module."""
+    return WIZARD_HTML.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. makePillFragment helper present
+# ---------------------------------------------------------------------------
+
+class TestMakePillFragmentHelper:
+    """The safe DOM helper makePillFragment() must be defined."""
+
+    def test_make_pill_fragment_defined(self, wizard_source):
+        """makePillFragment() is defined in the wizard script."""
+        assert "function makePillFragment(" in wizard_source, \
+            "makePillFragment() DOM helper is missing from the wizard"
+
+    def test_make_pill_fragment_uses_textcontent(self, wizard_source):
+        """makePillFragment() sets pill label via textContent."""
+        # Extract the function body
+        fn_match = re.search(
+            r'function makePillFragment\((.*?)\}\s*\n',
+            wizard_source,
+            re.DOTALL,
+        )
+        if fn_match:
+            fn_body = fn_match.group(0)
+            assert ".textContent = " in fn_body, \
+                "makePillFragment() must set pill text via textContent"
+            assert ".innerHTML" not in fn_body, \
+                "makePillFragment() must not use innerHTML"
+
+    def test_make_pill_fragment_uses_createelement(self, wizard_source):
+        """makePillFragment() builds DOM elements with createElement."""
+        fn_match = re.search(
+            r'function makePillFragment\((.*?)\}\s*\n',
+            wizard_source,
+            re.DOTALL,
+        )
+        if fn_match:
+            fn_body = fn_match.group(0)
+            assert "createElement(" in fn_body, \
+                "makePillFragment() must use createElement to build elements"
+
+
+# ---------------------------------------------------------------------------
+# 2. testOut (node /health response) — no innerHTML on remote data
+# ---------------------------------------------------------------------------
+
+class TestTestOutSafety:
+    """testOut div must be populated via DOM API, not innerHTML."""
+
+    def test_testout_no_innerHTML_assignment(self, wizard_source):
+        """
+        The 'testOut' assignment block must not use innerHTML for the
+        remote node /health response body (issue #7191).
+        """
+        # Locate the testBtn onclick block
+        testbtn_match = re.search(
+            r"testBtn.*?onclick\s*=\s*async\s*\(\)\s*=>\s*\{(.*?)^\s+\}",
+            wizard_source,
+            re.DOTALL | re.MULTILINE,
+        )
+        if testbtn_match:
+            block = testbtn_match.group(1)
+            innerhtml_with_template = re.compile(r"testOut.*?innerHTML\s*=\s*[r`'\"]", re.DOTALL)
+            assert not innerhtml_with_template.search(block), \
+                "testOut must not be populated via innerHTML on node response"
+
+    def test_testout_uses_textcontent_or_appendchild(self, wizard_source):
+        """testOut must be cleared/filled via textContent or appendChild."""
+        assert "testOut.textContent = ''" in wizard_source or \
+               "testOut.appendChild(" in wizard_source, \
+            "testOut should be cleared with textContent and filled with appendChild"
+
+    def test_testout_uses_makepillfragment(self, wizard_source):
+        """testOut should delegate rendering to makePillFragment()."""
+        assert "makePillFragment(" in wizard_source, \
+            "The wizard should use makePillFragment() for testOut rendering"
+
+
+# ---------------------------------------------------------------------------
+# 3. minerOut (/api/miners response) — no innerHTML on remote data
+# ---------------------------------------------------------------------------
+
+class TestMinerOutSafety:
+    """minerOut div must be populated via DOM API, not innerHTML."""
+
+    def test_minerout_no_innerHTML_on_api_data(self, wizard_source):
+        """
+        The 'minerOut' block must not use innerHTML with dynamic API response
+        values (issue #7191).
+        """
+        # Find any remaining innerHTML assignments targeting minerOut
+        innerhtml_pattern = re.compile(
+            r"minerOut\b.*?\.innerHTML\s*=\s*[`'\"].*?\$\{",
+            re.DOTALL,
+        )
+        matches = innerhtml_pattern.findall(wizard_source)
+        assert not matches, \
+            "minerOut must not use innerHTML with interpolated API values"
+
+    def test_minerout_cleared_via_textcontent(self, wizard_source):
+        """minerOut is cleared via textContent before re-population."""
+        assert "minerOut.textContent = ''" in wizard_source, \
+            "minerOut should be cleared with minerOut.textContent = ''"
+
+    def test_minerout_not_found_uses_textcontent(self, wizard_source):
+        """'Not found yet' message uses textContent, not innerHTML."""
+        # The "Not found" branch must use textContent for user-visible text
+        assert re.search(r"warnPill\.textContent\s*=\s*['\"]Not found yet['\"]", wizard_source), \
+            "'Not found yet' pill text should be set via textContent"
+
+
+# ---------------------------------------------------------------------------
+# 4. h() escaper still present for static template use
+# ---------------------------------------------------------------------------
+
+def test_h_escape_function_present(wizard_source):
+    """The h() HTML escaper must still be defined for static template contexts."""
+    assert "function h(value)" in wizard_source, \
+        "h() escaper function should still exist in the wizard"
+
+
+# ---------------------------------------------------------------------------
+# 5. Syntax validity via Node.js inline script check
+# ---------------------------------------------------------------------------
+
+def test_wizard_html_script_syntax_valid():
+    """
+    Extracts the inline <script> block and checks it for JS parse errors.
+    Uses node --check on the extracted script content.
+    """
+    import tempfile, os
+
+    source = WIZARD_HTML.read_text(encoding="utf-8")
+    # Extract content between <script> and </script>
+    script_match = re.search(r'<script>(.*?)</script>', source, re.DOTALL)
+    assert script_match, "No <script> block found in wizard HTML"
+
+    script_content = script_match.group(1)
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".js", delete=False, encoding="utf-8"
+    ) as tmp:
+        tmp.write(script_content)
+        tmp_path = tmp.name
+
+    try:
+        result = subprocess.run(
+            ["node", "--check", tmp_path],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0, (
+            f"JS syntax error in wizard script:\n{result.stderr}"
+        )
+    finally:
+        os.unlink(tmp_path)

--- a/tests/test_miner_setup_docs_wizard_security.py
+++ b/tests/test_miner_setup_docs_wizard_security.py
@@ -1,3 +1,14 @@
+"""
+Tests for miner setup wizard DOM-rendering security (issue #7191).
+
+The implementation was upgraded from innerHTML + h() escaper to a DOM-API
+approach using the makePillFragment() helper (createElement / textContent /
+DocumentFragment). These tests assert the *security property* — no innerHTML
+sink on remote node response data — rather than specific string patterns
+from the old implementation.
+"""
+
+import re
 from pathlib import Path
 
 
@@ -9,23 +20,151 @@ WIZARD_HTML = (
 )
 
 
-def test_remote_node_responses_are_escaped_before_inner_html_rendering():
-    html = WIZARD_HTML.read_text(encoding="utf-8")
+def _source():
+    """Return the current wizard HTML source text."""
+    return WIZARD_HTML.read_text(encoding="utf-8")
 
-    assert "<pre>${r.text}</pre>" not in html
-    assert "<pre>${JSON.stringify(hit,null,2)}</pre>" not in html
-    assert "<pre>${String(e)}</pre>" not in html
 
-    assert "<pre>${h(r.text)}</pre>" in html
-    assert "<pre>${h(JSON.stringify(hit,null,2))}</pre>" in html
-    assert "<pre>${h(String(e))}</pre>" in html
+# ---------------------------------------------------------------------------
+# 1. makePillFragment() DOM helper is present
+# ---------------------------------------------------------------------------
+
+
+def test_make_pill_fragment_helper_defined():
+    """
+    makePillFragment() must be defined in the wizard script.
+
+    This helper builds pill + pre + note entirely via the DOM API, replacing
+    the old innerHTML template-literal pattern.
+    """
+    assert "function makePillFragment(" in _source(), \
+        "makePillFragment() DOM helper is missing from the wizard"
+
+
+def test_make_pill_fragment_uses_textcontent():
+    """makePillFragment() sets pill label via textContent, not innerHTML."""
+    source = _source()
+    fn_match = re.search(r"function makePillFragment\(.*?\}\s*\n", source, re.DOTALL)
+    if fn_match:
+        fn_body = fn_match.group(0)
+        assert ".textContent = " in fn_body, \
+            "makePillFragment() must assign pill text via .textContent"
+        assert ".innerHTML" not in fn_body, \
+            "makePillFragment() must not use innerHTML"
+
+
+def test_make_pill_fragment_uses_createElement():
+    """makePillFragment() builds elements via createElement."""
+    source = _source()
+    fn_match = re.search(r"function makePillFragment\(.*?\}\s*\n", source, re.DOTALL)
+    if fn_match:
+        assert "createElement(" in fn_match.group(0), \
+            "makePillFragment() must use createElement"
+
+
+# ---------------------------------------------------------------------------
+# 2. testOut (node /health response) — no innerHTML on remote data
+# ---------------------------------------------------------------------------
+
+
+def test_testout_no_innerHTML_template_on_node_response():
+    """
+    The testOut element must not be populated via an innerHTML template
+    literal that embeds the raw node /health response text.
+
+    Old pattern (unsafe):
+        testOut.innerHTML = `<span>...</span><pre>${h(r.text)}</pre>`
+    New pattern (safe):
+        testOut.textContent = '';
+        testOut.appendChild(makePillFragment(...));
+    """
+    source = _source()
+    # Old assertions — the innerHTML template strings for testOut must be gone
+    assert "<pre>${h(r.text)}</pre>" not in source, (
+        "testOut must not use innerHTML with h(r.text) — use makePillFragment() instead"
+    )
+
+
+def test_testout_cleared_via_textcontent():
+    """testOut is cleared via textContent before re-population."""
+    assert "testOut.textContent = ''" in _source(), \
+        "testOut should be cleared via testOut.textContent = ''"
+
+
+def test_testout_uses_makepillfragment():
+    """testOut rendering delegates to the safe makePillFragment() helper."""
+    source = _source()
+    assert "makePillFragment(" in source, \
+        "testOut rendering must use makePillFragment()"
+
+
+# ---------------------------------------------------------------------------
+# 3. minerOut (/api/miners response) — no innerHTML on remote data
+# ---------------------------------------------------------------------------
+
+
+def test_minerout_no_innerHTML_template_on_api_response():
+    """
+    The minerOut element must not be populated via an innerHTML template
+    literal that embeds raw API response data.
+
+    Old patterns (unsafe):
+        minerOut.innerHTML = `<span>Found</span><pre>${h(JSON.stringify(hit,null,2))}</pre>`
+        minerOut.innerHTML = `<span>Check failed</span><pre>${h(String(e))}</pre>`
+    """
+    source = _source()
+    assert "<pre>${h(JSON.stringify(hit,null,2))}</pre>" not in source, (
+        "minerOut must not use innerHTML with JSON.stringify(hit) — use makePillFragment()"
+    )
+    assert "<pre>${h(String(e))}</pre>" not in source, (
+        "minerOut must not use innerHTML with String(e) — use makePillFragment()"
+    )
+
+
+def test_minerout_cleared_via_textcontent():
+    """minerOut is cleared via textContent before re-population."""
+    assert "minerOut.textContent = ''" in _source(), \
+        "minerOut should be cleared via minerOut.textContent = ''"
+
+
+# ---------------------------------------------------------------------------
+# 4. h() escaper still present for static template use
+# ---------------------------------------------------------------------------
+
+
+def test_h_escape_function_still_present():
+    """
+    The h() HTML escaper must still exist for the static template contexts
+    (commandBlock, platform detection display, wallet name inputs) that still
+    use innerHTML with fully static or local-state-only strings.
+    """
+    assert "function h(value)" in _source(), \
+        "h() escaper must still be defined for static template contexts"
+
+
+# ---------------------------------------------------------------------------
+# 5. commandBlock still properly escapes the copy attribute
+# ---------------------------------------------------------------------------
 
 
 def test_generated_command_blocks_escape_display_and_copy_attribute():
-    html = WIZARD_HTML.read_text(encoding="utf-8")
+    """
+    commandBlock() must escape the command string with h() when embedding
+    it into the innerHTML template, and must use data-copy= for the copy
+    attribute rather than an inline onclick with unescaped data.
 
-    assert "return `<pre>${cmd}</pre>" not in html
-    assert 'onclick="copyText(${JSON.stringify(cmd)})"' not in html
+    This test is unchanged from the original because commandBlock() renders
+    developer-controlled command strings (no remote data), and the pattern
+    is still correct.
+    """
+    source = _source()
 
-    assert "return `<pre>${h(cmd)}</pre>" in html
-    assert 'data-copy="${h(cmd)}" onclick="copyText(this.dataset.copy)"' in html
+    assert "return `<pre>${cmd}</pre>" not in source, \
+        "commandBlock must escape cmd via h(cmd), not raw ${cmd}"
+    assert 'onclick="copyText(${JSON.stringify(cmd)})"' not in source, \
+        "commandBlock must use data-copy attribute, not inline onclick with raw data"
+
+    assert "return `<pre>${h(cmd)}</pre>" in source, \
+        "commandBlock must use h(cmd) for display"
+    assert 'data-copy="${h(cmd)}" onclick="copyText(this.dataset.copy)"' in source, \
+        "commandBlock must use data-copy= pattern for copy button"

--- a/web/claims/claims.js
+++ b/web/claims/claims.js
@@ -1,6 +1,11 @@
 /**
  * RustChain Claims Page Client
  * RIP-305 Track D: Claim Page + Eligibility Flow
+ *
+ * Security hardening (issue #7204):
+ * All dynamic data from API responses and user input is rendered via
+ * DOM API (createElement / textContent / appendChild) — never via
+ * innerHTML template strings — to eliminate HTML parser sinks.
  */
 
 // API Configuration
@@ -30,76 +35,170 @@ const refreshBtn = document.getElementById('refreshBtn');
 const loadingModal = document.getElementById('loadingModal');
 const loadingText = document.getElementById('loadingText');
 
+// ---------------------------------------------------------------------------
 // Utility Functions
+// ---------------------------------------------------------------------------
+
+/** Muestra el modal de carga con el mensaje indicado. */
 function showLoading(message = 'Processing...') {
   loadingText.textContent = message;
   loadingModal.style.display = 'flex';
 }
 
+/** Oculta el modal de carga. */
 function hideLoading() {
   loadingModal.style.display = 'none';
 }
 
+/** Muestra un mensaje de error en el elemento indicado usando textContent. */
 function showError(elementId, message) {
   const element = document.getElementById(elementId);
   element.textContent = message;
   element.style.display = 'block';
 }
 
+/** Oculta el elemento de error indicado. */
 function hideError(elementId) {
   const element = document.getElementById(elementId);
   element.style.display = 'none';
 }
 
-function escapeHtml(value) {
-  const div = document.createElement('div');
-  div.textContent = String(value ?? '');
-  return div.innerHTML;
-}
-
+/**
+ * Normalises a CSS class name — strips any characters that are not safe
+ * identifier characters to prevent class-injection attacks.
+ * @param {*} value - Raw value to sanitise.
+ * @returns {string} Safe CSS class string.
+ */
 function safeCssClass(value) {
   return String(value || 'unknown').toLowerCase().replace(/[^a-z0-9_-]/g, '-') || 'unknown';
 }
 
+/**
+ * Returns a finite number or the fallback.
+ * @param {*} value - Raw value.
+ * @param {number} fallback - Fallback when value is not finite.
+ * @returns {number}
+ */
 function safeNumber(value, fallback = 0) {
   const number = Number(value);
   return Number.isFinite(number) ? number : fallback;
 }
 
+/**
+ * Returns a safe integer or the fallback.
+ * @param {*} value - Raw value.
+ * @param {number} fallback - Fallback when value is not a safe integer.
+ * @returns {number}
+ */
 function safeInteger(value, fallback = 0) {
   const number = Number.parseInt(value, 10);
   return Number.isFinite(number) ? number : fallback;
 }
 
+/**
+ * Converts snake_case check names to Title Case for display.
+ * @param {string} value - Raw check key.
+ * @returns {string}
+ */
 function formatCheckName(value) {
   return String(value || '')
     .replace(/_/g, ' ')
     .replace(/\b\w/g, l => l.toUpperCase());
 }
 
+/**
+ * Converts micro-RTC integer to human-readable RTC string.
+ * @param {number} urtc - Value in micro-RTC.
+ * @returns {string}
+ */
 function formatRtc(urtc) {
   return (safeNumber(urtc) / 100_000_000).toFixed(6);
 }
 
+/**
+ * Formats a Unix timestamp as a locale string.
+ * @param {number} ts - Unix timestamp in seconds.
+ * @returns {string}
+ */
 function formatTimestamp(ts) {
   if (!ts) return 'N/A';
   return new Date(safeNumber(ts) * 1000).toLocaleString();
 }
 
-function generateClaimId(minerId, epoch) {
-  return `claim_${epoch}_${minerId}`;
+// ---------------------------------------------------------------------------
+// Safe DOM Helpers — no innerHTML involved
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates an element with a CSS class and sets its textContent.
+ * @param {string} tag - HTML tag name.
+ * @param {string} className - CSS class.
+ * @param {string} text - Text content (rendered as text, not HTML).
+ * @returns {HTMLElement}
+ */
+function makeEl(tag, className, text) {
+  const el = document.createElement(tag);
+  if (className) el.className = className;
+  if (text !== undefined) el.textContent = text;
+  return el;
 }
 
+/**
+ * Creates a summary row div containing a label span and a value span.
+ * @param {string} label - Row label text.
+ * @param {string} value - Row value text.
+ * @param {string} [valueStyle] - Optional inline style for the value span.
+ * @returns {HTMLDivElement}
+ */
+function makeSummaryRow(label, value, valueStyle) {
+  const row = document.createElement('div');
+  row.className = 'summary-row';
+
+  const lbl = makeEl('span', 'summary-label', label);
+  const val = makeEl('span', 'summary-value', value);
+  if (valueStyle) val.setAttribute('style', valueStyle);
+
+  row.appendChild(lbl);
+  row.appendChild(val);
+  return row;
+}
+
+/**
+ * Creates a check-item div with pass/fail icon and label.
+ * @param {boolean} passed - Whether the check passed.
+ * @param {string} label - Display label for this check.
+ * @returns {HTMLDivElement}
+ */
+function makeCheckItem(passed, label) {
+  const item = document.createElement('div');
+  item.className = 'check-item';
+
+  const icon = makeEl('span', `check-icon ${passed ? 'pass' : 'fail'}`, passed ? '✓' : '✗');
+  const text = makeEl('span', '', label);
+
+  item.appendChild(icon);
+  item.appendChild(text);
+  return item;
+}
+
+// ---------------------------------------------------------------------------
 // API Functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks miner eligibility via the claims API.
+ * @param {string} minerId - Miner identifier.
+ * @returns {Promise<Object>} Eligibility data.
+ */
 async function checkEligibility(minerId) {
   try {
     const response = await fetch(`${API_BASE}/eligibility?miner_id=${encodeURIComponent(minerId)}`);
     const data = await response.json();
-    
+
     if (!response.ok) {
       throw new Error(data.reason || 'Eligibility check failed');
     }
-    
+
     return data;
   } catch (error) {
     console.error('Eligibility check error:', error);
@@ -107,15 +206,20 @@ async function checkEligibility(minerId) {
   }
 }
 
+/**
+ * Returns the list of eligible epochs for the given miner.
+ * @param {string} minerId - Miner identifier.
+ * @returns {Promise<Object>} Epoch list data.
+ */
 async function getEligibleEpochs(minerId) {
   try {
     const response = await fetch(`${API_BASE}/epochs?miner_id=${encodeURIComponent(minerId)}`);
     const data = await response.json();
-    
+
     if (!response.ok) {
       throw new Error(data.error || 'Failed to get eligible epochs');
     }
-    
+
     return data;
   } catch (error) {
     console.error('Get epochs error:', error);
@@ -123,22 +227,25 @@ async function getEligibleEpochs(minerId) {
   }
 }
 
+/**
+ * Submits a claim payload to the API.
+ * @param {Object} claimPayload - Claim data.
+ * @returns {Promise<Object>} API response.
+ */
 async function submitClaim(claimPayload) {
   try {
     const response = await fetch(`${API_BASE}/submit`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(claimPayload)
     });
-    
+
     const data = await response.json();
-    
+
     if (!response.ok) {
       throw new Error(data.error || 'Claim submission failed');
     }
-    
+
     return data;
   } catch (error) {
     console.error('Submit claim error:', error);
@@ -146,15 +253,20 @@ async function submitClaim(claimPayload) {
   }
 }
 
+/**
+ * Fetches the current status of a claim.
+ * @param {string} claimId - Claim identifier.
+ * @returns {Promise<Object>} Claim status data.
+ */
 async function getClaimStatus(claimId) {
   try {
     const response = await fetch(`${API_BASE}/status/${encodeURIComponent(claimId)}`);
     const data = await response.json();
-    
+
     if (!response.ok) {
       throw new Error(data.error || 'Failed to get claim status');
     }
-    
+
     return data;
   } catch (error) {
     console.error('Get status error:', error);
@@ -162,15 +274,20 @@ async function getClaimStatus(claimId) {
   }
 }
 
+/**
+ * Fetches claim history for a miner.
+ * @param {string} minerId - Miner identifier.
+ * @returns {Promise<Object>} History data.
+ */
 async function getClaimHistory(minerId) {
   try {
     const response = await fetch(`${API_BASE}/history?miner_id=${encodeURIComponent(minerId)}`);
     const data = await response.json();
-    
+
     if (!response.ok) {
       throw new Error(data.error || 'Failed to get claim history');
     }
-    
+
     return data;
   } catch (error) {
     console.error('Get history error:', error);
@@ -178,155 +295,193 @@ async function getClaimHistory(minerId) {
   }
 }
 
-// UI Update Functions
+// ---------------------------------------------------------------------------
+// UI Update Functions — all use DOM API, no innerHTML on API data
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders the eligibility result panel using safe DOM construction.
+ * All values from the API response are set via textContent, never innerHTML.
+ * @param {Object} eligibility - Eligibility API response.
+ */
 function renderEligibilityResult(eligibility) {
   const isEligible = eligibility.eligible;
-  
-  eligibilityResult.innerHTML = `
-    <div class="eligibility-status">
-      <div class="status-indicator ${isEligible ? 'eligible' : 'not-eligible'}"></div>
-      <span style="font-weight: 600; font-size: 1.125rem;">
-        ${isEligible ? 'Eligible to Claim' : 'Not Eligible'}
-      </span>
-    </div>
-    
-    ${isEligible ? `
-      <div class="summary-row">
-        <span class="summary-label">Miner ID</span>
-        <span class="summary-value" style="font-family: var(--font-mono);">${escapeHtml(eligibility.miner_id)}</span>
-      </div>
-      <div class="summary-row">
-        <span class="summary-label">Device Architecture</span>
-        <span class="summary-value">${escapeHtml(eligibility.attestation?.device_arch || 'N/A')}</span>
-      </div>
-      <div class="summary-row">
-        <span class="summary-label">Antiquity Multiplier</span>
-        <span class="summary-value">${safeNumber(eligibility.attestation?.antiquity_multiplier, 1).toFixed(2)}x</span>
-      </div>
-      <div class="summary-row">
-        <span class="summary-label">Wallet Address</span>
-        <span class="summary-value" style="font-family: var(--font-mono);">${escapeHtml(eligibility.wallet_address || 'Not registered')}</span>
-      </div>
-    ` : `
-      <div style="color: var(--error); margin-top: 1rem;">
-        Reason: ${escapeHtml(eligibility.reason || 'Unknown')}
-      </div>
-    `}
-    
-    ${isEligible ? `
-      <div class="checks-grid">
-        <div class="check-item">
-          <span class="check-icon pass">✓</span>
-          <span>Attestation Valid</span>
-        </div>
-        <div class="check-item">
-          <span class="check-icon pass">✓</span>
-          <span>Epoch Participation</span>
-        </div>
-        <div class="check-item">
-          <span class="check-icon pass">✓</span>
-          <span>Fingerprint Passed</span>
-        </div>
-        <div class="check-item">
-          <span class="check-icon ${eligibility.wallet_address ? 'pass' : 'fail'}">
-            ${eligibility.wallet_address ? '✓' : '✗'}
-          </span>
-          <span>Wallet Registered</span>
-        </div>
-      </div>
-    ` : `
-      <div class="checks-grid">
-        ${Object.entries(eligibility.checks || {}).map(([check, passed]) => `
-          <div class="check-item">
-            <span class="check-icon ${passed ? 'pass' : 'fail'}">
-              ${passed ? '✓' : '✗'}
-            </span>
-            <span>${escapeHtml(formatCheckName(check))}</span>
-          </div>
-        `).join('')}
-      </div>
-    `}
-  `;
+  eligibilityResult.textContent = '';
+
+  // Status indicator row
+  const statusDiv = document.createElement('div');
+  statusDiv.className = 'eligibility-status';
+
+  const indicator = document.createElement('div');
+  indicator.className = `status-indicator ${isEligible ? 'eligible' : 'not-eligible'}`;
+
+  const statusLabel = document.createElement('span');
+  statusLabel.setAttribute('style', 'font-weight: 600; font-size: 1.125rem;');
+  statusLabel.textContent = isEligible ? 'Eligible to Claim' : 'Not Eligible';
+
+  statusDiv.appendChild(indicator);
+  statusDiv.appendChild(statusLabel);
+  eligibilityResult.appendChild(statusDiv);
+
+  if (isEligible) {
+    const attest = eligibility.attestation || {};
+    eligibilityResult.appendChild(makeSummaryRow('Miner ID', String(eligibility.miner_id || ''), 'font-family: var(--font-mono);'));
+    eligibilityResult.appendChild(makeSummaryRow('Device Architecture', String(attest.device_arch || 'N/A')));
+    eligibilityResult.appendChild(makeSummaryRow('Antiquity Multiplier', `${safeNumber(attest.antiquity_multiplier, 1).toFixed(2)}x`));
+    eligibilityResult.appendChild(makeSummaryRow('Wallet Address', String(eligibility.wallet_address || 'Not registered'), 'font-family: var(--font-mono);'));
+
+    // Static check grid for eligible miners
+    const checksGrid = document.createElement('div');
+    checksGrid.className = 'checks-grid';
+    checksGrid.appendChild(makeCheckItem(true, 'Attestation Valid'));
+    checksGrid.appendChild(makeCheckItem(true, 'Epoch Participation'));
+    checksGrid.appendChild(makeCheckItem(true, 'Fingerprint Passed'));
+    checksGrid.appendChild(makeCheckItem(Boolean(eligibility.wallet_address), 'Wallet Registered'));
+    eligibilityResult.appendChild(checksGrid);
+  } else {
+    // Reason line
+    const reasonDiv = document.createElement('div');
+    reasonDiv.setAttribute('style', 'color: var(--error); margin-top: 1rem;');
+    reasonDiv.textContent = `Reason: ${eligibility.reason || 'Unknown'}`;
+    eligibilityResult.appendChild(reasonDiv);
+
+    // Dynamic check grid from API
+    const checksGrid = document.createElement('div');
+    checksGrid.className = 'checks-grid';
+    Object.entries(eligibility.checks || {}).forEach(([check, passed]) => {
+      checksGrid.appendChild(makeCheckItem(Boolean(passed), formatCheckName(check)));
+    });
+    eligibilityResult.appendChild(checksGrid);
+  }
 }
 
+/**
+ * Populates the epoch <select> element with safe DOM option nodes.
+ * @param {Object} epochData - API response containing an `epochs` array.
+ */
 function renderEpochSelect(epochData) {
   const unclaimedEpochs = epochData.epochs.filter(e => !e.claimed && e.settled);
-  
+
+  // Clear existing options safely
+  while (epochSelect.options.length > 0) {
+    epochSelect.remove(0);
+  }
+
   if (unclaimedEpochs.length === 0) {
-    epochSelect.innerHTML = '<option value="">No unclaimed epochs available</option>';
+    const opt = document.createElement('option');
+    opt.value = '';
+    opt.textContent = 'No unclaimed epochs available';
+    epochSelect.appendChild(opt);
     return;
   }
-  
-  epochSelect.innerHTML = `
-    <option value="">-- Select an epoch --</option>
-    ${unclaimedEpochs.map(epoch => `
-      <option value="${safeInteger(epoch.epoch)}" data-reward="${safeInteger(epoch.reward_urtc)}">
-        Epoch ${safeInteger(epoch.epoch)} - ${formatRtc(epoch.reward_urtc)} RTC
-      </option>
-    `).join('')}
-  `;
-  
+
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = '-- Select an epoch --';
+  epochSelect.appendChild(placeholder);
+
+  unclaimedEpochs.forEach(epoch => {
+    const opt = document.createElement('option');
+    opt.value = String(safeInteger(epoch.epoch));
+    opt.dataset.reward = String(safeInteger(epoch.reward_urtc));
+    opt.textContent = `Epoch ${safeInteger(epoch.epoch)} - ${formatRtc(epoch.reward_urtc)} RTC`;
+    epochSelect.appendChild(opt);
+  });
+
   eligibleEpochs = unclaimedEpochs;
 }
 
+/**
+ * Renders the claim summary panel using safe DOM construction.
+ * @param {string} minerId - Miner identifier.
+ * @param {number} epoch - Selected epoch number.
+ * @param {number} rewardUrtc - Reward in micro-RTC.
+ * @param {string} walletAddress - Destination wallet address.
+ */
 function renderClaimSummary(minerId, epoch, rewardUrtc, walletAddress) {
-  claimSummary.innerHTML = `
-    <div class="summary-row">
-      <span class="summary-label">Miner ID</span>
-      <span class="summary-value" style="font-family: var(--font-mono);">${escapeHtml(minerId)}</span>
-    </div>
-    <div class="summary-row">
-      <span class="summary-label">Epoch</span>
-      <span class="summary-value">${safeInteger(epoch)}</span>
-    </div>
-    <div class="summary-row">
-      <span class="summary-label">Wallet Address</span>
-      <span class="summary-value" style="font-family: var(--font-mono);">${escapeHtml(walletAddress)}</span>
-    </div>
-    <div class="summary-row">
-      <span class="summary-label">Reward Amount</span>
-      <span class="summary-value" style="color: var(--accent-primary);">${formatRtc(rewardUrtc)} RTC</span>
-    </div>
-    <div class="summary-row">
-      <span class="summary-label">Estimated Settlement</span>
-      <span class="summary-value">~30 minutes</span>
-    </div>
-  `;
+  claimSummary.textContent = '';
+  claimSummary.appendChild(makeSummaryRow('Miner ID', String(minerId), 'font-family: var(--font-mono);'));
+  claimSummary.appendChild(makeSummaryRow('Epoch', String(safeInteger(epoch))));
+  claimSummary.appendChild(makeSummaryRow('Wallet Address', String(walletAddress), 'font-family: var(--font-mono);'));
+
+  const rewardRow = makeSummaryRow('Reward Amount', `${formatRtc(rewardUrtc)} RTC`);
+  rewardRow.querySelector('.summary-value').setAttribute('style', 'color: var(--accent-primary);');
+  claimSummary.appendChild(rewardRow);
+
+  claimSummary.appendChild(makeSummaryRow('Estimated Settlement', '~30 minutes'));
 }
 
+/**
+ * Renders claim history into the table body using safe DOM construction.
+ * All claim fields are set via textContent — no innerHTML on API data.
+ * @param {Object} history - API response with a `claims` array.
+ */
 function renderClaimHistory(history) {
   const tbody = document.getElementById('claimsHistoryBody');
-  
+  tbody.textContent = '';
+
   if (!history.claims || history.claims.length === 0) {
-    tbody.innerHTML = `
-      <tr>
-        <td colspan="6" class="empty-state">No claims yet. Check your eligibility to get started.</td>
-      </tr>
-    `;
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.setAttribute('colspan', '6');
+    td.className = 'empty-state';
+    td.textContent = 'No claims yet. Check your eligibility to get started.';
+    tr.appendChild(td);
+    tbody.appendChild(tr);
     return;
   }
-  
-  tbody.innerHTML = history.claims.map(claim => `
-    <tr>
-      <td style="font-family: var(--font-mono); font-size: 0.875rem;">${escapeHtml(claim.claim_id)}</td>
-      <td>${safeInteger(claim.epoch)}</td>
-      <td>
-        <span class="status-badge ${safeCssClass(claim.status)}">${escapeHtml(claim.status)}</span>
-      </td>
-      <td style="font-family: var(--font-mono);">${formatRtc(claim.reward_urtc)}</td>
-      <td>${formatTimestamp(claim.submitted_at)}</td>
-      <td>${formatTimestamp(claim.settled_at)}</td>
-    </tr>
-  `).join('');
+
+  history.claims.forEach(claim => {
+    const tr = document.createElement('tr');
+
+    // Claim ID cell
+    const tdId = document.createElement('td');
+    tdId.setAttribute('style', 'font-family: var(--font-mono); font-size: 0.875rem;');
+    tdId.textContent = String(claim.claim_id || '');
+    tr.appendChild(tdId);
+
+    // Epoch cell
+    const tdEpoch = document.createElement('td');
+    tdEpoch.textContent = String(safeInteger(claim.epoch));
+    tr.appendChild(tdEpoch);
+
+    // Status badge cell
+    const tdStatus = document.createElement('td');
+    const badge = document.createElement('span');
+    badge.className = `status-badge ${safeCssClass(claim.status)}`;
+    badge.textContent = String(claim.status || '');
+    tdStatus.appendChild(badge);
+    tr.appendChild(tdStatus);
+
+    // Reward cell
+    const tdReward = document.createElement('td');
+    tdReward.setAttribute('style', 'font-family: var(--font-mono);');
+    tdReward.textContent = formatRtc(claim.reward_urtc);
+    tr.appendChild(tdReward);
+
+    // Submitted at cell
+    const tdSubmitted = document.createElement('td');
+    tdSubmitted.textContent = formatTimestamp(claim.submitted_at);
+    tr.appendChild(tdSubmitted);
+
+    // Settled at cell
+    const tdSettled = document.createElement('td');
+    tdSettled.textContent = formatTimestamp(claim.settled_at);
+    tr.appendChild(tdSettled);
+
+    tbody.appendChild(tr);
+  });
 }
 
+/**
+ * Fetches and updates the dashboard stats counters.
+ * Uses textContent for all dynamic values.
+ */
 function updateStats() {
-  // Update dashboard stats (would come from API in production)
   document.getElementById('totalClaimed').textContent = 'Loading...';
   document.getElementById('pendingClaims').textContent = 'Loading...';
   document.getElementById('settlementTime').textContent = 'Loading...';
-  
-  // In production, fetch from API
+
   fetch('/api/claims/stats')
     .then(r => r.json())
     .then(stats => {
@@ -341,45 +496,46 @@ function updateStats() {
     });
 }
 
+// ---------------------------------------------------------------------------
 // Event Handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * Handles the "Check Eligibility" button click.
+ * Fetches eligibility data and renders the result panel.
+ */
 async function handleCheckEligibility() {
   const minerId = minerIdInput.value.trim();
-  
+
   if (!minerId) {
     showError('minerIdError', 'Please enter your miner ID');
     return;
   }
-  
+
   hideError('minerIdError');
   showLoading('Checking eligibility...');
-  
+
   try {
-    // Check eligibility
     const eligibility = await checkEligibility(minerId);
     currentMinerId = minerId;
-    
+
     renderEligibilityResult(eligibility);
     eligibilityPanel.style.display = 'block';
-    
+
     if (eligibility.eligible) {
-      // Get eligible epochs
       const epochData = await getEligibleEpochs(minerId);
       renderEpochSelect(epochData);
-      
-      // Pre-fill wallet address if available
+
       if (eligibility.wallet_address) {
         walletAddressInput.value = eligibility.wallet_address;
       }
-      
-      // Scroll to eligibility panel
+
       eligibilityPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
     } else {
-      // Hide subsequent panels if not eligible
       walletPanel.style.display = 'none';
       submitPanel.style.display = 'none';
     }
-    
-    // Load claim history
+
     loadClaimHistory(minerId);
   } catch (error) {
     showError('minerIdError', error.message || 'Failed to check eligibility');
@@ -389,101 +545,98 @@ async function handleCheckEligibility() {
   }
 }
 
+/**
+ * Handles epoch selection change — shows wallet panel and updates summary.
+ */
 function handleEpochSelect() {
   const selectedOption = epochSelect.options[epochSelect.selectedIndex];
-  
+
   if (!selectedOption.value) {
     selectedEpoch = null;
     walletPanel.style.display = 'none';
     submitPanel.style.display = 'none';
     return;
   }
-  
+
   selectedEpoch = parseInt(selectedOption.value);
   const rewardUrtc = parseInt(selectedOption.dataset.reward);
-  
+
   walletPanel.style.display = 'block';
-  
-  // Update claim summary
+
   renderClaimSummary(
     currentMinerId,
     selectedEpoch,
     rewardUrtc,
     walletAddressInput.value || 'Not provided'
   );
-  
+
   walletPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
+/**
+ * Handles wallet address input — validates format and shows submit panel.
+ */
 function handleWalletInput() {
   const walletAddress = walletAddressInput.value.trim();
-  
+
   if (!walletAddress || !selectedEpoch) {
     submitPanel.style.display = 'none';
     return;
   }
-  
-  // Validate wallet address format
+
   if (!walletAddress.startsWith('RTC') || walletAddress.length < 23) {
     showError('walletError', 'Invalid wallet address format. Must start with RTC and be at least 23 characters.');
     submitPanel.style.display = 'none';
     return;
   }
-  
+
   hideError('walletError');
-  
-  // Update claim summary
+
   const selectedOption = epochSelect.options[epochSelect.selectedIndex];
   const rewardUrtc = parseInt(selectedOption.dataset.reward);
-  
-  renderClaimSummary(
-    currentMinerId,
-    selectedEpoch,
-    rewardUrtc,
-    walletAddress
-  );
-  
+
+  renderClaimSummary(currentMinerId, selectedEpoch, rewardUrtc, walletAddress);
+
   submitPanel.style.display = 'block';
   submitPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
+/**
+ * Syncs submit button disabled state with the confirm checkbox.
+ */
 function handleConfirmChange() {
   submitClaimBtn.disabled = !confirmCheckbox.checked;
 }
 
+/**
+ * Handles claim submission — renders success message via safe DOM,
+ * not via innerHTML template strings.
+ */
 async function handleSubmitClaim() {
   if (!currentMinerId || !selectedEpoch) {
     showError('submitError', 'Invalid claim data');
     return;
   }
-  
+
   const walletAddress = walletAddressInput.value.trim();
   const selectedOption = epochSelect.options[epochSelect.selectedIndex];
   const rewardUrtc = parseInt(selectedOption.dataset.reward);
-  
+
   if (!walletAddress) {
     showError('submitError', 'Wallet address is required');
     return;
   }
-  
+
   showLoading('Generating signature and submitting claim...');
   hideError('submitError');
-  
+
   try {
-    // In production, this would generate a real Ed25519 signature
-    // For now, we'll use a mock signature
     const timestamp = Math.floor(Date.now() / 1000);
-    const payload = {
-      miner_id: currentMinerId,
-      epoch: selectedEpoch,
-      wallet_address: walletAddress,
-      timestamp: timestamp
-    };
-    
-    // Mock signature (in production, use actual cryptographic signing)
+
+    // Mock signature (in production, use actual Ed25519 cryptographic signing)
     const mockSignature = '0'.repeat(128);
     const mockPublicKey = '1'.repeat(64);
-    
+
     const claimPayload = {
       miner_id: currentMinerId,
       epoch: selectedEpoch,
@@ -491,20 +644,38 @@ async function handleSubmitClaim() {
       signature: mockSignature,
       public_key: mockPublicKey
     };
-    
+
     const result = await submitClaim(claimPayload);
-    
+
     if (result.success) {
-      // Show success message
-      document.getElementById('submitSuccess').innerHTML = `
-        <strong>Claim submitted successfully!</strong><br>
-        Claim ID: <code style="font-family: var(--font-mono);">${escapeHtml(result.claim_id)}</code><br>
-        Reward: ${formatRtc(result.reward_urtc)} RTC<br>
-        Estimated settlement: ${new Date(safeNumber(result.estimated_settlement) * 1000).toLocaleString()}
-      `;
-      document.getElementById('submitSuccess').style.display = 'block';
-      
-      // Reset form
+      // Render success message via safe DOM — no innerHTML on API response
+      const successEl = document.getElementById('submitSuccess');
+      successEl.textContent = '';
+
+      const strong = document.createElement('strong');
+      strong.textContent = 'Claim submitted successfully!';
+      successEl.appendChild(strong);
+      successEl.appendChild(document.createElement('br'));
+
+      const claimIdLabel = document.createTextNode('Claim ID: ');
+      successEl.appendChild(claimIdLabel);
+
+      const claimIdCode = document.createElement('code');
+      claimIdCode.setAttribute('style', 'font-family: var(--font-mono);');
+      claimIdCode.textContent = String(result.claim_id || '');
+      successEl.appendChild(claimIdCode);
+      successEl.appendChild(document.createElement('br'));
+
+      const rewardLine = document.createTextNode(`Reward: ${formatRtc(result.reward_urtc)} RTC`);
+      successEl.appendChild(rewardLine);
+      successEl.appendChild(document.createElement('br'));
+
+      const settlementTs = new Date(safeNumber(result.estimated_settlement) * 1000).toLocaleString();
+      const settlementLine = document.createTextNode(`Estimated settlement: ${settlementTs}`);
+      successEl.appendChild(settlementLine);
+
+      successEl.style.display = 'block';
+
       setTimeout(() => {
         resetForm();
         loadClaimHistory(currentMinerId);
@@ -519,31 +690,48 @@ async function handleSubmitClaim() {
   }
 }
 
+/** Handles the Cancel button — resets form to initial state. */
 function handleCancel() {
   resetForm();
 }
 
+/**
+ * Resets all form fields and hides all dynamic panels.
+ */
 function resetForm() {
   minerIdInput.value = '';
   walletAddressInput.value = '';
-  epochSelect.innerHTML = '<option value="">-- Select an epoch --</option>';
+
+  // Clear epoch options safely
+  while (epochSelect.options.length > 0) {
+    epochSelect.remove(0);
+  }
+  const defaultOpt = document.createElement('option');
+  defaultOpt.value = '';
+  defaultOpt.textContent = '-- Select an epoch --';
+  epochSelect.appendChild(defaultOpt);
+
   confirmCheckbox.checked = false;
   submitClaimBtn.disabled = true;
-  
+
   eligibilityPanel.style.display = 'none';
   walletPanel.style.display = 'none';
   submitPanel.style.display = 'none';
-  
+
   hideError('minerIdError');
   hideError('walletError');
   hideError('submitError');
   document.getElementById('submitSuccess').style.display = 'none';
-  
+
   currentMinerId = null;
   selectedEpoch = null;
   eligibleEpochs = [];
 }
 
+/**
+ * Loads and renders claim history for the given miner.
+ * @param {string} minerId - Miner identifier.
+ */
 async function loadClaimHistory(minerId) {
   try {
     const history = await getClaimHistory(minerId);
@@ -553,20 +741,23 @@ async function loadClaimHistory(minerId) {
   }
 }
 
+/**
+ * Exports claim history as a CSV file download.
+ * CSV cell values are quoted to prevent formula injection.
+ */
 function handleExportHistory() {
   if (!currentMinerId) {
     alert('Please enter your miner ID first');
     return;
   }
-  
-  // Get history data and export as CSV
+
   getClaimHistory(currentMinerId)
     .then(history => {
       if (!history.claims || history.claims.length === 0) {
         alert('No claims to export');
         return;
       }
-      
+
       const headers = ['Claim ID', 'Epoch', 'Status', 'Reward (RTC)', 'Submitted At', 'Settled At'];
       const rows = history.claims.map(c => [
         c.claim_id,
@@ -576,9 +767,11 @@ function handleExportHistory() {
         new Date(c.submitted_at * 1000).toISOString(),
         c.settled_at ? new Date(c.settled_at * 1000).toISOString() : ''
       ]);
-      
-      const csv = [headers, ...rows].map(row => row.join(',')).join('\n');
-      
+
+      // Quote all CSV cells to prevent CSV injection / formula injection
+      const escape = v => `"${String(v ?? '').replace(/"/g, '""')}"`;
+      const csv = [headers, ...rows].map(row => row.map(escape).join(',')).join('\n');
+
       const blob = new Blob([csv], { type: 'text/csv' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -592,6 +785,9 @@ function handleExportHistory() {
     });
 }
 
+/**
+ * Handles the Refresh button — reloads stats and claim history.
+ */
 function handleRefresh() {
   if (currentMinerId) {
     showLoading('Refreshing...');
@@ -603,14 +799,16 @@ function handleRefresh() {
   }
 }
 
+// ---------------------------------------------------------------------------
 // Initialize
+// ---------------------------------------------------------------------------
+
 document.addEventListener('DOMContentLoaded', () => {
-  // Event listeners
   checkEligibilityBtn.addEventListener('click', handleCheckEligibility);
   minerIdInput.addEventListener('keypress', (e) => {
     if (e.key === 'Enter') handleCheckEligibility();
   });
-  
+
   epochSelect.addEventListener('change', handleEpochSelect);
   walletAddressInput.addEventListener('input', handleWalletInput);
   confirmCheckbox.addEventListener('change', handleConfirmChange);
@@ -618,11 +816,10 @@ document.addEventListener('DOMContentLoaded', () => {
   cancelBtn.addEventListener('click', handleCancel);
   exportHistoryBtn.addEventListener('click', handleExportHistory);
   refreshBtn.addEventListener('click', handleRefresh);
-  
-  // Initial stats load
+
   updateStats();
-  
-  // Check if miner ID is in URL query params
+
+  // Auto-populate miner ID from URL query param
   const urlParams = new URLSearchParams(window.location.search);
   const minerIdParam = urlParams.get('miner_id');
   if (minerIdParam) {


### PR DESCRIPTION
## Summary

Hardens three separate DOM XSS / data-integrity surfaces across the RustChain web frontend. Each is a self-contained fix scoped to its issue.

---

## Fix 1 — Closes #7204: Claims page DOM XSS hardening (`web/claims/claims.js`)

### Problem
`claims.js` used `innerHTML` template-literal strings to render eligibility data, epoch options, claim summaries, history rows, and the submit-success message from `/api/claims/*` responses. While individual fields were escaped with `escapeHtml()`, the pattern still routes API values through an HTML parser sink.

### Fix
- **Removed all dynamic `innerHTML` template literals** that embedded API response values
- **Added safe DOM helpers**: `makeEl()`, `makeSummaryRow()`, `makeCheckItem()`
- All render functions now use `textContent` and `createElement`/`appendChild`
- `handleExportHistory()`: quoted CSV cells to prevent spreadsheet formula injection
- `resetForm()`: rebuilds default epoch option via `createElement`, not `innerHTML`

### Tests
13 new tests in `tests/test_claims_dom_hardening_7204.py` — all passing.

---

## Fix 2 — Closes #7191: Miner setup wizard DOM XSS hardening (`docs/miner-setup-wizard/index.html`)

### Problem
The wizard used `innerHTML` to render remote node `/health` responses (in `testOut`) and `/api/miners` JSON data (in `minerOut`). A compromised or malicious node endpoint could inject HTML.

### Fix
- **Added `makePillFragment()`**: builds pill + `<pre>` + note entirely via DOM API (no `innerHTML`)
- `testOut` block: `testOut.textContent = ''; testOut.appendChild(makePillFragment(...))`
- `minerOut` found/not-found/error branches: same safe DOM pattern

### Tests
11 new tests in `tests/test_miner_setup_docs_wizard_dom_hardening_7191.py` — all passing.

---

## Fix 3 — Closes #7127: Bridge dashboard real data fallback (`static/bridge/dashboard.html`)

### Problem
When `GET /api/bridge/stats` and `GET /api/bridge/ledger` returned nginx 404, the dashboard silently fell back to `MOCK_DATA` — showing fake bridge totals and fake transactions to real users.

### Fix
- **`fetchBridgeStats()`**: tries native API first; falls back to `GET /wallet/balance?miner_id=bridge-escrow` (which IS live) to surface real escrow balance
- **`fetchBridgeLedger()`**: tries native API first; falls back to `GET /wallet/history?miner_id=bridge-escrow&limit=50` with schema normalisation
- **`refreshAll()`**: uses real fetched data; never renders `MOCK_DATA.stats/transactions`
- **`setDegradedBanner()`**: shows a visible orange warning banner when bridge API is unavailable instead of silently rendering fake data

---

## Test validation
```
pytest tests/test_claims_dom_hardening_7204.py tests/test_miner_setup_docs_wizard_dom_hardening_7191.py -v
24 passed in 0.45s
```

## BCOS Label
BCOS-L2 (3 XSS/data-integrity fixes, runtime-tested)