### PR TITLE
docs: clarify RTC price as approximate in QUICKSTART

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -9,7 +9,7 @@ A step-by-step guide for first-time users. Every command is copy-paste ready.
 RustChain is a blockchain that rewards you for keeping old computers alive. Instead of
 rewarding the fastest machine (like Bitcoin), RustChain rewards the *oldest* machine.
 A PowerBook G4 from 2003 earns 2.5x more than a brand-new gaming PC. The token is called
-**RTC** (RustChain Token), and it has real value -- 1 RTC is roughly $0.15 USD. Over 260
+**RTC** (RustChain Token), and it has real value -- 1 RTC trades at roughly $0.15 USD (subject to market conditions). Over 260
 contributors have earned 25,000+ RTC through mining and code bounties.
 
 ---
@@ -258,8 +258,8 @@ PowerPC G5 (2.0x):       0.24 RTC/epoch
 Modern x86 PC (0.8x):    0.12 RTC/epoch
 ```
 
-Over 24 hours (144 epochs), a G4 Mac earns roughly **43 RTC** ($4.30) while a modern
-PC earns roughly **17 RTC** ($1.70). More miners on the network means smaller individual
+Over 24 hours (144 epochs), a G4 Mac earns roughly **43 RTC** (~$4.30 at $0.15/RTC) while a modern
+PC earns roughly **17 RTC** (~$1.70 at $0.15/RTC). Actual USD value fluctuates with the RTC market price. More miners on the network means smaller individual
 slices, but also means a healthier network.
 
 ---
@@ -445,7 +445,7 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 
 | Term | Meaning |
 |------|---------|
-| **RTC** | RustChain Token -- the cryptocurrency you earn by mining. 1 RTC is roughly $0.15 USD. |
+| **RTC** | RustChain Token -- the cryptocurrency you earn by mining. 1 RTC trades at roughly $0.15 USD (market price may vary). |
 | **Epoch** | A 10-minute window. At the end of each epoch, 1.5 RTC is distributed to all active miners. |
 | **Attestation** | The process where your miner proves its hardware is real by running 6 fingerprint checks. |
 | **Antiquity Multiplier** | A bonus based on how old your hardware is. Older CPUs get higher multipliers. |


### PR DESCRIPTION
## What

The QUICKSTART guide references the RTC token price as "roughly $0.15 USD" in three places without making it clear that this is an approximation that can change. This caused confusion for new users (issues #7682 and #7683) who saw slightly different values elsewhere and weren't sure which was correct.

## Changes

All three RTC price mentions in `docs/QUICKSTART.md` now consistently note that the figure is approximate and subject to market conditions:

1. **Intro section (line 12)**: "roughly $0.15 USD" → "roughly $0.15 USD (subject to market conditions)"
2. **Earnings example (lines 261-262)**: Added "at $0.15/RTC" basis and a note that actual USD value fluctuates with market price
3. **Glossary (line 448)**: "roughly $0.15 USD" → "roughly $0.15 USD (market price may vary)"

No functional changes — documentation only.

Closes #7682, #7683