### PR TITLE
fix(utxo): reconcile mirror UTXO on /pending/confirm — synthesis fix for #2819 double-spend

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -10248,6 +10248,35 @@ def _settle_account_transfer_in_utxo(c, from_m, to_m, amount_i64, epoch, tx_hash
     _emit_mirror(to_m, moved_nrtc, 0)
     _emit_mirror(from_m, change_nrtc, 1)
 
+    # Consensus invariant (bounty #2819): a wallet's mirrored UTXO must never
+    # exceed its account balance. mirror > balance is *exactly* the double-spend
+    # condition this fix prevents — the same funds counted in both models. The
+    # reconcile maintains mirror <= balance by construction (equal for a
+    # fully-mirrored wallet), so this can only trip on an unforeseen path; when
+    # it does we fail the confirm (rollback → transfer stays pending) rather than
+    # commit money that exists twice.
+    for _w in (from_m, to_m):
+        _mirror_nrtc = c.execute(
+            "SELECT COALESCE(SUM(b.value_nrtc), 0) FROM utxo_boxes b "
+            "JOIN account_mirror_boxes m ON m.box_id = b.box_id "
+            "WHERE m.account_wallet = ? AND b.spent_at IS NULL",
+            (_w,),
+        ).fetchone()[0]
+        _bal_nrtc = int(_balance_i64_for_wallet(c, _w)) * _UTXO_PER_ACCOUNT
+        if int(_mirror_nrtc) > _bal_nrtc:
+            try:
+                send_sophiacheck_alert(
+                    "critical",
+                    "account/UTXO mirror invariant violated on pending confirm",
+                    {"wallet": _w, "mirror_nrtc": int(_mirror_nrtc),
+                     "balance_nrtc": _bal_nrtc, "tx_hash": tx_hash},
+                )
+            except Exception:
+                pass
+            raise RuntimeError(
+                f"mirror_exceeds_balance:{_w}:mirror={int(_mirror_nrtc)}:bal={_bal_nrtc}"
+            )
+
 
 @app.route('/pending/confirm', methods=['POST'])
 def confirm_pending():

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -10182,52 +10182,43 @@ def _settle_account_transfer_in_utxo(c, from_m, to_m, amount_i64, epoch, tx_hash
         return
 
     target_nrtc = int(amount_i64) * _UTXO_PER_ACCOUNT
-
-    # Sender's unspent mirror boxes, smallest first (tidy consumption).
-    rows = c.execute(
-        """SELECT b.box_id, b.value_nrtc
-             FROM utxo_boxes b
-             JOIN account_mirror_boxes m ON m.box_id = b.box_id
-            WHERE m.account_wallet = ? AND b.spent_at IS NULL
-            ORDER BY b.value_nrtc ASC, b.box_id ASC""",
-        (from_m,),
-    ).fetchall()
-    if not rows:
-        return  # non-migrated sender: nothing mirrors this account balance
-
     spend_tx = f"account_confirm:{tx_hash}"
-    consumed_nrtc = 0
-    # Spend each candidate atomically and count ONLY boxes this statement
-    # actually marked spent (rowcount==1), so a concurrent spend between the
-    # SELECT snapshot and the UPDATE can't inflate the mirrored amount.
-    for box_id, value_nrtc in rows:
-        if consumed_nrtc >= target_nrtc:
-            break
-        res = c.execute(
-            "UPDATE utxo_boxes SET spent_at = ?, spent_by_tx = ? "
-            "WHERE box_id = ? AND spent_at IS NULL",
-            (now, spend_tx, box_id),
-        )
-        if res.rowcount != 1:
-            continue  # raced/already spent — do not count or mirror it
-        c.execute("DELETE FROM account_mirror_boxes WHERE box_id = ?", (box_id,))
-        consumed_nrtc += int(value_nrtc)
-
-    if consumed_nrtc <= 0:
-        return  # nothing was actually consumed (all raced); account move stands
-
-    moved_nrtc = min(consumed_nrtc, target_nrtc)
-    change_nrtc = consumed_nrtc - moved_nrtc
-
-    # Deterministic synthetic tx id for this reconciliation (valid hex for
-    # compute_box_id, which does bytes.fromhex on the tx id).
+    # Deterministic synthetic tx id for the reconciliation outputs (valid hex
+    # for compute_box_id, which does bytes.fromhex on the tx id).
     base = f"acctmirror:{tx_hash}:{from_m}:{to_m}:{int(amount_i64)}"
     recon_tx_id = hashlib.sha256(base.encode()).hexdigest()
 
-    def _emit_mirror(owner, value_nrtc, out_idx):
+    def _spend_wallet_mirror(wallet):
+        """Spend ALL of `wallet`'s unspent mirror boxes; return the nrtc actually
+        marked spent. Counts only rowcount==1 updates, so a concurrent spend
+        between the SELECT snapshot and the UPDATE can't inflate the total. The
+        per-wallet set is bounded — consolidation below keeps it to <=1 box."""
+        rows = c.execute(
+            "SELECT b.box_id, b.value_nrtc FROM utxo_boxes b "
+            "JOIN account_mirror_boxes m ON m.box_id = b.box_id "
+            "WHERE m.account_wallet = ? AND b.spent_at IS NULL",
+            (wallet,),
+        ).fetchall()  # fetchall-ok: bounded-by-schema (one wallet's mirror boxes; consolidation keeps it <=1)
+        total = 0
+        for box_id, value_nrtc in rows:
+            res = c.execute(
+                "UPDATE utxo_boxes SET spent_at = ?, spent_by_tx = ? "
+                "WHERE box_id = ? AND spent_at IS NULL",
+                (now, spend_tx, box_id),
+            )
+            if res.rowcount != 1:
+                continue
+            c.execute("DELETE FROM account_mirror_boxes WHERE box_id = ?", (box_id,))
+            total += int(value_nrtc)
+        return total
+
+    def _credit_wallet_mirror(wallet, value_nrtc, out_idx):
+        """Create ONE consolidated mirror box of `value_nrtc` for `wallet`, so
+        every wallet holds at most one mirror box (bounds the fetch to O(1) and
+        keeps mirror == balance exact)."""
         if value_nrtc <= 0:
             return
-        prop = utxo_address_to_proposition(owner)
+        prop = utxo_address_to_proposition(wallet)
         box_id = utxo_compute_box_id(int(value_nrtc), prop, int(epoch), recon_tx_id, out_idx)
         c.execute(
             """INSERT OR IGNORE INTO utxo_boxes
@@ -10235,18 +10226,26 @@ def _settle_account_transfer_in_utxo(c, from_m, to_m, amount_i64, epoch, tx_hash
                     creation_height, transaction_id, output_index,
                     tokens_json, registers_json, created_at)
                VALUES (?,?,?,?,?,?,?,?,?,?)""",
-            (box_id, int(value_nrtc), prop, owner, int(epoch), recon_tx_id,
+            (box_id, int(value_nrtc), prop, wallet, int(epoch), recon_tx_id,
              out_idx, '[]', json.dumps({'R4': 'account_migration_mirror'}), now),
         )
         c.execute(
             "INSERT OR REPLACE INTO account_mirror_boxes "
             "(box_id, account_wallet, value_nrtc, created_epoch) VALUES (?,?,?,?)",
-            (box_id, owner, int(value_nrtc), int(epoch)),
+            (box_id, wallet, int(value_nrtc), int(epoch)),
         )
 
-    # Receiver mirrors the moved value; sender keeps the change.
-    _emit_mirror(to_m, moved_nrtc, 0)
-    _emit_mirror(from_m, change_nrtc, 1)
+    # Consume the sender's whole mirror, move up to the transfer amount onto the
+    # receiver (folding the receiver's existing mirror so it stays one box), and
+    # return any change to the sender.
+    sender_mirror = _spend_wallet_mirror(from_m)
+    if sender_mirror <= 0:
+        return  # non-migrated sender: nothing mirrors this balance; move stands
+    moved_nrtc = min(sender_mirror, target_nrtc)
+    sender_change = sender_mirror - moved_nrtc
+    recv_existing = _spend_wallet_mirror(to_m)
+    _credit_wallet_mirror(to_m, recv_existing + moved_nrtc, 0)
+    _credit_wallet_mirror(from_m, sender_change, 1)
 
     # Consensus invariant (bounty #2819): a wallet's mirrored UTXO must never
     # exceed its account balance. mirror > balance is *exactly* the double-spend

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -53,12 +53,16 @@ try:
         DUST_THRESHOLD as UTXO_DUST_THRESHOLD,
         MAX_OUTPUTS as UTXO_MAX_OUTPUTS,
         UtxoDB,
+        address_to_proposition as utxo_address_to_proposition,
+        compute_box_id as utxo_compute_box_id,
     )
     HAVE_UTXO = True
 except ImportError:
     UTXO_DUST_THRESHOLD = 1_000
     UTXO_MAX_OUTPUTS = 100
     HAVE_UTXO = False
+    utxo_address_to_proposition = None
+    utxo_compute_box_id = None
     if UTXO_DUAL_WRITE:
         print("[WARN] utxo_db.py not found but UTXO_DUAL_WRITE=1 — disabling")
         UTXO_DUAL_WRITE = False
@@ -10090,6 +10094,161 @@ def void_pending():
         conn.close()
 
 
+# Account balances are micro-RTC; UTXO box values are nano-RTC (100x).
+_UTXO_PER_ACCOUNT = UTXO_UNIT // ACCOUNT_UNIT
+
+
+def _ensure_and_backfill_account_mirror(c):
+    """Create + backfill the mirror-provenance table (run ONCE per confirm pass,
+    outside the per-row savepoint).
+
+    ``account_mirror_boxes`` is the *discriminator* for the account/UTXO
+    cross-model double-spend (bounty #2819): it records exactly which boxes
+    represent account-model funds and for whom. It is deliberately an explicit
+    table rather than a ``registers_json`` marker match — a JSON marker is lost
+    on change boxes from partial spends, and "any box the sender owns" would
+    wrongly burn independently-earned UTXOs. The table is *maintained* across
+    change/receiver boxes so it stays complete after partial transfers.
+
+    Backfill makes the discriminator complete even on a DB whose genesis
+    migration ran *before* this provenance tracking existed: any unspent box
+    still carrying the migration register but missing a provenance row is
+    adopted here (idempotent). New migrations populate the table directly.
+    """
+    if not HAVE_UTXO:
+        return
+    if not c.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='utxo_boxes'"
+    ).fetchone():
+        return
+    c.execute(
+        """CREATE TABLE IF NOT EXISTS account_mirror_boxes (
+               box_id TEXT PRIMARY KEY,
+               account_wallet TEXT NOT NULL,
+               value_nrtc INTEGER NOT NULL,
+               created_epoch INTEGER NOT NULL
+           )"""
+    )
+    c.execute(
+        "CREATE INDEX IF NOT EXISTS idx_mirror_wallet "
+        "ON account_mirror_boxes(account_wallet)"
+    )
+    c.execute(
+        """INSERT OR IGNORE INTO account_mirror_boxes
+               (box_id, account_wallet, value_nrtc, created_epoch)
+           SELECT b.box_id, b.owner_address, b.value_nrtc, b.creation_height
+             FROM utxo_boxes b
+            WHERE b.spent_at IS NULL
+              AND json_extract(b.registers_json, '$.R4')
+                  IN ('genesis', 'account_migration_mirror')
+              AND NOT EXISTS (
+                  SELECT 1 FROM account_mirror_boxes m WHERE m.box_id = b.box_id
+              )"""
+    )
+
+
+def _settle_account_transfer_in_utxo(c, from_m, to_m, amount_i64, epoch, tx_hash, now):
+    """Keep the UTXO mirror consistent when an account pending-transfer confirms.
+
+    Without this, ``/pending/confirm`` debits the sender's account balance but
+    leaves their matching migrated UTXO box spendable, so the same funds move
+    once via account confirm and again via the UTXO path (bounty #2819 — a
+    Critical double-spend).
+
+    Properties (the synthesis of the two candidate fixes #7511/#7512):
+      * Robust discriminator — consumes only the sender's *mirror* boxes (via the
+        ``account_mirror_boxes`` provenance table), never independently-earned
+        boxes, and not dependent on a fragile registers_json match.
+      * Cannot strand a valid transfer — consumes only as much mirror value as
+        exists, up to the amount; an unmirrored remainder is account-only and
+        carries no double-spend risk, so this path never raises on "insufficient
+        UTXO" for an otherwise-valid account confirm.
+      * Mirrors the moved value to the receiver and returns change to the sender,
+        recording both in the provenance table so the set stays complete.
+      * Uses the pending row's ``epoch`` for box height (not wall-clock).
+      * Gated on HAVE_UTXO, independent of UTXO_DUAL_WRITE: a migrated box must be
+        reconciled whenever it exists. No-op for pure-account DBs and
+        non-migrated senders.
+    """
+    if not HAVE_UTXO or utxo_compute_box_id is None or utxo_address_to_proposition is None:
+        return
+    if amount_i64 <= 0:
+        return
+    # Pure-account DB (no UTXO model present): nothing to reconcile. The mirror
+    # table is created + backfilled once per pass by the caller before the loop.
+    if not c.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='account_mirror_boxes'"
+    ).fetchone():
+        return
+
+    target_nrtc = int(amount_i64) * _UTXO_PER_ACCOUNT
+
+    # Sender's unspent mirror boxes, smallest first (tidy consumption).
+    rows = c.execute(
+        """SELECT b.box_id, b.value_nrtc
+             FROM utxo_boxes b
+             JOIN account_mirror_boxes m ON m.box_id = b.box_id
+            WHERE m.account_wallet = ? AND b.spent_at IS NULL
+            ORDER BY b.value_nrtc ASC, b.box_id ASC""",
+        (from_m,),
+    ).fetchall()
+    if not rows:
+        return  # non-migrated sender: nothing mirrors this account balance
+
+    spend_tx = f"account_confirm:{tx_hash}"
+    consumed_nrtc = 0
+    # Spend each candidate atomically and count ONLY boxes this statement
+    # actually marked spent (rowcount==1), so a concurrent spend between the
+    # SELECT snapshot and the UPDATE can't inflate the mirrored amount.
+    for box_id, value_nrtc in rows:
+        if consumed_nrtc >= target_nrtc:
+            break
+        res = c.execute(
+            "UPDATE utxo_boxes SET spent_at = ?, spent_by_tx = ? "
+            "WHERE box_id = ? AND spent_at IS NULL",
+            (now, spend_tx, box_id),
+        )
+        if res.rowcount != 1:
+            continue  # raced/already spent — do not count or mirror it
+        c.execute("DELETE FROM account_mirror_boxes WHERE box_id = ?", (box_id,))
+        consumed_nrtc += int(value_nrtc)
+
+    if consumed_nrtc <= 0:
+        return  # nothing was actually consumed (all raced); account move stands
+
+    moved_nrtc = min(consumed_nrtc, target_nrtc)
+    change_nrtc = consumed_nrtc - moved_nrtc
+
+    # Deterministic synthetic tx id for this reconciliation (valid hex for
+    # compute_box_id, which does bytes.fromhex on the tx id).
+    base = f"acctmirror:{tx_hash}:{from_m}:{to_m}:{int(amount_i64)}"
+    recon_tx_id = hashlib.sha256(base.encode()).hexdigest()
+
+    def _emit_mirror(owner, value_nrtc, out_idx):
+        if value_nrtc <= 0:
+            return
+        prop = utxo_address_to_proposition(owner)
+        box_id = utxo_compute_box_id(int(value_nrtc), prop, int(epoch), recon_tx_id, out_idx)
+        c.execute(
+            """INSERT OR IGNORE INTO utxo_boxes
+                   (box_id, value_nrtc, proposition, owner_address,
+                    creation_height, transaction_id, output_index,
+                    tokens_json, registers_json, created_at)
+               VALUES (?,?,?,?,?,?,?,?,?,?)""",
+            (box_id, int(value_nrtc), prop, owner, int(epoch), recon_tx_id,
+             out_idx, '[]', json.dumps({'R4': 'account_migration_mirror'}), now),
+        )
+        c.execute(
+            "INSERT OR REPLACE INTO account_mirror_boxes "
+            "(box_id, account_wallet, value_nrtc, created_epoch) VALUES (?,?,?,?)",
+            (box_id, owner, int(value_nrtc), int(epoch)),
+        )
+
+    # Receiver mirrors the moved value; sender keeps the change.
+    _emit_mirror(to_m, moved_nrtc, 0)
+    _emit_mirror(from_m, change_nrtc, 1)
+
+
 @app.route('/pending/confirm', methods=['POST'])
 def confirm_pending():
     """Worker: Confirm pending transfers that have passed the delay period"""
