### PR TITLE
fix(ci): make the BCOS tier auto-labeler risk-aware (consensus code → L2)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -70,21 +70,64 @@ api:
       - '**/api*'
       - '**/endpoint*'
 
+# ----------------------------------------------------------------------------
+# BCOS risk tiers — the proof a reviewer relies on to know how hard to look.
+#
+# L2 (critical scrutiny): anything that can move money, change balances/supply,
+#   decide consensus/rewards, gate auth/identity, or migrate ledger state. A bug
+#   here can mint, burn, double-spend, or take over the chain. The MAIN NODE
+#   (`rustchain_v2_integrated*.py`, `node/**`) lives here — it owns the ledger,
+#   UTXO set, epoch settlement, pending-confirm, and the agent-economy escrow,
+#   so a change to it is L2 by default, NOT L1.
+# L1 (standard scrutiny): code that does not touch any of the above (tooling,
+#   bots, explorers, dashboards, miners' non-reward paths). Mutually exclusive
+#   with L2 via the negation block below, so the tier is unambiguous.
+# Doc-only PRs are exempt (handled by the gate in bcos.yml).
+# ----------------------------------------------------------------------------
+
+# Keep this list in sync with the negations in BCOS-L1.
 BCOS-L2:
   - changed-files:
     - any-glob-to-any-file:
+      # Consensus engine + the node that owns ledger/UTXO/settlement state
+      - 'rustchain_v2_integrated*.py'
+      - 'node/**'
+      - 'rip_200_round_robin_1cpu1vote.py'
+      - 'rewards_implementation_rip200.py'
+      - '**/consensus*'
+      - '**/epoch*'
+      - '**/settle*'
+      # Money: ledger, UTXO, balances, transfers, pending confirm, migration
+      - '**/utxo*'
+      - '**/*ledger*'
+      - '**/pending*'
+      - '**/*migration*'
+      - '**/anti_double_mining*'
+      - '**/balance*'
+      - '**/transfer*'
+      # Cross-chain value movement (bridge / anchors)
+      - '**/bridge*'
+      - '**/*anchor*'
+      - 'ergo_*'
+      # Agent-economy escrow / staking settlement
+      - '**/rip302*'
+      - '**/*agent_economy*'
+      - '**/*escrow*'
+      - '**/*stak*'
+      # Auth, crypto, hardware attestation, wallets, identity
       - 'fingerprint_checks.py'
       - 'hardware_fingerprint.py'
       - 'rustchain_crypto.py'
       - 'rustchain_wallet_*.py'
-      - 'rip_200_round_robin_1cpu1vote.py'
-      - 'rewards_implementation_rip200.py'
       - '**/auth*'
       - '**/crypto*'
       - '**/security*'
-      - '**/consensus*'
       - '**/wallet*'
+      - '**/beacon*'
 
+# L1 = source code that matches NONE of the L2 high-risk paths above.
+# The any-glob (a code file) and all-globs (not an L2 path) are AND-ed, so a
+# consensus/money file never lands in L1.
 BCOS-L1:
   - changed-files:
     - any-glob-to-any-file:
@@ -96,3 +139,34 @@ BCOS-L1:
       - '**/*.c'
       - '**/*.h'
       - '**/*.go'
+    - all-globs-to-all-files:
+      - '!rustchain_v2_integrated*.py'
+      - '!node/**'
+      - '!rip_200_round_robin_1cpu1vote.py'
+      - '!rewards_implementation_rip200.py'
+      - '!**/consensus*'
+      - '!**/epoch*'
+      - '!**/settle*'
+      - '!**/utxo*'
+      - '!**/*ledger*'
+      - '!**/pending*'
+      - '!**/*migration*'
+      - '!**/anti_double_mining*'
+      - '!**/balance*'
+      - '!**/transfer*'
+      - '!**/bridge*'
+      - '!**/*anchor*'
+      - '!ergo_*'
+      - '!**/rip302*'
+      - '!**/*agent_economy*'
+      - '!**/*escrow*'
+      - '!**/*stak*'
+      - '!fingerprint_checks.py'
+      - '!hardware_fingerprint.py'
+      - '!rustchain_crypto.py'
+      - '!rustchain_wallet_*.py'
+      - '!**/auth*'
+      - '!**/crypto*'
+      - '!**/security*'
+      - '!**/wallet*'
+      - '!**/beacon*'


### PR DESCRIPTION
## Problem
The tier auto-labeler under-labeled **consensus-critical PRs as BCOS-L1**. The main node (`rustchain_v2_integrated*.py`, `node/**`), UTXO/ledger code, pending-confirm, epoch settlement, migrations, and the agent-economy escrow were **absent from the BCOS-L2 path set** — so a change to the chain's money path fell through the blanket `**/*.py` rule and got L1 (standard scrutiny) instead of L2 (critical).

Real example: the #2819 double-spend fix (#7727) edits the core node and was auto-labeled **BCOS-L1**, and re-asserted L1 even after a manual bump to L2.

## Fix
**BCOS-L2** now covers everything that can move money, change balances/supply, decide consensus/rewards, gate auth/identity, or migrate ledger state — each family documented with *why* it's high-risk (the "proof" a reviewer relies on):
- node / consensus engine / epoch settlement
- ledger / UTXO / transfer / pending-confirm / migration / anti-double-mining / balances
- bridge / anchors (cross-chain value)
- agent-economy escrow / staking
- auth / crypto / wallet / beacon (identity)

**BCOS-L1** now `all-globs`-negates the L2 paths, so a consensus/money file lands in **exactly one tier** (no more L1+L2 ambiguity, no more L1 re-assertion over a correct L2).

## Verification (simulated against the rules)
| PR | tier |
|----|------|
| #2819 node fix (`node/…`, `utxo_genesis_migration.py`) | **L2** (was L1) |
| wallet SDK (`…/wallet.py`) | L2 |
| explorer JS / bot tooling | L1 |
| docs / dep bumps | exempt |

## Follow-up (noted, not in this PR)
A future enhancement could feed the **BCOS trust-score scan receipts** back into the tier decision (bump to L2 when the scan flags high-risk patterns even in an unlisted path), making the labeler dynamic rather than purely path-based. This PR fixes the path coverage that caused the immediate mislabeling.