### PR TITLE
fix(beacon): documented /beacon/api/relay/discover returns 404 (closes #7794)

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -1366,7 +1366,14 @@ def chat():
 # RELAY DISCOVERY ENDPOINT
 # ============================================================
 
+# Both paths resolve under the blueprint's /beacon prefix, i.e.
+#   /beacon/relay/discover      (canonical, used by site/beacon/data.js)
+#   /beacon/api/relay/discover  (compat alias for onboarding/bounty docs
+#                                that still reference the /api/ form)
+# Keeping the alias means the documented verification command returns 200
+# instead of 404 regardless of which form a newcomer copies.
 @beacon_api.route('/relay/discover', methods=['GET'])
+@beacon_api.route('/api/relay/discover', methods=['GET'])
 def relay_discover():
     """Discover relay agents (for 3D visualization)."""
     # In production, query the relay registry

--- a/site/beacon/advertise.js
+++ b/site/beacon/advertise.js
@@ -46,7 +46,7 @@ const LISTING_TIERS = [
     benefits: [
       'Your agent appears as a permanent node on the 3D Atlas',
       'Custom city placement based on your agent capabilities',
-      'Listed in /relay/discover API for cross-agent collaboration',
+      'Listed in /beacon/relay/discover API for cross-agent collaboration',
       'Reputation score tracking and bounty eligibility',
       'Featured in "Integrated Partners" section',
       'Access to Beacon contract and mayday systems',


### PR DESCRIPTION
## Problem
The Beacon Atlas onboarding / bounty instructions still tell newcomers to verify their relay registration with:

```bash
curl -s https://rustchain.org/beacon/api/relay/discover
```

But only `/relay/discover` is registered on the `beacon_api` blueprint (which mounts under the `/beacon` prefix), so the documented `/api/` form returns **404** on the live site — the onboarding verification step fails even when the atlas is up. Reproduced:

```
[404] https://rustchain.org/beacon/api/relay/discover
[200] https://rustchain.org/beacon/relay/discover
```

Refs: `Scottcjn/rustchain-bounties#422` (Step 5), `Scottcjn/Rustchain#175`.

## Fix
- **`node/beacon_api.py`** — add a backward-compatible `/api/relay/discover` route decorator to the existing `relay_discover()` handler. Both the canonical `/beacon/relay/discover` and the documented `/beacon/api/relay/discover` now resolve with an identical body. Strictly additive; the existing route is unchanged.
- **`site/beacon/advertise.js`** — correct the in-code endpoint text (`/relay/discover` → `/beacon/relay/discover`) so a command copied from the advertise panel doesn't 404.

## Verification
Registered both routes on a Flask app with `url_prefix='/beacon'` and hit them via the test client:

```
registered: ['/beacon/api/relay/discover', '/beacon/relay/discover']
/beacon/relay/discover      -> 200 []
/beacon/api/relay/discover  -> 200 []   (was 404)
```

`python3 -m py_compile node/beacon_api.py` passes. 2 files changed, no behavior change to any other endpoint.

Closes #7794