### PR TITLE
fix(sophia): fail closed on ticket-less block submission under ENFORCE (#14588)

### DIFF
--- a/node/sophia_elya_service.py
+++ b/node/sophia_elya_service.py
@@ -563,7 +563,10 @@ def api_submit_block():
         return jsonify({"error": "invalid_ticket"}), 400
     ticket_id = ticket.get("ticket_id")
 
-    if ENFORCE and ticket_id and ticket_id not in tickets_db:
+    # When enforcement is on, a block MUST carry a valid ticket. Guarding on
+    # `ticket_id and ...` short-circuited to False for a missing/empty ticket_id,
+    # so omitting the ticket bypassed the check entirely. Fail closed instead.
+    if ENFORCE and (not ticket_id or ticket_id not in tickets_db):
         return jsonify({"error": "invalid_ticket"}), 400
 
     # Epoch rollover & accounting

--- a/node/tests/test_sophia_elya_service.py
+++ b/node/tests/test_sophia_elya_service.py
@@ -136,6 +136,44 @@ def test_elya_submit_block_rejects_invalid_ticket_shape():
     assert resp.get_json()["error"] == "invalid_ticket"
 
 
+def test_elya_submit_block_rejects_missing_ticket_when_enforced():
+    # Regression: with ENFORCE on, omitting the ticket (or sending an empty /
+    # unknown ticket_id) must be rejected. The old `and ticket_id and` guard
+    # short-circuited on a falsey ticket_id, so a ticket-less block slipped
+    # through even in enforcement mode.
+    client = _client()
+    original_enforce = elya.ENFORCE
+    elya.ENFORCE = True
+    try:
+        no_ticket_resp = client.post(
+            "/api/submit_block",
+            json={
+                "header": {"prev_hash_b3": elya.LAST_HASH_B3, "slot": 0},
+                "header_ext": {},
+            },
+        )
+        empty_ticket_resp = client.post(
+            "/api/submit_block",
+            json={
+                "header": {"prev_hash_b3": elya.LAST_HASH_B3, "slot": 0},
+                "header_ext": {"ticket": {"ticket_id": ""}},
+            },
+        )
+        unknown_ticket_resp = client.post(
+            "/api/submit_block",
+            json={
+                "header": {"prev_hash_b3": elya.LAST_HASH_B3, "slot": 0},
+                "header_ext": {"ticket": {"ticket_id": "not-in-db"}},
+            },
+        )
+    finally:
+        elya.ENFORCE = original_enforce
+
+    for resp in (no_ticket_resp, empty_ticket_resp, unknown_ticket_resp):
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "invalid_ticket"
+
+
 def test_elya_submit_block_rejects_invalid_slot():
     resp = _client().post(
         "/api/submit_block",


### PR DESCRIPTION
## Summary
Fixes the ticket-less block-submission bypass reported in **Scottcjn/rustchain-bounties#14588** (High).

`api_submit_block()` in `node/sophia_elya_service.py` guarded the Silicon Ticket check with:

```python
if ENFORCE and ticket_id and ticket_id not in tickets_db:
    return jsonify({"error": "invalid_ticket"}), 400
```

Because `ticket_id` is falsey when the field is omitted (`None`) or empty (`""`), the `and ticket_id and` clause short-circuits and the `tickets_db` membership check never runs. A miner could POST a block with `header_ext` carrying no `ticket` (or `{"ticket": {"ticket_id": ""}}`) and pass straight through **even with `ENFORCE` enabled**, defeating the ticket-based access control.

## Fix
Fail closed — reject when the ticket is missing/empty *or* unknown, only under enforcement:

```python
if ENFORCE and (not ticket_id or ticket_id not in tickets_db):
    return jsonify({"error": "invalid_ticket"}), 400
```

Behaviour with `ENFORCE` off is unchanged, so normal operation is unaffected.

## Tests
Added `test_elya_submit_block_rejects_missing_ticket_when_enforced` covering all three bypass vectors under `ENFORCE=True`: missing ticket, empty `ticket_id`, and unknown `ticket_id`. Verified it **fails on the pre-fix code** (the ticket-less request slips past the gate into epoch accounting) and **passes after the fix** (clean `400 invalid_ticket`).

```
$ python3 -m pytest node/tests/test_sophia_elya_service.py -q
10 passed
```

Two files changed, +42/-1, no dependency or workflow changes.

Closes Scottcjn/rustchain-bounties#14588
/claim #14588

RTC payout address: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
