### PR TITLE
Fix new fetchall guard hits

### DIFF
--- a/node/api_v1.py
+++ b/node/api_v1.py
@@ -46,9 +46,13 @@ def register_api_v1(app, *, db_path, current_slot, slot_to_epoch,
                 return jsonify({"error": "internal_error"}), 500
         return wrapper
 
-    def _rows(sql, params=()):
+    def _rows(sql, params=(), *, limit=1000):
         with _ro() as c:
             c.row_factory = sqlite3.Row
+            if "LIMIT" not in sql.upper():
+                sql = sql.rstrip().rstrip(";") + " LIMIT ?"
+                params = tuple(params) + (limit,)
+            # fetchall-ok: already-paginated
             return [dict(r) for r in c.execute(sql, params).fetchall()]
 
     def _one(sql, params=()):

--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -26,6 +26,8 @@ from decimal import Decimal, InvalidOperation
 from dataclasses import dataclass
 from enum import Enum
 
+from node.db_helpers import fetch_page
+
 # Import from main node module
 try:
     from rustchain_v2_integrated_v2_2_1_rip200 import (
@@ -579,10 +581,9 @@ def list_bridge_transfers(
         query += " AND direction = ?"
         params.append(direction)
     
-    query += " ORDER BY id DESC LIMIT ?"
-    params.append(min(limit, 500))
-    
-    rows = cursor.execute(query, params).fetchall()
+    query += " ORDER BY id DESC"
+    db = cursor.connection if hasattr(cursor, "connection") else cursor
+    rows = fetch_page(db, query, params, limit=min(limit, 500))
     
     return [
         {
@@ -1195,36 +1196,54 @@ def migrate_deposits_to_hard_locks(cursor):
     model) is left at source_debited=0 and logged for manual review rather than
     minting a negative balance.
     """
-    try:
-        rows = cursor.execute("""
-            SELECT id, source_address, amount_i64
-            FROM bridge_transfers
-            WHERE direction = 'deposit'
-              AND status IN ('pending', 'locked', 'confirming')
-              AND source_debited = 0
-        """).fetchall()
-    except sqlite3.OperationalError as exc:
-        # Expected only when bridge_transfers/balances aren't created yet in this
-        # init ordering. Log it so a genuine schema error can't hide here and
-        # silently leave legacy deposits un-migrated (which the completion safety
-        # net would then have to catch).
-        logger.warning("debit-on-lock migration skipped (schema not ready?): %s", exc)
-        return
+    page_size = 250
+    last_seen_id = 0
+    db = cursor.connection if hasattr(cursor, "connection") else cursor
 
-    for row_id, source, amount in rows:
-        cursor.execute(
-            "UPDATE balances SET amount_i64 = amount_i64 - ? "
-            "WHERE miner_id = ? AND amount_i64 >= ?",
-            (amount, source, amount),
-        )
-        if cursor.rowcount == 1:
-            cursor.execute(
-                "UPDATE bridge_transfers SET source_debited = 1 WHERE id = ?",
-                (row_id,),
+    while True:
+        try:
+            rows = fetch_page(
+                db,
+                """
+                SELECT id, source_address, amount_i64
+                FROM bridge_transfers
+                WHERE direction = 'deposit'
+                  AND status IN ('pending', 'locked', 'confirming')
+                  AND source_debited = 0
+                  AND id > ?
+                ORDER BY id ASC
+                """,
+                (last_seen_id,),
+                limit=page_size,
             )
-        else:
-            logger.warning(
-                "debit-on-lock migration: deposit %s source %s lacks funds to "
-                "hard-lock %s micro-RTC; left source_debited=0 for manual review",
-                row_id, source, amount,
+        except sqlite3.OperationalError as exc:
+            # Expected only when bridge_transfers/balances aren't created yet in
+            # this init ordering. Log it so a genuine schema error can't hide
+            # here and silently leave legacy deposits un-migrated.
+            logger.warning("debit-on-lock migration skipped (schema not ready?): %s", exc)
+            return
+
+        if not rows:
+            return
+
+        for row_id, source, amount in rows:
+            last_seen_id = row_id
+            balance_update = cursor.execute(
+                "UPDATE balances SET amount_i64 = amount_i64 - ? "
+                "WHERE miner_id = ? AND amount_i64 >= ?",
+                (amount, source, amount),
             )
+            if balance_update.rowcount == 1:
+                cursor.execute(
+                    "UPDATE bridge_transfers SET source_debited = 1 WHERE id = ?",
+                    (row_id,),
+                )
+            else:
+                logger.warning(
+                    "debit-on-lock migration: deposit %s source %s lacks funds to "
+                    "hard-lock %s micro-RTC; left source_debited=0 for manual review",
+                    row_id, source, amount,
+                )
+
+        if len(rows) < page_size:
+            return

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -27,7 +27,6 @@ node/beacon_x402.py:).fetchall()
 node/beacon_x402.py:).fetchall()
 node/beacon_x402.py:for row in cursor.fetchall()}
 node/bottube_feed_routes.py:rows = cursor_obj.fetchall()
-node/bridge_api.py:rows = cursor.execute(query, params).fetchall()
 node/claims_eligibility.py:epochs = [row[0] for row in cursor.fetchall() if row[0] >= 0]
 node/claims_settlement.py:""", (batch_id, max_claims)).fetchall()
 node/claims_settlement.py:""", (max_claims,)).fetchall()


### PR DESCRIPTION
## Summary
- Adds a guarded fallback cap to the /api/v1 row helper so callers that omit an explicit LIMIT still receive at most 1000 rows.
- Converts the bridge transfer listing query to `fetch_page` instead of a raw fetchall.
- Converts the bridge debit-on-lock migration from one unbounded fetchall to bounded fetch_page batches with id-based forward progress.

## Notes for Reviewers
- `node/db_helpers.py` already defines and exports `fetch_page(conn, sql, params=(), *, limit, offset=0, max_limit=1000)` on current main.
- The bridge calls match that signature, including `fetch_page(db, sql, (last_seen_id,), limit=page_size)` in the migration path.
- `_rows()` no longer relies only on code-review discipline; if SQL lacks `LIMIT`, it appends a bounded `LIMIT ?` before the guarded fetchall.
- Bridge helpers now tolerate either a sqlite cursor or connection object; this matches existing call paths used during DB initialization/tests.

## Validation
- python -m py_compile node/api_v1.py node/bridge_api.py
- git diff --check
- rg -n "fetchall\\(|fetchall-ok|fetch_page\\(" node/api_v1.py node/bridge_api.py

Could not run pytest locally because this Windows Python environment is missing pytest and Flask.

Refs #6627