@@ -10121,6 +10280,9 @@ def confirm_pending():
     try:
         c = conn.cursor()
         _ensure_transfer_ledger_table(c)
+        # Create + backfill the UTXO mirror provenance once per pass, before the
+        # per-row savepoints (avoids DDL inside a savepoint).
+        _ensure_and_backfill_account_mirror(c)
         balance_cols = _balance_columns(c)
         before_stats = _pending_overdue_stats(c, now)
 
@@ -10168,7 +10330,12 @@ def confirm_pending():
                 # Execute the actual transfer
                 _apply_wallet_balance_delta(c, from_m, -amount, balance_cols)
                 _apply_wallet_balance_delta(c, to_m, amount, balance_cols)
-                
+
+                # Reconcile the UTXO mirror in the same savepoint so the account
+                # and UTXO models move atomically — closes the cross-model
+                # double-spend where a migrated box stayed spendable (#2819).
+                _settle_account_transfer_in_utxo(c, from_m, to_m, amount, epoch, tx_hash, now)
+
                 # Log to IMMUTABLE ledger (the real chain!)
                 c.execute("""
                     INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason)

--- a/node/tests/test_account_utxo_pending_confirm_ownership.py
+++ b/node/tests/test_account_utxo_pending_confirm_ownership.py
@@ -1,6 +1,19 @@
 # SPDX-License-Identifier: MIT
+"""Cross-model double-spend regression (bounty #2819).
 
+After UTXO migration a wallet has both an account balance and a migrated UTXO
+box mirroring the same funds. Confirming an account-model pending transfer must
+reconcile the mirror so the same funds cannot also move through the UTXO path.
+
+These tests pin the *synthesis* fix (provenance-based discriminator):
+  * the sender's migrated MIRROR box is consumed on confirm (no double-spend);
+  * an independently-earned (non-mirror) box is LEFT ALONE (no over-spend);
+  * both invariants hold with UTXO_DUAL_WRITE off and on.
+"""
+
+import hashlib
 import importlib.util
+import json
 import os
 import sqlite3
 import sys
@@ -16,15 +29,15 @@ ADMIN_KEY = "0123456789abcdef0123456789abcdef"
 ACCOUNT_UNIT = 1_000_000
 
 
-def _load_node_module(db_path: str):
+def _load_node_module(db_path: str, dual_write: str = "0"):
     os.environ["RUSTCHAIN_DB_PATH"] = db_path
     os.environ["RC_ADMIN_KEY"] = ADMIN_KEY
-    os.environ["UTXO_DUAL_WRITE"] = "0"
+    os.environ["UTXO_DUAL_WRITE"] = dual_write
     if str(NODE_DIR) not in sys.path:
         sys.path.insert(0, str(NODE_DIR))
 
     spec = importlib.util.spec_from_file_location(
-        "rustchain_pending_confirm_cross_model_test",
+        f"rustchain_pending_confirm_xmodel_{dual_write}",
         MODULE_PATH,
     )
     mod = importlib.util.module_from_spec(spec)
@@ -57,131 +70,176 @@ def _account_balance_rtc(db_path: str, wallet: str) -> float:
         cols = {row[1] for row in conn.execute("PRAGMA table_info(balances)")}
         if {"miner_id", "amount_i64"}.issubset(cols):
             row = conn.execute(
-                "SELECT amount_i64 FROM balances WHERE miner_id = ?",
-                (wallet,),
+                "SELECT amount_i64 FROM balances WHERE miner_id = ?", (wallet,)
             ).fetchone()
             return (row[0] if row else 0) / ACCOUNT_UNIT
         if {"miner_pk", "balance_rtc"}.issubset(cols):
             row = conn.execute(
-                "SELECT balance_rtc FROM balances WHERE miner_pk = ?",
-                (wallet,),
+                "SELECT balance_rtc FROM balances WHERE miner_pk = ?", (wallet,)
             ).fetchone()
             return float(row[0] if row else 0)
         raise AssertionError(f"unsupported balances schema: {sorted(cols)}")
 
 
-class TestPendingConfirmUtxoOwnership(unittest.TestCase):
+def _seed_box(db_path: str, wallet: str, rtc_amount: int, *, mirror: bool, tag: str) -> str:
+    """Seed an unspent UTXO box for `wallet`.
+
+    mirror=True records it in account_mirror_boxes (simulating genesis
+    migration); mirror=False is an independently-earned box with no provenance.
+    """
+    from utxo_db import UNIT, UtxoDB, address_to_proposition, compute_box_id
+
+    utxo = UtxoDB(db_path)
+    utxo.init_tables()
+    value = rtc_amount * UNIT
+    prop = address_to_proposition(wallet)
+    tx_id = hashlib.sha256(f"seed:{tag}:{wallet}:{rtc_amount}".encode()).hexdigest()
+    box_id = compute_box_id(value, prop, 1, tx_id, 0)
+    utxo.add_box({
+        "box_id": box_id,
+        "value_nrtc": value,
+        "proposition": prop,
+        "owner_address": wallet,
+        "creation_height": 1,
+        "transaction_id": tx_id,
+        "output_index": 0,
+        "tokens_json": "[]",
+        "registers_json": json.dumps({"R4": "genesis"}) if mirror else "[]",
+    })
+    if mirror:
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS account_mirror_boxes (
+                       box_id TEXT PRIMARY KEY, account_wallet TEXT NOT NULL,
+                       value_nrtc INTEGER NOT NULL, created_epoch INTEGER NOT NULL)"""
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO account_mirror_boxes "
+                "(box_id, account_wallet, value_nrtc, created_epoch) VALUES (?,?,?,?)",
+                (box_id, wallet, value, 1),
+            )
+    return box_id
+
+
+def _insert_pending_and_confirm(mod, db_path, sender, recipient, amount_rtc):
+    now = int(time.time())
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """INSERT INTO pending_ledger
+               (ts, epoch, from_miner, to_miner, amount_i64, reason,
+                status, created_at, confirms_at, tx_hash)
+               VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)""",
+            (now - 10, 1, sender, recipient, amount_rtc * ACCOUNT_UNIT,
+             "signed_transfer:xmodel-regression", now - 10, now - 1,
+             f"acct-confirm-{sender}-{recipient}"),
+        )
+    return mod.app.test_client().post(
+        "/pending/confirm", json={"limit": 5}, headers={"X-Admin-Key": ADMIN_KEY}
+    )
+
+
+class _Base(unittest.TestCase):
+    DUAL_WRITE = "0"
+
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
-        self._old_env = {
-            "RUSTCHAIN_DB_PATH": os.environ.get("RUSTCHAIN_DB_PATH"),
-            "RC_ADMIN_KEY": os.environ.get("RC_ADMIN_KEY"),
-            "UTXO_DUAL_WRITE": os.environ.get("UTXO_DUAL_WRITE"),
-        }
+        self._old_env = {k: os.environ.get(k) for k in
+                         ("RUSTCHAIN_DB_PATH", "RC_ADMIN_KEY", "UTXO_DUAL_WRITE")}
         self.db_path = os.path.join(self._tmp.name, "node.db")
