### PR TITLE
fix(sophia): rule-based fallback must not grant APPROVED (Golden Fingerprint bypass, #14571)

### DIFF
--- a/sophia_core.py
+++ b/sophia_core.py
@@ -211,13 +211,30 @@ def _rule_based_fallback(fingerprint):
             score -= 2
             reasons.append("Stability score critically low")
 
-    # Map score to verdict
-    if score >= 3:
-        verdict = "APPROVED"
-        confidence = min(0.85, 0.6 + score * 0.05)
-    elif score >= 1:
+    # Map score to verdict.
+    #
+    # SECURITY (rustchain-bounties#14571 -- "Golden Fingerprint" bypass):
+    # this rule-based fallback runs ONLY when the Ollama LLM is unavailable.
+    # Every metric it inspects is self-reported by the miner and independently
+    # forgeable in software -- the checks are additive over static ranges with
+    # no cryptographic or hardware binding. A synthetic fingerprint that simply
+    # satisfies each positive range (e.g. clock_drift_cv=0.05, ordered cache
+    # 1<2<3, any SIMD flag, cpu_temp_c=40, stability=0.9) reaches score >= 3
+    # and would previously be handed the top-trust APPROVED verdict without any
+    # legitimate hardware.
+    #
+    # Fix (fail closed): a heuristic fallback must not be able to grant the
+    # highest trust level on its own. It caps at CAUTIOUS, which routes the
+    # miner to the human spot-check review queue (see sophia_db). Full APPROVED
+    # can only come from the LLM attestation path, not from this fallback.
+    if score >= 1:
         verdict = "CAUTIOUS"
-        confidence = 0.55 + score * 0.05
+        confidence = min(0.7, 0.5 + score * 0.03)
+        if score >= 3:
+            reasons.append(
+                "Rule-based fallback caps at CAUTIOUS (no LLM); APPROVED "
+                "requires LLM attestation"
+            )
     elif score >= -2:
         verdict = "SUSPICIOUS"
         confidence = 0.5 + abs(score) * 0.05

--- a/tests/test_sophia_core.py
+++ b/tests/test_sophia_core.py
@@ -259,10 +259,34 @@ class TestSophiaDB(unittest.TestCase):
 # -- Core / Rule-based tests -----------------------------------------------
 
 class TestRuleBasedFallback(unittest.TestCase):
-    def test_approved_verdict(self):
+    def test_fallback_never_approves(self):
+        # SECURITY (rustchain-bounties#14571): the rule-based fallback is a
+        # heuristic over self-reported, forgeable metrics and must never grant
+        # the top-trust APPROVED verdict on its own. Even a strong, legitimate
+        # fingerprint degrades to CAUTIOUS (human spot-check) when the LLM is
+        # unavailable; full APPROVED can only come from the LLM path.
         result = _rule_based_fallback(_good_fingerprint())
-        self.assertEqual(result["verdict"], "APPROVED")
-        self.assertGreaterEqual(result["confidence"], 0.6)
+        self.assertEqual(result["verdict"], "CAUTIOUS")
+        self.assertNotEqual(result["verdict"], "APPROVED")
+
+    def test_golden_fingerprint_not_approved(self):
+        # The "Golden Fingerprint" from the report: a fully synthetic bundle
+        # (no real hardware) that satisfies every positive static range and
+        # previously scored >= 3 -> APPROVED. It must now be CAUTIOUS at best.
+        golden = {
+            "clock_drift_cv": 0.05,
+            "cache_hierarchy": {
+                "l1_latency_ns": 1,
+                "l2_latency_ns": 2,
+                "l3_latency_ns": 3,
+            },
+            "simd_identity": {"avx2": True},
+            "thermal": {"cpu_temp_c": 40},
+            "stability_score": 0.9,
+        }
+        result = _rule_based_fallback(golden)
+        self.assertNotEqual(result["verdict"], "APPROVED")
+        self.assertEqual(result["verdict"], "CAUTIOUS")
 
     def test_cautious_verdict(self):
         result = _rule_based_fallback(_cautious_fingerprint())


### PR DESCRIPTION
## Closes rustchain-bounties#14571 — Deterministic Fallback Bypass ("Golden Fingerprint") in SophiaCore

### Problem
`_rule_based_fallback()` in `sophia_core.py` runs **only when the Ollama LLM is unavailable**. It scores a fingerprint additively across a handful of static ranges (clock drift CV, cache-latency ordering, SIMD flags, thermal, stability). Every one of those metrics is **self-reported by the miner and forgeable in software** — there is no cryptographic or hardware binding.

Because the checks are independent positive ranges, a fully synthetic **Golden Fingerprint** with no real hardware behind it reaches `score >= 3` and was granted the top-trust **APPROVED** verdict:

```python
golden = {
    "clock_drift_cv": 0.05,                                              # acceptable  (+0)
    "cache_hierarchy": {"l1_latency_ns": 1, "l2_latency_ns": 2, "l3_latency_ns": 3},  # ordered  (+1)
    "simd_identity": {"avx2": True},                                     # SIMD present (+1)
    "thermal": {"cpu_temp_c": 40},                                      # normal temp  (+1)
    "stability_score": 0.9,                                              # healthy      (+1)
}
# score = 4  ->  verdict "APPROVED", confidence 0.8   (before this PR)
```

An attacker who can force the fallback path (LLM down, or simply DoS the Ollama endpoints) can hand-craft attested "hardware" and be auto-approved.

### Fix (fail closed)
A rule-based heuristic over forgeable inputs cannot legitimately establish the **highest** trust level — that is exactly what the LLM attestation is for. So the fallback now **caps at `CAUTIOUS`**, which routes the miner into the existing human spot-check review queue (`sophia_review_queue`). Full `APPROVED` can only come from the LLM path.

- `SUSPICIOUS` / `REJECTED` mapping is **unchanged** — a bad fingerprint is still caught.
- A legitimate strong fingerprint degrades from `APPROVED` to `CAUTIOUS` **only during an LLM outage**; when Ollama is up it is unaffected. Safe degraded behaviour, not a lockout.
- No new dependencies, 2 files.

### Verification
- **Golden fingerprint:** before → `APPROVED 0.8`; after → `CAUTIOUS`.
- Added regression tests `test_golden_fingerprint_not_approved` and `test_fallback_never_approves` — both **fail on pre-fix code** (`AssertionError: 'APPROVED' == 'APPROVED'`) and **pass after**.
- Full suite: **64 passed** (`python3 -m pytest tests/test_sophia_core.py`).

Same fail-closed class as the merged & paid #7793 (emulation-detector PATH hijack).

/claim #14571
RTC wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`