### PR TITLE
docs: correct emission to fixed 1.5 RTC/epoch (no halving)

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,18 +406,16 @@ Compare to Bitcoin's 21M (≈2.5x more), Ethereum's uncapped supply, and the typ
 
 Total premine: **6%** (503,316 RTC = 4 × 125,829.12, one per founder wallet). Premine wallets have a 1-year on-chain unlock delay. No VC pre-sale. No private allocation. The early miners were `pawnshop_g4_115` and `dual-g4-125`.
 
-### Emission schedule (halving)
+### Emission schedule (fixed)
 
-| Period | Block reward (per epoch) |
-|--------|--------------------------|
-| Genesis – Year 2 | 1.5 RTC |
-| Year 2 – Year 4 | 0.75 RTC |
-| Year 4 – Year 6 | 0.375 RTC |
-| Continues until minimum dust threshold | — |
+| Parameter | Value |
+|-----------|-------|
+| Block reward | 1.5 RTC per epoch, fixed |
+| Block time | 600s (10 min) |
+| Epoch duration | 144 blocks (~24 hours) |
+| Halving | None |
 
-Block time: 600s (10 min). Epoch duration: 144 blocks (~24 hours).
-
-Halving fires every 2 years OR on an **Epoch Relic Event** milestone — whichever comes first. This keeps emissions tied to either time or community-meaningful milestones, not just arbitrary block counts.
+Emission is a fixed 1.5 RTC per epoch and does not halve. It continues at that rate until the 8,388,608 RTC (2²³) supply cap is reached, consistent with RIP-0004 and the running node. This matches the "Fixed forever" cap noted above.
 
 ### Reference rate climbs as holder count grows
 

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -582,12 +582,11 @@ TOTAL                      7.5×         100%      0.90 RTC
 
 ### 6.3 Emission Schedule
 
-**Halving Events:**
-- Every 2 years OR upon "Epoch Relic Event" milestone
-- Initial: 1.5 RTC per epoch
-- Year 2: 0.75 RTC per epoch
-- Year 4: 0.375 RTC per epoch
-- (Continues until minimum dust threshold)
+**Fixed emission (no halving):**
+- 1.5 RTC per epoch, constant
+- Epoch = 144 blocks (~24 hours) at 600s block time
+- Emission continues at the fixed rate until the 8,388,608 RTC (2^23) supply cap is reached
+- Per RIP-0004; the running node emits a fixed 1.5 RTC/epoch, with no halving schedule
 
 **Burn Mechanisms (Optional):**
 - Unused validator capacity

--- a/docs/chain_architecture.md
+++ b/docs/chain_architecture.md
@@ -24,9 +24,10 @@ Each block contains:
 
 ## Token Emission
 
-- 5 RUST / block → validator
-- NFT badge may alter payout (e.g., “Paw Paw” adds retro bonus)
-- Halving every 2 years or “epoch milestone”
+- 1.5 RTC per epoch to validators (fixed, no halving)
+- Epoch = 144 blocks (~24 hours); pool split by antiquity weight
+- NFT badge may alter an individual payout (e.g., "Paw Paw" adds a retro bonus)
+- Fixed emission until the 8,388,608 RTC (2^23) cap, per RIP-0004
 
 ## External Integration
 


### PR DESCRIPTION
The whitepaper, README, and chain_architecture docs described a halving schedule (1.5 to 0.75 to 0.375 every 2 years) that the code never implemented. The running node and RIP-0004 both use a fixed 1.5 RTC per epoch with no halving, continuing until the 8,388,608 RTC (2^23) supply cap.

Corrects the three docs to the actual policy. README already stated "Fixed forever" for the cap, so its emission section was internally contradictory; now consistent.

Not touched: docs/tokenomics_v1.md is already labeled a superseded historical draft that points at WHITEPAPER section 6 as authoritative. The non-English README translations still describe halving and should be corrected in a follow-up.