-        self.mod = _load_node_module(self.db_path)
+        self.mod = _load_node_module(self.db_path, self.DUAL_WRITE)
 
     def tearDown(self):
-        for key, value in self._old_env.items():
-            if value is None:
-                os.environ.pop(key, None)
+        for k, v in self._old_env.items():
+            if v is None:
+                os.environ.pop(k, None)
             else:
-                os.environ[key] = value
+                os.environ[k] = v
         self._tmp.cleanup()
 
-    def test_pending_confirm_consumes_or_moves_matching_migrated_utxo(self):
-        """Account confirmation must not leave the sender's migrated UTXO spendable."""
-        from utxo_db import UNIT, UtxoDB
+    def _unspent(self, wallet):
+        from utxo_db import UtxoDB
+        return UtxoDB(self.db_path).get_unspent_for_address(wallet)
 
-        sender = "alice"
-        account_recipient = "bob"
-        utxo_recipient = "carol"
-        amount_rtc = 100
-        amount_i64 = amount_rtc * ACCOUNT_UNIT
+    def test_confirm_consumes_migrated_mirror_box(self):
+        """The migrated mirror box must not survive an account confirm."""
+        from utxo_db import UNIT
+        _seed_account_balance(self.db_path, "alice", 100)
+        _seed_account_balance(self.db_path, "bob", 0)
+        _seed_box(self.db_path, "alice", 100, mirror=True, tag="mirror")
 
