### PR TITLE
[codex] Compute mining calculator average multiplier

### DIFF
--- a/mining-calculator/index.html
+++ b/mining-calculator/index.html
@@ -464,6 +464,12 @@
             { multiplier: 1.0, count: 2 }   // Modern x86
         ];
 
+        const DEFAULT_AVG_MULTIPLIER = (() => {
+            const weightedMultiplierSum = DEFAULT_NETWORK.reduce((sum, item) => sum + item.multiplier * item.count, 0);
+            const totalMiners = DEFAULT_NETWORK.reduce((sum, item) => sum + item.count, 0);
+            return totalMiners > 0 ? weightedMultiplierSum / totalMiners : 1.0;
+        })();
+
         function normalizeNetworkPayload(payload) {
             if (Array.isArray(payload)) {
                 return { miners: payload, total: payload.length };
@@ -576,7 +582,7 @@
                 const presetMiners = parseInt(networkMode);
                 
                 // Estimate total weight based on preset count and average multiplier
-                const avgMultiplier = 1.5; // Conservative average
+                const avgMultiplier = DEFAULT_AVG_MULTIPLIER;
                 const totalWeight = presetMiners * avgMultiplier + userMultiplier;
                 
                 performCalculations(userMultiplier, totalWeight, presetMiners + 1);
@@ -625,7 +631,7 @@
             tbody.innerHTML = '';
             
             const networkSizes = [10, 50, 100, 200, 500, 1000];
-            const avgMultiplier = 1.5;
+            const avgMultiplier = DEFAULT_AVG_MULTIPLIER;
             
             networkSizes.forEach(size => {
                 const totalWeight = (size * avgMultiplier) + userMultiplier;


### PR DESCRIPTION
## Summary
- Replace the mining calculator's hardcoded default-network average multiplier with a computed value derived from DEFAULT_NETWORK.
- Reuse the computed average in preset miner mode and the sensitivity table.

## Why
The calculator had two paths using const avgMultiplier = 1.5, so estimates could drift when DEFAULT_NETWORK changes. With the current DEFAULT_NETWORK, the derived value is 19.9 / 12 = 1.6583 instead of the hardcoded 1.5.

Fixes #7728.

## Validation
- git diff --check
- node static calculation check confirmed totalWeight=19.9, totalMiners=12, avg=1.6583