### PR TITLE
fix(web): harden setup wizard status rendering

### DIFF
--- a/tests/test_setup_wizard_frontend_security.py
+++ b/tests/test_setup_wizard_frontend_security.py
@@ -50,14 +50,13 @@ def test_python_check_failure_escapes_pasted_output():
     html = WIZARD_HTML.read_text(encoding="utf-8")
 
     assert "Python 3.8+ required. Found: '+(input||'unknown')+'" not in html
-    assert "Python 3.8+ required. Found: '+esc(input||'unknown')+'" in html
+    assert 'setStatusPill(result,"bg-err","✗ Python 3.8+ required. Found: "+(input||"unknown"))' in html
 
 
 def test_python_check_success_still_escapes_pasted_output():
     html = WIZARD_HTML.read_text(encoding="utf-8")
 
-    assert "Python '+m[1]+'.'+m[2]+' detected" in html
-    assert "&#10003; '+esc(input)+'" in html
+    assert 'setStatusPill(result,"bg-ok","✓ "+input+" — Python "+m[1]+"."+m[2]+" detected")' in html
 
 
 def test_setup_wizard_renders_connection_check():
@@ -81,6 +80,26 @@ def test_attestation_step_escapes_wallet_commands():
 
     assert 'var minerCmd="~/.rustchain/venv/bin/python ~/.rustchain/rustchain_miner.py --wallet "+esc(wName);' in html
     assert 'monitor your balance with <code>curl -sk https://rustchain.org/wallet/balance?miner_id=\'+esc(wName)+\'</code>' in html
+
+
+def test_status_helpers_present_for_dynamic_results():
+    html = WIZARD_HTML.read_text(encoding="utf-8")
+
+    assert "function makeStatusPill(cls,text)" in html
+    assert "function setStatusPill(el,cls,text)" in html
+    assert "function setLoadingStatus(el,text)" in html
+    assert ".textContent=text" in html
+    assert 'result.innerHTML=\'<span class="bg bg-ok">' not in html
+    assert 'result.innerHTML=\'<span class="bg bg-err">' not in html
+
+
+def test_network_and_miner_results_use_dom_status_helpers():
+    html = WIZARD_HTML.read_text(encoding="utf-8")
+
+    assert 'setLoadingStatus(el,"Testing node connectivity...")' in html
+    assert 'setStatusPillWithLoading(el,"bg-ok","✓ Node ONLINE — network is reachable!","Testing attestation system...")' in html
+    assert 'setLoadingStatus(result,"Fetching active miners...")' in html
+    assert 'setStatusPill(result,"bg-ok","✓ Miner FOUND on network! ID: "+String(match.miner_id||match.name||JSON.stringify(match)))' in html
 
 
 def test_attestation_esc_shield_for_shell_metacharacters():
@@ -132,5 +151,4 @@ def test_esc_function_runtime_escaping():
     assert ">" not in output
     assert "&amp;" in output
     assert "&lt;script&gt;" in output
-
 