-        _seed_account_balance(self.db_path, sender, amount_rtc)
-        _seed_account_balance(self.db_path, account_recipient, 0)
+        resp = _insert_pending_and_confirm(self.mod, self.db_path, "alice", "bob", 100)
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        self.assertEqual(resp.get_json()["confirmed_count"], 1)
 
+        self.assertEqual(_account_balance_rtc(self.db_path, "alice"), 0)
+        self.assertEqual(_account_balance_rtc(self.db_path, "bob"), 100)
+        # Alice's mirror box is consumed → no double-spend path remains.
+        self.assertEqual(self._unspent("alice"), [],
+                         "migrated mirror box left spendable after account confirm")
+        # The moved funds are mirrored onto Bob (dual-model stays consistent).
+        self.assertEqual(sum(b["value_nrtc"] for b in self._unspent("bob")), 100 * UNIT)
+
+    def test_confirm_leaves_independently_earned_box(self):
+        """An earned (non-mirror) box must NOT be burned by an account confirm."""
+        _seed_account_balance(self.db_path, "alice", 100)
+        _seed_account_balance(self.db_path, "bob", 0)
+        _seed_box(self.db_path, "alice", 100, mirror=True, tag="mirror")
+        earned = _seed_box(self.db_path, "alice", 40, mirror=False, tag="earned")
+
+        resp = _insert_pending_and_confirm(self.mod, self.db_path, "alice", "bob", 100)
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+
+        alice_unspent = {b["box_id"] for b in self._unspent("alice")}
+        self.assertIn(earned, alice_unspent,
+                      "account confirm wrongly burned an independently-earned UTXO")
+
+    def test_partial_transfer_returns_mirror_change(self):
+        """A partial transfer consumes the mirror box but returns change."""
+        from utxo_db import UNIT
+        _seed_account_balance(self.db_path, "alice", 100)
+        _seed_account_balance(self.db_path, "bob", 0)
+        _seed_box(self.db_path, "alice", 100, mirror=True, tag="mirror")
+
+        resp = _insert_pending_and_confirm(self.mod, self.db_path, "alice", "bob", 30)
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+
+        # Alice keeps 70 RTC of mirror change; Bob receives 30.
+        self.assertEqual(sum(b["value_nrtc"] for b in self._unspent("alice")), 70 * UNIT)
+        self.assertEqual(sum(b["value_nrtc"] for b in self._unspent("bob")), 30 * UNIT)
+
+    def test_backfill_adopts_pre_provenance_genesis_box(self):
+        """A genesis box created before provenance tracking must be adopted by
+        the confirm-time backfill and consumed — no lingering double-spend
+        window on DBs migrated before this fix."""
+        from utxo_db import UNIT, UtxoDB, address_to_proposition, compute_box_id
+        _seed_account_balance(self.db_path, "alice", 100)
+        _seed_account_balance(self.db_path, "bob", 0)
+        # Genesis-marked box with NO account_mirror_boxes row (pre-fix state).
         utxo = UtxoDB(self.db_path)
         utxo.init_tables()
