### PR TITLE
[codex] Show VM mining rewards with six decimals

### DIFF
--- a/mining-simulator.html
+++ b/mining-simulator.html
@@ -366,7 +366,7 @@
                     <div class="icon">${c.icon}</div>
                     <div>${c.name}</div>
                     <div class="multiplier">${c.multiplier}x</div>
-                    <div class="earnings">${(baseReward * c.multiplier).toFixed(2)} RTC</div>
+                    <div class="earnings">${(baseReward * c.multiplier).toFixed(6)} RTC</div>
                 </div>
             `).join('');
             


### PR DESCRIPTION
## Summary
- Update the mining simulator comparison table to render rewards with six decimal places.
- Keep VM rewards visible as 0.000001 RTC instead of rounding them to 0.00 RTC.

## Why
The main reward display already uses six decimals, but the comparison table used two decimals. That made very small VM rewards appear as zero in one part of the UI while still showing a non-zero reward elsewhere.

Fixes #7732.

## Validation
- git diff --check
- Extracted the inline script from mining-simulator.html and parsed it with Node
- Confirmed the comparison table uses toFixed(6)