### PR TITLE
fix(poa): resolve hardware-attestation tools from trusted dirs only (PATH-hijack)

### DIFF
--- a/rustchain-poa/validator/hardware_fingerprint.py
+++ b/rustchain-poa/validator/hardware_fingerprint.py
@@ -1,4 +1,38 @@
-import platform, subprocess, re, json, hashlib, os
+import platform, subprocess, re, json, hashlib, os, shutil
+
+# The hardware-attestation tools below must only ever be resolved from trusted,
+# root/Administrator-owned system directories — never from an attacker-controllable
+# PATH. RustChain's Proof-of-Antiquity treats the node operator as the adversary:
+# a VM/emulator operator wants their machine to pass as authentic physical hardware
+# (VMs receive 1 billionth of normal rewards). If `dmidecode`/`wmic`/
+# `system_profiler` were looked up via PATH, that operator could place a fake
+# binary earlier on PATH that prints attacker-chosen serial/UUID/BIOS strings,
+# forging the "difficult to spoof" hardware signature without ever touching real
+# firmware or needing root. Resolving only from trusted dirs closes that hole;
+# a normal node — where these tools live in the standard system dirs — is
+# unaffected.
+if platform.system() == 'Windows':
+    _system_root = os.environ.get('SystemRoot', r'C:\Windows')
+    _TRUSTED_BIN_DIRS = (
+        os.path.join(_system_root, 'System32'),
+        os.path.join(_system_root, 'System32', 'wbem'),  # wmic lives here
+    )
+else:
+    _TRUSTED_BIN_DIRS = (
+        "/usr/bin",
+        "/bin",
+        "/usr/sbin",  # dmidecode / system_profiler
+        "/sbin",
+        "/run/current-system/sw/bin",  # NixOS
+    )
+
+
+def _resolve_trusted(name):
+    """Return an absolute path to *name* found only in trusted, root-owned system
+    directories, or None if it is not present in any of them. Never consults the
+    ambient PATH, so an attacker-planted binary cannot shadow the real tool."""
+    return shutil.which(name, path=os.pathsep.join(_TRUSTED_BIN_DIRS))
+
 
 def detect_unique_hardware_signature():
     """
@@ -29,10 +63,12 @@ def detect_unique_hardware_signature():
             # macOS: Use system_profiler to get Hardware UUID
             # This UUID is burned into the Mac's logic board at manufacture time
             # and persists across OS reinstalls, making it ideal for hardware binding
-            output = subprocess.check_output(['system_profiler', 'SPHardwareDataType']).decode()
-            hw_uuid = re.search(r'Hardware UUID: (.*)', output)
-            if hw_uuid:
-                unique_markers['hardware_uuid'] = hw_uuid.group(1).strip()
+            system_profiler = _resolve_trusted('system_profiler')
+            if system_profiler:
+                output = subprocess.check_output([system_profiler, 'SPHardwareDataType']).decode()
+                hw_uuid = re.search(r'Hardware UUID: (.*)', output)
+                if hw_uuid:
+                    unique_markers['hardware_uuid'] = hw_uuid.group(1).strip()
 
         elif platform.system() == 'Windows':
             # Windows: Combine motherboard serial + CPU ID
@@ -40,10 +76,12 @@ def detect_unique_hardware_signature():
             # - Motherboard serial alone can be spoofed in VMs
             # - CPU ID alone changes if the CPU is replaced
             # - Together they create a strong hardware binding
-            mb_serial = subprocess.check_output(['wmic', 'baseboard', 'get', 'serialnumber']).decode().strip().split('\n')[1].strip()
-            cpu_id = subprocess.check_output(['wmic', 'cpu', 'get', 'processorid']).decode().strip().split('\n')[1].strip()
-            unique_markers['mb_serial'] = mb_serial
-            unique_markers['cpu_id'] = cpu_id
+            wmic = _resolve_trusted('wmic')
+            if wmic:
+                mb_serial = subprocess.check_output([wmic, 'baseboard', 'get', 'serialnumber']).decode().strip().split('\n')[1].strip()
+                cpu_id = subprocess.check_output([wmic, 'cpu', 'get', 'processorid']).decode().strip().split('\n')[1].strip()
+                unique_markers['mb_serial'] = mb_serial
+                unique_markers['cpu_id'] = cpu_id
 
         elif platform.system() == 'Linux':
             # Linux: Use dmidecode to read DMI/SMBIOS data
@@ -51,14 +89,16 @@ def detect_unique_hardware_signature():
             # - Some VMs fake individual DMI fields but rarely fake all of them
             # - Different hardware vendors populate different fields
             # - Multiple markers increase fingerprint uniqueness
-            for tag in ['system-serial-number', 'bios-version', 'baseboard-product-name']:
-                try:
-                    out = subprocess.check_output(['dmidecode', '-s', tag]).decode().strip()
-                    unique_markers[tag] = out
-                except:
-                    # dmidecode requires root on some systems, or the field may not exist
-                    # We continue collecting other markers rather than failing completely
-                    continue
+            dmidecode = _resolve_trusted('dmidecode')
+            if dmidecode:
+                for tag in ['system-serial-number', 'bios-version', 'baseboard-product-name']:
+                    try:
+                        out = subprocess.check_output([dmidecode, '-s', tag]).decode().strip()
+                        unique_markers[tag] = out
+                    except:
+                        # dmidecode requires root on some systems, or the field may not exist
+                        # We continue collecting other markers rather than failing completely
+                        continue
 
     except Exception as e:
         # If hardware detection fails, we record the error but don't crash

--- a/tests/test_poa_hardware_fingerprint_path.py
+++ b/tests/test_poa_hardware_fingerprint_path.py
@@ -1,0 +1,107 @@
+"""Regression tests for hardware_fingerprint PATH-hijack hardening.
+
+RustChain's Proof-of-Antiquity treats the node operator as the adversary: an
+operator on a VM/emulator wants to pass as authentic physical hardware. The
+hardware-attestation tools (`dmidecode`, `wmic`, `system_profiler`) must be
+resolved only from trusted, root-owned system directories so an operator cannot
+shadow them with an attacker-planted binary earlier on PATH.
+"""
+import importlib.util
+from pathlib import Path
+
+
+def load_hardware_fingerprint():
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "rustchain-poa"
+        / "validator"
+        / "hardware_fingerprint.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "poa_hardware_fingerprint", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_resolve_trusted_ignores_ambient_path(monkeypatch, tmp_path):
+    """A planted binary on PATH must not be resolved: only trusted dirs count."""
+    module = load_hardware_fingerprint()
+
+    planted = tmp_path / "dmidecode"
+    planted.write_text("#!/bin/sh\necho spoofed\n")
+    planted.chmod(0o755)
+    # Attacker controls PATH and points it at their planted binary.
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    # Trusted dirs do not contain the tool in this test env, so it must resolve
+    # to None rather than to the planted binary.
+    monkeypatch.setattr(module, "_TRUSTED_BIN_DIRS", ("/nonexistent-trusted",))
+
+    assert module._resolve_trusted("dmidecode") is None
+
+
+def test_resolve_trusted_finds_tool_in_trusted_dir(monkeypatch, tmp_path):
+    """A tool present in a trusted dir resolves to its absolute path there."""
+    module = load_hardware_fingerprint()
+
+    trusted = tmp_path / "trusted"
+    trusted.mkdir()
+    real = trusted / "dmidecode"
+    real.write_text("#!/bin/sh\necho ok\n")
+    real.chmod(0o755)
+
+    # Even with an empty/hostile ambient PATH, the trusted dir wins.
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setattr(module, "_TRUSTED_BIN_DIRS", (str(trusted),))
+
+    assert module._resolve_trusted("dmidecode") == str(real)
+
+
+def test_linux_skips_dmidecode_when_untrusted(monkeypatch, tmp_path):
+    """If dmidecode is only reachable via PATH, it is skipped, not executed.
+
+    This proves an operator cannot inject spoofed DMI markers by planting a fake
+    dmidecode: no attacker output ever reaches the signature.
+    """
+    module = load_hardware_fingerprint()
+
+    monkeypatch.setattr(module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(module, "_resolve_trusted", lambda name: None)
+
+    def _fail(*args, **kwargs):  # must never run
+        raise AssertionError("subprocess must not be invoked for untrusted tool")
+
+    monkeypatch.setattr(module.subprocess, "check_output", _fail)
+
+    signature, markers = module.detect_unique_hardware_signature()
+
+    # No attacker-controlled markers were collected.
+    assert "system-serial-number" not in markers
+    assert "error" not in markers
+    assert len(signature) == 64  # SHA256 hexdigest still produced
+
+
+def test_linux_uses_resolved_dmidecode(monkeypatch):
+    """When dmidecode resolves in a trusted dir, its output is collected."""
+    module = load_hardware_fingerprint()
+
+    monkeypatch.setattr(module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        module, "_resolve_trusted", lambda name: "/usr/sbin/dmidecode"
+    )
+
+    def _fake_check_output(command):
+        assert command[0] == "/usr/sbin/dmidecode"
+        tag = command[-1]
+        return ("value-for-" + tag + "\n").encode()
+
+    monkeypatch.setattr(module.subprocess, "check_output", _fake_check_output)
+
+    signature, markers = module.detect_unique_hardware_signature()
+
+    assert markers["system-serial-number"] == "value-for-system-serial-number"
+    assert markers["bios-version"] == "value-for-bios-version"
+    assert markers["baseboard-product-name"] == "value-for-baseboard-product-name"
+    assert len(signature) == 64


### PR DESCRIPTION
## Problem

`rustchain-poa/validator/hardware_fingerprint.py` builds the physical-hardware
signature by shelling out to `dmidecode` (Linux), `wmic` (Windows) and
`system_profiler` (macOS) as **bare command names**, so each is resolved through
the ambient `PATH`.

Proof-of-Antiquity treats the node operator as the adversary: a VM/emulator
operator wants their machine to pass as authentic physical hardware (VMs receive
1 billionth of normal rewards, per the module docstring). By placing a fake
`dmidecode`/`wmic`/`system_profiler` earlier on `PATH`, that operator can feed
**attacker-chosen** serial-number / UUID / BIOS strings straight into the
`SHA256` hardware signature — forging the "difficult to spoof or emulate"
fingerprint the code advertises, without ever touching real firmware or needing
root.

This is the exact same PATH-hijack class already fixed and merged for the sibling
`emulation_detector` in this directory (issue #14586 / PR #7793).

## Fix (narrow, host-independent)

- Add `_resolve_trusted(name)` — `shutil.which(name, path=_TRUSTED_BIN_DIRS)` —
  which resolves each tool **only** from trusted, root/Administrator-owned system
  dirs (`/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`, NixOS `sw/bin`; on Windows
  `System32` + `System32\wbem`), never from the ambient PATH.
- Each attestation call resolves its tool first and **skips the marker
  gracefully** when it is not present in a trusted dir — an attacker-planted
  binary can no longer shadow the real tool or be executed. A normal node, where
  these tools live in the standard system dirs, is unaffected.

## Tests

Adds `tests/test_poa_hardware_fingerprint_path.py` (4 tests):
- a PATH-planted `dmidecode` is **not** resolved (returns `None`);
- a tool in a trusted dir resolves to its absolute path even with a hostile PATH;
- when the tool is only reachable via PATH, `subprocess` is **never invoked** and
  no attacker markers reach the signature (SHA256 still produced);
- when resolved in a trusted dir, its output is collected normally.

`pytest tests/test_poa_hardware_fingerprint_path.py` → 4 passed. Existing
`test_poa_score_calculator.py`, `test_poa_emulation_detector.py`,
`test_attestation_regression.py`, `test_fingerprint.py` still pass.

2 files changed. RTC reward wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`