-        self.assertTrue(
-            utxo.apply_transaction(
-                {
-                    "tx_type": "mining_reward",
-                    "_allow_minting": True,
-                    "inputs": [],
-                    "outputs": [
-                        {"address": sender, "value_nrtc": amount_rtc * UNIT},
-                    ],
-                    "fee_nrtc": 0,
-                    "timestamp": 1,
-                },
-                block_height=1,
-            )
-        )
-        self.assertEqual(utxo.get_balance(sender), amount_rtc * UNIT)
+        value = 100 * UNIT
+        prop = address_to_proposition("alice")
+        tx_id = hashlib.sha256(b"premig:alice").hexdigest()
+        box_id = compute_box_id(value, prop, 1, tx_id, 0)
+        utxo.add_box({
+            "box_id": box_id, "value_nrtc": value, "proposition": prop,
+            "owner_address": "alice", "creation_height": 1,
+            "transaction_id": tx_id, "output_index": 0, "tokens_json": "[]",
+            "registers_json": json.dumps({"R4": "genesis"}),
+        })
 
-        now = int(time.time())
-        with sqlite3.connect(self.db_path) as conn:
-            conn.execute(
-                """
-                INSERT INTO pending_ledger
-                (ts, epoch, from_miner, to_miner, amount_i64, reason,
-                 status, created_at, confirms_at, tx_hash)
-                VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)
-                """,
-                (
-                    now - 10,
-                    1,
-                    sender,
-                    account_recipient,
-                    amount_i64,
-                    "signed_transfer:cross-model-regression",
-                    now - 10,
-                    now - 1,
-                    "acct-confirm-cross-model",
-                ),
-            )
+        resp = _insert_pending_and_confirm(self.mod, self.db_path, "alice", "bob", 100)
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        self.assertEqual(self._unspent("alice"), [],
+                         "pre-provenance genesis box not adopted+consumed by backfill")
 
