### PR TITLE
Fix vintage miner attestation multiplier output

### DIFF
--- a/vintage_miner/vintage_miner_client.py
+++ b/vintage_miner/vintage_miner_client.py
@@ -430,7 +430,7 @@ def main():
             evidence = result['evidence']
             print(f"\nFingerprint Hash: {evidence['attestation']['fingerprint_hash'][:32]}...")
             print(f"Device Arch: {evidence['attestation']['device_arch']}")
-            print(f"Multiplier: {evidence['profile']['multiplier']}x")
+            print(f"Multiplier: {client.multiplier}x")
             print(f"Era: {evidence['profile']['era']}")
             print(f"Bounty: {evidence['profile']['bounty']} RTC")
             


### PR DESCRIPTION
## Summary
- Fixes the successful attestation output path so it reads the multiplier from the client instead of a missing profile field.
- Prevents a KeyError after attestation evidence is generated.

## Validation
- python -m py_compile vintage_miner/vintage_miner_client.py
- python vintage_miner_client.py --profile pentium_ii --miner-id codex-test --dry-run

Fixes #7766