### PR TITLE
fix(bcos): harden badge preview DOM rendering

### DIFF
--- a/bcos/badge-generator.html
+++ b/bcos/badge-generator.html
@@ -458,20 +458,46 @@
             return `${baseUrl}${certId}.svg${styleParam}`;
         }
 
+        function clearBadgePreview() {
+            badgePreview.replaceChildren();
+        }
+
+        function setPreviewPlaceholder(message, color = null) {
+            clearBadgePreview();
+            const span = document.createElement('span');
+            span.className = 'preview-placeholder';
+            if (color) {
+                span.style.color = color;
+            }
+            span.textContent = message;
+            badgePreview.appendChild(span);
+        }
+
+        function setBadgePreviewImage(badgeUrl) {
+            clearBadgePreview();
+            const image = document.createElement('img');
+            image.src = badgeUrl;
+            image.alt = 'BCOS Badge';
+            image.addEventListener('error', () => {
+                setPreviewPlaceholder('Badge not found - verify this repo first', 'var(--yellow)');
+            }, { once: true });
+            badgePreview.appendChild(image);
+        }
+
         // Update preview and code
         function updateOutput() {
             const input = repoInput.value.trim();
             const style = document.querySelector('input[name="badgeStyle"]:checked').value;
 
             if (!input) {
-                badgePreview.innerHTML = '<span class="preview-placeholder">Enter a repo URL or certificate ID to preview</span>';
+                setPreviewPlaceholder('Enter a repo URL or certificate ID to preview');
                 codeOutput.textContent = '[![BCOS](https://50.28.86.131/bcos/badge/BCOS-xxx.svg)](https://rustchain.org/bcos/verify/BCOS-xxx)';
                 return;
             }
 
             currentCertId = extractCertId(input);
             if (!currentCertId) {
-                badgePreview.innerHTML = '<span class="preview-placeholder" style="color: var(--red);">Invalid format. Use BCOS-xxx or a GitHub URL.</span>';
+                setPreviewPlaceholder('Invalid format. Use BCOS-xxx or a GitHub URL.', 'var(--red)');
                 return;
             }
 
@@ -479,7 +505,7 @@
             const verifyUrl = `https://rustchain.org/bcos/verify/${currentCertId}`;
 
             // Update preview
-            badgePreview.innerHTML = `<img src="${badgeUrl}" alt="BCOS Badge" onerror="this.parentElement.innerHTML='<span style=\\'color: var(--yellow);\\'>Badge not found - verify this repo first</span>'">`;
+            setBadgePreviewImage(badgeUrl);
 
             // Update code output
             updateCodeOutput(badgeUrl, verifyUrl);

--- a/tests/test_bcos_badge_generator_frontend_security.py
+++ b/tests/test_bcos_badge_generator_frontend_security.py
@@ -37,3 +37,15 @@ def test_static_badge_preview_uses_dom_nodes():
     assert "document.createTextNode('Badge URL: ')" in html
 
 
+def test_public_bcos_badge_preview_uses_dom_nodes():
+    page = Path(__file__).resolve().parents[1] / "bcos" / "badge-generator.html"
+    html = page.read_text(encoding="utf-8")
+
+    assert "badgePreview.innerHTML = `<img src=" not in html
+    assert "onerror=\"this.parentElement.innerHTML=" not in html
+    assert "function clearBadgePreview()" in html
+    assert "badgePreview.replaceChildren()" in html
+    assert "const image = document.createElement('img');" in html
+    assert "image.src = badgeUrl;" in html
+    assert "image.addEventListener('error'" in html
+


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [ ] Add a tier label: `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`)
- [x] If adding new code files, include SPDX header near the top (example: `# SPDX-License-Identifier: MIT`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

This PR hardens the public BCOS badge generator preview in `bcos/badge-generator.html` by removing parser-based preview rendering and replacing it with DOM-node construction.

Changes included:

- Added `clearBadgePreview()`
- Added `setPreviewPlaceholder()`
- Added `setBadgePreviewImage()`
- Replaced the interpolated `badgePreview.innerHTML = <img ... onerror=...>` preview path with `document.createElement('img')`
- Replaced the inline `onerror` HTML sink with an `addEventListener('error', ...)` fallback
- Extended `tests/test_bcos_badge_generator_frontend_security.py` with a focused static regression for `bcos/badge-generator.html`

## Why

The page still built its preview image through dynamic `innerHTML` and chained its fallback through an inline `onerror` HTML mutation. This change keeps the same behavior while moving the preview path to explicit DOM APIs.

## Testing / Evidence

Commands run:

```bash
git diff --check
python3 -m py_compile tests/test_bcos_badge_generator_frontend_security.py
python3 tests/test_bcos_badge_generator_frontend_security.py
```

Results:

- `git diff --check` passed cleanly
- `py_compile` passed for `tests/test_bcos_badge_generator_frontend_security.py`
- `python3 tests/test_bcos_badge_generator_frontend_security.py` completed successfully

## RTC Wallet / Payout

If this PR is eligible for RTC payout, please send the reward to this RTC wallet:

`RTCc78142b4cc31531e913c4082bc5d771eb0a91ac1`