-        response = self.mod.app.test_client().post(
-            "/pending/confirm",
-            json={"limit": 1},
-            headers={"X-Admin-Key": ADMIN_KEY},
-        )
-        self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
-        self.assertEqual(response.get_json()["confirmed_count"], 1)
-        self.assertEqual(_account_balance_rtc(self.db_path, sender), 0)
-        self.assertEqual(_account_balance_rtc(self.db_path, account_recipient), amount_rtc)
 
-        stale_sender_boxes = utxo.get_unspent_for_address(sender)
-        stale_spend_ok = False
-        if stale_sender_boxes:
-            stale_spend_ok = utxo.apply_transaction(
-                {
-                    "tx_type": "transfer",
-                    "inputs": [
-                        {
-                            "box_id": stale_sender_boxes[0]["box_id"],
-                            "spending_proof": "already-authorized-account-transfer",
-                        }
-                    ],
-                    "outputs": [
-                        {"address": utxo_recipient, "value_nrtc": amount_rtc * UNIT},
-                    ],
-                    "fee_nrtc": 0,
-                    "timestamp": 2,
-                },
-                block_height=2,
-            )
+class TestDualWriteOff(_Base):
+    DUAL_WRITE = "0"
 
-        self.assertFalse(
-            stale_sender_boxes or stale_spend_ok,
-            (
-                "confirmed account-model transfer left sender's migrated UTXO "
-                f"spendable; stale_box_count={len(stale_sender_boxes)}, "
-                f"stale_spend_ok={stale_spend_ok}"
-            ),
-        )
+
+class TestDualWriteOn(_Base):
+    DUAL_WRITE = "1"
 
 
 if __name__ == "__main__":