--- a/web/wizard/setup-wizard.html
+++ b/web/wizard/setup-wizard.html
@@ -101,16 +101,21 @@ function render(){renderProgress();var main=document.getElementById("mainContent
 function go(n){S.step=n;render()}
 function copyCode(btn){var el=btn.previousSibling;while(el&&el.nodeType!==3)el=el.previousSibling;var text=el?el.textContent:"";navigator.clipboard.writeText(text.trim()).then(function(){btn.textContent="Copied!";btn.classList.add("copied");setTimeout(function(){btn.textContent="Copy";btn.classList.remove("copied");},1500)})}
 function esc(s){return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;")}
+function clearNode(el){el.textContent=""}
+function makeStatusPill(cls,text){var span=document.createElement("span");span.className="bg "+cls;span.textContent=text;return span}
+function setStatusPill(el,cls,text){clearNode(el);el.appendChild(makeStatusPill(cls,text))}
+function setLoadingStatus(el,text){clearNode(el);var wrap=document.createElement("div");wrap.className="nr";var spinner=document.createElement("div");spinner.className="spn";wrap.appendChild(spinner);wrap.appendChild(document.createTextNode(text));el.appendChild(wrap)}
+function setStatusPillWithLoading(el,cls,text,loadingText){clearNode(el);el.appendChild(makeStatusPill(cls,text));var wrap=document.createElement("div");wrap.className="nr";wrap.style.marginTop="8px";var spinner=document.createElement("div");spinner.className="spn";wrap.appendChild(spinner);wrap.appendChild(document.createTextNode(loadingText));el.appendChild(wrap)}
 function renderPlatform(el){el.innerHTML='<div class="card"><h2>&#128187; Step 1 \u2014 Platform Detection</h2><p>We automatically detected your OS and architecture. The one-line installer handles everything for your platform.</p></div><div class="banner"><span class="icon">'+pIcon(S.platform)+'</span><div class="info"><h3>'+pName(S.platform)+'</h3><p>Architecture: '+esc(S.arch)+'</p></div><span class="bg bg-ok" style="margin-left:auto">&#10003; Detected</span></div><div class="card"><h3>One-line installer</h3><div class="cl">Run in terminal</div><div class="cb">curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash<span class="cpy" onclick="copyCode(this)">Copy</span></div><p class="cn">Supports Linux (x86_64, ppc64le, aarch64, mips, sparc, m68k, riscv64, ia64, s390x), macOS (Intel, Apple Silicon, PowerPC), and Windows via WSL.</p></div><div class="card"><h3>What the installer does</h3><ul><li>Auto-detects your OS and architecture</li><li>Downloads the correct miner binary for your platform</li><li>Sets up a Python 3 virtual environment</li><li>Registers the miner as a system service (auto-starts on boot)</li><li>Runs a first-attestation test against the RustChain network</li></ul></div><div class="br"><button class="bp" onclick="go(1)">Next: Check Python \u2192</button></div>'}
 function renderPython(el){el.innerHTML='<div class="card"><h2>&#128993; Step 2 \u2014 Python Check</h2><p>RustChain miner requires <strong>Python 3.8 or higher</strong>. Run the command below to verify your version.</p></div><div class="card"><h3>Check Python version</h3><div class="cl">Run in terminal</div><div class="cb">python3 --version<span class="cpy" onclick="copyCode(this)">Copy</span></div><div class="ir" style="margin-top:12px"><input type="text" id="pythonInput" placeholder="Paste output here (e.g. Python 3.11.4)" /><button class="bp" onclick="verifyPython()">Verify</button></div><div id="pythonResult" style="margin-top:10px"></div></div><div class="card"><h3>Installing Python if missing</h3><div class="cl">Ubuntu / Debian</div><div class="cb">sudo apt-get update && sudo apt-get install -y python3 python3-venv python3-pip<span class="cpy" onclick="copyCode(this)">Copy</span></div><div class="cl" style="margin-top:10px">macOS</div><div class="cb">brew install python3<span class="cpy" onclick="copyCode(this)">Copy</span></div><div class="cl" style="margin-top:10px">Windows (WSL)</div><div class="cb">wsl --install -d Ubuntu<span class="cpy" onclick="copyCode(this)">Copy</span></div></div><div class="br"><button class="bs" onclick="go(0)">\u2190 Back</button><button class="bp" onclick="go(2)">Next: Wallet Setup \u2192</button></div>'}
-function verifyPython(){var input=document.getElementById("pythonInput").value.trim();var result=document.getElementById("pythonResult");var m=input.match(/Python\s+(\d+)\.(\d+)/);if(m&&parseInt(m[1])>=3&&parseInt(m[2])>=8){S.pythonOk=true;S.pythonVersion=input;result.innerHTML='<span class="bg bg-ok">&#10003; '+esc(input)+' \u2014 Python '+m[1]+'.'+m[2]+' detected</span>'}else{S.pythonOk=false;result.innerHTML='<span class="bg bg-err">&#10007; Python 3.8+ required. Found: '+esc(input||'unknown')+'</span>'}}
+function verifyPython(){var input=document.getElementById("pythonInput").value.trim();var result=document.getElementById("pythonResult");var m=input.match(/Python\s+(\d+)\.(\d+)/);if(m&&parseInt(m[1])>=3&&parseInt(m[2])>=8){S.pythonOk=true;S.pythonVersion=input;setStatusPill(result,"bg-ok","✓ "+input+" — Python "+m[1]+"."+m[2]+" detected")}else{S.pythonOk=false;setStatusPill(result,"bg-err","✗ Python 3.8+ required. Found: "+(input||"unknown"))}}
 function renderWallet(el){el.innerHTML='<div class="card"><h2>&#128272; Step 3 \u2014 Wallet Setup</h2><p>Your wallet name identifies you to the RustChain network. Generate a new Ed25519 keypair or import an existing wallet.</p></div><div class="card"><div class="tr"><button class="tb active" id="tabNew" onclick="setWalletMode(\'new\')">&#128279; Generate New</button><button class="tb" id="tabImport" onclick="setWalletMode(\'import\')">&#128230; Import Existing</button></div><div id="walletGenArea"><p>Click the button below to generate a new Ed25519 keypair using your browser\'s Web Crypto API. Your public key becomes your wallet name on the network.</p><div class="br"><button class="bp" id="genWalletBtn" onclick="generateWallet()">&#9889; Generate Keypair</button></div><div id="walletResult"></div></div><div id="walletImportArea" style="display:none"><p>Enter your existing wallet name or public key:</p><div class="ir"><input type="text" id="importWalletInput" placeholder="Enter wallet name or public key" /><button class="bp" onclick="importWallet()">Use This Wallet</button></div><div id="importResult" style="margin-top:8px"></div></div></div><div class="br"><button class="bs" onclick="go(1)">\u2190 Back</button><button class="bp" onclick="go(3)" id="walletNextBtn" disabled>Next: Download Miner \u2192</button></div>'}
 function setWalletMode(mode){S.walletMode=mode;document.getElementById("tabNew").classList.toggle("active",mode==="new");document.getElementById("tabImport").classList.toggle("active",mode==="import");document.getElementById("walletGenArea").style.display=mode==="new"?"":"none";document.getElementById("walletImportArea").style.display=mode==="import"?"":"none"}
 async function generateWallet(){var btn=document.getElementById("genWalletBtn");btn.disabled=true;btn.textContent="&#8987; Generating...";try{var hex;try{var key=await crypto.subtle.generateKey({name:"Ed25519",publicKeyExportable:false},true,["sign","verify"]);var pubRaw=await crypto.subtle.exportRawPublicKey(key.publicKey);hex=Array.from(new Uint8Array(pubRaw)).map(function(b){return b.toString(16).padStart(2,"0")}).join("")}catch(e){var arr=crypto.getRandomValues(new Uint8Array(32));hex=Array.from(arr).map(function(b){return b.toString(16).padStart(2,"0")}).join("")}S.publicKeyHex=hex;S.walletName="miner-"+hex.substring(0,16);var wordData=crypto.getRandomValues(new Uint8Array(24));S.seedWords=Array.from(wordData).map(function(b){return BIP39[b%BIP39.length]});var seedHtml=S.seedWords.map(function(w,i){return'<div class="sw"><span class="nm">'+(i+1)+'.</span><span class="wd2">'+esc(w)+'</span></div>'}).join("");document.getElementById("walletResult").innerHTML='<div class="wd"><div class="lb">Wallet Name (use this with --wallet)</div><div class="vl">'+esc(S.walletName)+'</div></div><div class="cl" style="margin-top:12px">&#128273; 24-Word Seed Phrase (SAVE THESE \u2014 offline backup!)</div><div class="sg">'+seedHtml+'</div><div class="warn">&#9888; Write these words down and store them somewhere safe. Never share your seed phrase. Anyone with it controls your wallet.</div><span class="bg bg-ok" style="display:inline-flex">&#10003; Wallet ready \u2014 save your seed phrase!</span>';document.getElementById("walletNextBtn").disabled=false}finally{btn.disabled=false;btn.textContent="&#9889; Generate Keypair"}}
-function importWallet(){var v=document.getElementById("importWalletInput").value.trim();var result=document.getElementById("importResult");if(!v){result.innerHTML='<span class="bg bg-err">&#10007; Enter a wallet name</span>';return}S.walletName=v;S.publicKeyHex=v;result.innerHTML='<span class="bg bg-ok">&#10003; Using wallet: '+esc(v)+'</span>';document.getElementById("walletNextBtn").disabled=false}
+function importWallet(){var v=document.getElementById("importWalletInput").value.trim();var result=document.getElementById("importResult");if(!v){setStatusPill(result,"bg-err","✗ Enter a wallet name");return}S.walletName=v;S.publicKeyHex=v;setStatusPill(result,"bg-ok","✓ Using wallet: "+v);document.getElementById("walletNextBtn").disabled=false}
 function renderDownload(el){var walletArg=S.walletName?" --wallet "+S.walletName:"";var cmd="curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s --"+walletArg;var minerDl=S.platform==="macos"?"curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/macos/rustchain_mac_miner_v2.4.py -o rustchain_miner.py":"curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/rustchain_linux_miner.py -o rustchain_miner.py";var runCmd="~/.rustchain/venv/bin/python rustchain_miner.py --wallet "+(S.walletName||"YOUR_WALLET_NAME");var checkCmd="curl -sk https://rustchain.org/health";var balanceCmd="curl -sk \"https://rustchain.org/wallet/balance?miner_id="+(S.walletName||"YOUR_WALLET_NAME")+"\"";el.innerHTML='<div class="card"><h2>&#128229; Step 4 \u2014 Download &amp; Install</h2><p>Run the one-line installer. It auto-detects your platform, sets up a Python venv, and registers the miner as a system service.</p></div><div class="card"><h3>&#129514; One-Line Installer</h3><div class="cl">Run in terminal (includes your wallet name from Step 3)</div><div class="cb">'+esc(cmd)+'<span class="cpy" onclick="copyCode(this)">Copy</span></div><div class="ib">Add <code>--dry-run</code> to preview without making changes. Add <code>--skip-checksum</code> to skip checksum verification (not recommended).</div></div><div class="card"><h3>&#128736; Manual install (alternative)</h3><div class="cl">1. Create directory</div><div class="cb">mkdir -p ~/.rustchain && cd ~/.rustchain<span class="cpy" onclick="copyCode(this)">Copy</span></div><div class="cl" style="margin-top:8px">2. Download miner</div><div class="cb">'+esc(minerDl)+'<span class="cpy" onclick="copyCode(this)">Copy</span></div><div class="cl" style="margin-top:8px">3. Set up Python venv</div><div class="cb">python3 -m venv ~/.rustchain/venv && ~/.rustchain/venv/bin/pip install requests -q<span class="cpy" onclick="copyCode(this)">Copy</span></div><div class="cl" style="margin-top:8px">4. Start miner</div><div class="cb">'+esc(runCmd)+'<span class="cpy" onclick="copyCode(this)">Copy</span></div></div><div class="card"><h3>After installation</h3><div class="cl">Check node health</div><div class="cb">'+esc(checkCmd)+'<span class="cpy" onclick="copyCode(this)">Copy</span></div><div class="cl" style="margin-top:8px">Check wallet balance</div><div class="cb">'+esc(balanceCmd)+'<span class="cpy" onclick="copyCode(this)">Copy</span></div></div><div class="br"><button class="bs" onclick="go(2)">\u2190 Back</button><button class="bp" onclick="go(4)">Next: Configure \u2192</button></div>'}
 function renderConfigure(el){var wName=S.walletName||"YOUR_WALLET_NAME";var nodeVal=S.walletName?"https://rustchain.org":"https://rustchain.org";el.innerHTML='<div class="card"><h2>&#9881; Step 5 \u2014 Configure</h2><p>Set your wallet name and the RustChain node URL. These are written to your miner config.</p></div><div class="card"><div class="cl">Wallet Name</div><div class="cb">'+esc(wName)+'<span class="cpy" onclick="copyCode(this)">Copy</span></div><p class="cn">Use this name when starting the miner: <code>--wallet '+esc(wName)+'</code></p><div class="ir" style="margin-top:12px"><input type="text" id="nodeInput" value="https://rustchain.org" placeholder="Node URL" /><button class="bp" onclick="saveNode()">Save Node</button></div><div id="nodeResult" style="margin-top:8px"></div></div><div class="card"><h3>Quick config summary</h3><div class="sm"><div class="rw"><span class="lb">Wallet</span><span class="vl">'+esc(wName)+'</span></div><div class="rw"><span class="lb">Node</span><span class="vl">https://rustchain.org</span></div><div class="rw"><span class="lb">Platform</span><span class="vl">'+pName(S.platform)+'</span></div><div class="rw"><span class="lb">Python</span><span class="vl">'+(S.pythonVersion||"Not verified yet")+'</span></div></div></div><div class="br"><button class="bs" onclick="go(3)">\u2190 Back</button><button class="bp" onclick="go(5)">Next: Test Connection \u2192</button></div>'}
-function saveNode(){var v=document.getElementById("nodeInput").value.trim();var result=document.getElementById("nodeResult");if(!v||!v.startsWith("http")){result.innerHTML='<span class="bg bg-err">&#10007; Enter a valid URL starting with http</span>';return}result.innerHTML='<span class="bg bg-ok">&#10003; Node URL saved: '+esc(v)+'</span>'}
+function saveNode(){var v=document.getElementById("nodeInput").value.trim();var result=document.getElementById("nodeResult");if(!v||!v.startsWith("http")){setStatusPill(result,"bg-err","✗ Enter a valid URL starting with http");return}setStatusPill(result,"bg-ok","✓ Node URL saved: "+v)}
 function renderTest(el){
   el.innerHTML=
     '<div class="card"><h2>&#127763; Step 6 \u2014 Test Connection</h2><p>Verify that your machine can reach the RustChain network node.</p></div>'+
@@ -123,26 +128,26 @@ function renderTest(el){
 }
 function testConnection(){
   var el=document.getElementById("netResult");
-  el.innerHTML='<div class="nr"><div class="spn"></div>Testing node connectivity...</div>';
+  setLoadingStatus(el,"Testing node connectivity...");
   var xhr=new XMLHttpRequest();
   xhr.open("GET","https://rustchain.org/health",true);
   xhr.timeout=8000;
   xhr.onload=function(){
     if(xhr.status===200){
       S.nodeOnline=true;
-      el.innerHTML='<span class="bg bg-ok">&#10003; Node ONLINE &mdash; network is reachable!</span><div class="nr" style="margin-top:8px"><div class="spn"></div>Testing attestation system...</div>';
+      setStatusPillWithLoading(el,"bg-ok","✓ Node ONLINE — network is reachable!","Testing attestation system...");
       setTimeout(testAttestation,500);
     }else{
-      el.innerHTML='<span class="bg bg-err">&#10007; Node returned status '+xhr.status+'</span>';
+      setStatusPill(el,"bg-err","✗ Node returned status "+xhr.status);
     }
   };
-  xhr.onerror=function(){el.innerHTML='<span class="bg bg-err">&#10007; Network error &mdash; check your internet connection</span>'};
-  xhr.ontimeout=function(){el.innerHTML='<span class="bg bg-warn">&#10007; Timeout &mdash; node may be temporarily unreachable</span>'};
+  xhr.onerror=function(){setStatusPill(el,"bg-err","✗ Network error — check your internet connection")};
+  xhr.ontimeout=function(){setStatusPill(el,"bg-warn","✗ Timeout — node may be temporarily unreachable")};
   xhr.send();
 }
 function testAttestation(){
   var el=document.getElementById("attResult");
-  el.innerHTML='<div class="nr"><div class="spn"></div>Requesting attestation challenge...</div>';
+  setLoadingStatus(el,"Requesting attestation challenge...");
   var xhr=new XMLHttpRequest();
   xhr.open("POST","https://rustchain.org/attest/challenge",true);
   xhr.setRequestHeader("Content-Type","application/json");
@@ -150,13 +155,13 @@ function testAttestation(){
   xhr.onload=function(){
     if(xhr.status===200||xhr.status===201){
       S.attestationReady=true;
-      el.innerHTML='<span class="bg bg-ok">&#10003; Attestation system READY! Your node is ready to process attestations.</span>';
+      setStatusPill(el,"bg-ok","✓ Attestation system READY! Your node is ready to process attestations.");
     }else{
-      el.innerHTML='<span class="bg bg-warn">&#10007; Attestation returned status '+xhr.status+' &mdash; node may still be initializing</span>';
+      setStatusPill(el,"bg-warn","✗ Attestation returned status "+xhr.status+" — node may still be initializing");
     }
   };
-  xhr.onerror=function(){el.innerHTML='<span class="bg bg-warn">&#10007; Could not reach attestation endpoint &mdash; try again in a few minutes</span>'};
-  xhr.ontimeout=function(){el.innerHTML='<span class="bg bg-warn">&#10007; Timeout reaching attestation endpoint</span>'};
+  xhr.onerror=function(){setStatusPill(el,"bg-warn","✗ Could not reach attestation endpoint — try again in a few minutes")};
+  xhr.ontimeout=function(){setStatusPill(el,"bg-warn","✗ Timeout reaching attestation endpoint")};
   xhr.send(JSON.stringify({}));
 }
 function renderAttest(el){
@@ -181,7 +186,7 @@ function renderAttest(el){
 }
 function checkMiner(){
   var result=document.getElementById("minerResult");
-  result.innerHTML='<div class="nr"><div class="spn"></div>Fetching active miners...</div>';
+  setLoadingStatus(result,"Fetching active miners...");
   var xhr=new XMLHttpRequest();
   xhr.open("GET","https://rustchain.org/api/miners",true);
   xhr.timeout=8000;
@@ -198,19 +203,19 @@ function checkMiner(){
           }
         }
         if(match){
-          result.innerHTML='<span class="bg bg-ok">&#10003; Miner FOUND on network! ID: '+esc(match.miner_id||match.name||JSON.stringify(match))+'</span>';
+          setStatusPill(result,"bg-ok","✓ Miner FOUND on network! ID: "+String(match.miner_id||match.name||JSON.stringify(match)));
         }else{
-          result.innerHTML='<span class="bg bg-warn">&#9888; Miner not visible yet. This can take a few minutes. Check again shortly.</span>';
+          setStatusPill(result,"bg-warn","⚠ Miner not visible yet. This can take a few minutes. Check again shortly.");
         }
       }catch(e){
-        result.innerHTML='<span class="bg bg-warn">&#9888; Response received but could not parse. Try again shortly.</span>';
+        setStatusPill(result,"bg-warn","⚠ Response received but could not parse. Try again shortly.");
       }
     }else{
-      result.innerHTML='<span class="bg bg-err">&#10007; Server returned status: '+xhr.status+'</span>';
+      setStatusPill(result,"bg-err","✗ Server returned status: "+xhr.status);
     }
   };
-  xhr.onerror=function(){result.innerHTML='<span class="bg bg-err">&#10007; Network error</span>'};
-  xhr.ontimeout=function(){result.innerHTML='<span class="bg bg-warn">&#10007; Timeout</span>'};
+  xhr.onerror=function(){setStatusPill(result,"bg-err","✗ Network error")};
+  xhr.ontimeout=function(){setStatusPill(result,"bg-warn","✗ Timeout")};
   xhr.send();
 }
 window.addEventListener("DOMContentLoaded",init);


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [ ] Add a tier label: `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`)
- [x] If adding new code files, include SPDX header near the top (example: `# SPDX-License-Identifier: MIT`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

This PR hardens dynamic status/result rendering in `web/wizard/setup-wizard.html` by moving runtime validation and network-status outputs from parser-based `innerHTML` strings to small DOM helpers.

Changes included:

- Added:
  - `clearNode()`
  - `makeStatusPill()`
  - `setStatusPill()`
  - `setLoadingStatus()`
  - `setStatusPillWithLoading()`
- Replaced dynamic status rendering in:
  - `verifyPython()`
  - `importWallet()`
  - `saveNode()`
  - `testConnection()`
  - `testAttestation()`
  - `checkMiner()`
- Extended `tests/test_setup_wizard_frontend_security.py` with focused assertions for the new DOM helpers

## Why

The setup wizard still rendered several user-facing status messages through concatenated `innerHTML` strings. This keeps the overall page structure unchanged while moving the dynamic status surfaces to explicit DOM-node construction.

## Testing / Evidence

Commands run:

```bash
git diff --check
python3 -m py_compile tests/test_setup_wizard_frontend_security.py
python3 tests/test_setup_wizard_frontend_security.py
```

Results:

- `git diff --check` passed cleanly
- `py_compile` passed for `tests/test_setup_wizard_frontend_security.py`
- `python3 tests/test_setup_wizard_frontend_security.py` completed successfully

## RTC Wallet / Payout

If this PR is eligible for RTC payout, please send the reward to this RTC wallet:

`RTCc78142b4cc31531e913c4082bc5d771eb0a91ac1`
