### PR TITLE
fix(dashboard): harden rustchain stats stat rendering

### DIFF
--- a/dashboards/rustchain-stats/index.html
+++ b/dashboards/rustchain-stats/index.html
@@ -580,24 +580,39 @@
 
         function updateStat(elementId, value, unit, previousValue) {
             const element = document.getElementById(elementId);
-            element.innerHTML = formatNumber(value) + (unit ? `<span class="stat-unit">${unit}</span>` : '');
+            element.replaceChildren();
+            element.appendChild(document.createTextNode(formatNumber(value)));
+            if (unit) {
+                const unitSpan = document.createElement('span');
+                unitSpan.className = 'stat-unit';
+                unitSpan.textContent = unit;
+                element.appendChild(unitSpan);
+            }
 
             // Show change indicator
             const changeElement = document.getElementById(elementId.replace('Value', 'Change'));
             if (previousValue !== undefined && previousValue !== null) {
                 const diff = value - previousValue;
+                changeElement.replaceChildren();
+                const marker = document.createElement('span');
                 if (diff > 0) {
-                    changeElement.innerHTML = `<span>▲</span> +${formatNumber(diff)}`;
+                    marker.textContent = '▲';
+                    changeElement.appendChild(marker);
+                    changeElement.appendChild(document.createTextNode(' +' + formatNumber(diff)));
                     changeElement.className = 'stat-change positive';
                 } else if (diff < 0) {
-                    changeElement.innerHTML = `<span>▼</span> ${formatNumber(diff)}`;
+                    marker.textContent = '▼';
+                    changeElement.appendChild(marker);
+                    changeElement.appendChild(document.createTextNode(' ' + formatNumber(diff)));
                     changeElement.className = 'stat-change negative';
                 } else {
-                    changeElement.innerHTML = '<span>▬</span> No change';
+                    marker.textContent = '▬';
+                    changeElement.appendChild(marker);
+                    changeElement.appendChild(document.createTextNode(' No change'));
                     changeElement.className = 'stat-change';
                 }
             } else {
-                changeElement.innerHTML = '';
+                changeElement.replaceChildren();
             }
         }
 

--- a/tests/test_rustchain_stats_dashboard_miners_payload.py
+++ b/tests/test_rustchain_stats_dashboard_miners_payload.py
@@ -19,3 +19,13 @@ def test_rustchain_stats_dashboard_uses_normalized_miners_fallback():
     assert "updateStat('minersValue', enrolledMiners, '', previousStats?.minersCount);" in html
     assert "minersCount: enrolledMiners" in html
     assert "updateStat('minersValue', epoch.enrolled_miners || 0, '', previousStats?.epoch?.enrolled_miners);" not in html
+
+
+def test_rustchain_stats_dashboard_uses_dom_nodes_for_stat_markup():
+    html = DASHBOARD_HTML.read_text(encoding="utf-8")
+
+    assert "element.replaceChildren();" in html
+    assert "const unitSpan = document.createElement('span');" in html
+    assert "changeElement.replaceChildren();" in html
+    assert "const marker = document.createElement('span');" in html
+    assert "changeElement.innerHTML =" not in html


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [ ] Add a tier label: `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- Replaced dynamic stat markup in the Rustchain stats dashboard with explicit DOM node construction.
- Removed `innerHTML` usage for unit and trend marker rendering in `updateStat`.
- Added source-level regression checks for the safer DOM pattern.

## Testing / Evidence

- `git diff --check`
- `python3 -m py_compile tests/test_rustchain_stats_dashboard_miners_payload.py`
- `python3 tests/test_rustchain_stats_dashboard_miners_payload.py`

## RTC Wallet

- `RTCc78142b4cc31531e913c4082bc5d771eb0a91ac1`