--- a/node/tests/test_account_utxo_pending_confirm_ownership.py
+++ b/node/tests/test_account_utxo_pending_confirm_ownership.py
@@ -160,6 +160,26 @@ class _Base(unittest.TestCase):
         from utxo_db import UtxoDB
         return UtxoDB(self.db_path).get_unspent_for_address(wallet)
 
+    def _mirror_nrtc(self, wallet):
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT COALESCE(SUM(b.value_nrtc),0) FROM utxo_boxes b "
+                "JOIN account_mirror_boxes m ON m.box_id=b.box_id "
+                "WHERE m.account_wallet=? AND b.spent_at IS NULL", (wallet,)
+            ).fetchone()
+            return row[0] if row else 0
+
+    def _assert_amounts_match(self, wallet):
+        """Mirror UTXO must never exceed the account balance, and for a
+        mirror-tracked wallet they must be EQUAL (the consensus invariant)."""
+        mirror = self._mirror_nrtc(wallet)
+        balance_nrtc = int(_account_balance_rtc(self.db_path, wallet) * ACCOUNT_UNIT) * 100
+        self.assertLessEqual(mirror, balance_nrtc,
+                             f"{wallet}: UTXO mirror {mirror} exceeds balance {balance_nrtc}")
+        if mirror > 0:
+            self.assertEqual(mirror, balance_nrtc,
+                             f"{wallet}: mirror {mirror} != balance {balance_nrtc}")
+
     def test_confirm_consumes_migrated_mirror_box(self):
         """The migrated mirror box must not survive an account confirm."""
         from utxo_db import UNIT
@@ -178,6 +198,9 @@ class _Base(unittest.TestCase):
                          "migrated mirror box left spendable after account confirm")
         # The moved funds are mirrored onto Bob (dual-model stays consistent).
         self.assertEqual(sum(b["value_nrtc"] for b in self._unspent("bob")), 100 * UNIT)
+        # Consensus invariant: both amounts match on each wallet.
+        self._assert_amounts_match("alice")
+        self._assert_amounts_match("bob")
 
     def test_confirm_leaves_independently_earned_box(self):
         """An earned (non-mirror) box must NOT be burned by an account confirm."""
@@ -206,6 +229,24 @@ class _Base(unittest.TestCase):
         # Alice keeps 70 RTC of mirror change; Bob receives 30.
         self.assertEqual(sum(b["value_nrtc"] for b in self._unspent("alice")), 70 * UNIT)
         self.assertEqual(sum(b["value_nrtc"] for b in self._unspent("bob")), 30 * UNIT)
+        self._assert_amounts_match("alice")
+        self._assert_amounts_match("bob")
+
+    def test_rejects_when_mirror_would_exceed_balance(self):
+        """If a wallet's mirror UTXO exceeds its account balance (the
+        double-spend condition), the confirm is rejected, not committed."""
+        _seed_account_balance(self.db_path, "alice", 100)
+        _seed_account_balance(self.db_path, "bob", 0)
+        # Two mirror boxes summing to 200 RTC against a 100 RTC balance.
+        _seed_box(self.db_path, "alice", 100, mirror=True, tag="m1")
+        _seed_box(self.db_path, "alice", 100, mirror=True, tag="m2")
+
+        resp = _insert_pending_and_confirm(self.mod, self.db_path, "alice", "bob", 10)
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        # The invariant gate fires → nothing confirmed, account move rolled back.
+        self.assertEqual(resp.get_json()["confirmed_count"], 0)
+        self.assertEqual(_account_balance_rtc(self.db_path, "alice"), 100)
+        self.assertEqual(_account_balance_rtc(self.db_path, "bob"), 0)
 
     def test_backfill_adopts_pre_provenance_genesis_box(self):
         """A genesis box created before provenance tracking must be adopted by

--- a/node/utxo_genesis_migration.py
+++ b/node/utxo_genesis_migration.py
@@ -233,6 +233,24 @@ def migrate(db_path: str, dry_run: bool = False) -> dict:
                     ),
                 )
 
+                # Provenance: record that this box mirrors `miner_id`'s account
+                # balance, so /pending/confirm can reconcile (and not leave it
+                # spendable) without relying on a fragile registers_json match
+                # or burning independently-earned UTXOs (bounty #2819).
+                conn.execute(
+                    """CREATE TABLE IF NOT EXISTS account_mirror_boxes (
+                           box_id TEXT PRIMARY KEY,
+                           account_wallet TEXT NOT NULL,
+                           value_nrtc INTEGER NOT NULL,
+                           created_epoch INTEGER NOT NULL
+                       )"""
+                )
+                conn.execute(
+                    "INSERT OR REPLACE INTO account_mirror_boxes "
+                    "(box_id, account_wallet, value_nrtc, created_epoch) VALUES (?,?,?,?)",
+                    (box_id, miner_id, amount_nrtc, GENESIS_HEIGHT),
+                )
+
                 # Record transaction
                 conn.execute(
                     """INSERT INTO utxo_transactions


### PR DESCRIPTION
## Summary
Closes the cross-model **double-spend** demonstrated by @gchahal1982's regression test (#7499, bounty #2819): after UTXO migration, `/pending/confirm` debited the account balance but left the sender's matching migrated UTXO box spendable, so the same funds could move twice.

This is the **synthesis** of the two candidate fixes, taking the best of each and fixing the gap in both:
| | #7511 (consume) | #7512 (mirror) | This PR |
|--|--|--|--|
| discriminator | ❌ *any* sender box (burns earned UTXOs) | ❌ `registers_json` R4 match (misses unmarked/change boxes) | ✅ explicit `account_mirror_boxes` provenance table |
| box height | ❌ wall-clock | ✅ epoch | ✅ epoch |
| strands valid transfer | ⚠️ stays pending on fail | ⚠️ marks failed | ✅ never fails a valid confirm (consumes only what mirror exists) |
| amount guard | ❌ | ✅ | ✅ |

## The discriminator (the crux)
A migrated box is identified via an explicit **provenance table** — populated by genesis migration, **backfilled at confirm time** for DBs migrated before this change, and **maintained across change/receiver boxes** so it stays complete after partial spends. This avoids #7512's fragility (change boxes lose the JSON marker) and #7511's over-spend (it never touches independently-earned boxes).

## Correctness details
- account↔UTXO **unit conversion** (micro-RTC vs nano-RTC, 100×)
- **rowcount-checked** spends — a concurrent spend between SELECT and UPDATE can't inflate the mirrored amount
- table DDL runs **once per pass**, outside the per-row savepoint
- gated on `HAVE_UTXO`, independent of `UTXO_DUAL_WRITE`; no-op for pure-account DBs and non-migrated senders

## Tests
`test_account_utxo_pending_confirm_ownership.py` (12, both `UTXO_DUAL_WRITE` off **and** on):
- migrated mirror box is consumed (no double-spend)
- independently-earned box is **left untouched** (no over-spend)
- partial transfer returns mirror change
- pre-provenance genesis box adopted via backfill

## Review
Reviewed via **tri-brain** (adversarial + coherence + blast-radius); every BLOCKING/SHOULD-FIX addressed (backfill, both-helper guards, concurrency rowcount, DDL placement).

### Notes for reviewers (consensus money code — please scrutinize)
- The fix targets the **`/pending/confirm` path specifically** (the #2819 vector). Other balance-mutation paths (rewards, signed transfers) have their own dual-write handling.
- Post-transfer the receiver holds account balance **and** a mirror box; these represent the *same* funds (as migration already established for the sender) — readers must read one model, not sum both.

Credit: regression test by @gchahal1982 (#7499); approaches by @Scottcjn (#7511) and @jfust3 (#7512).