### PR TITLE
fix(calculator): harden sensitivity table row rendering

### DIFF
--- a/mining-calculator/index.html
+++ b/mining-calculator/index.html
@@ -635,14 +635,18 @@
                 const perMonth = perDay * 30;
                 
                 const tr = document.createElement('tr');
-                tr.innerHTML = `
-                    <td>${size} miners</td>
-                    <td>${perDay.toFixed(2)} RTC</td>
-                    <td>${perMonth.toFixed(2)} RTC</td>
-                    <td>$${(perMonth * USD_RATE).toFixed(2)}</td>
-                `;
+                appendSensitivityCell(tr, `${size} miners`);
+                appendSensitivityCell(tr, `${perDay.toFixed(2)} RTC`);
+                appendSensitivityCell(tr, `${perMonth.toFixed(2)} RTC`);
+                appendSensitivityCell(tr, `$${(perMonth * USD_RATE).toFixed(2)}`);
                 tbody.appendChild(tr);
             });
+        }
+
+        function appendSensitivityCell(row, text) {
+            const cell = document.createElement('td');
+            cell.textContent = text;
+            row.appendChild(cell);
         }
         
         function showError(message) {

--- a/tests/test_mining_calculator_miners_payload.py
+++ b/tests/test_mining_calculator_miners_payload.py
@@ -17,3 +17,12 @@ def test_mining_calculator_normalizes_current_miners_envelope():
     assert "activeMiners = networkData.total;" in html
     assert "const miners = networkData?.miners || [];" in html
     assert "if (miners && miners.length > 0)" not in html
+
+
+def test_mining_calculator_sensitivity_rows_use_text_cells():
+    html = SOURCE.read_text()
+
+    assert "function appendSensitivityCell(row, text)" in html
+    assert "cell.textContent = text;" in html
+    assert "appendSensitivityCell(tr, `${size} miners`);" in html
+    assert "tr.innerHTML = `" not in html


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [ ] Add a tier label: `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- Replaced sensitivity-table row templating with explicit cell creation in the mining calculator.
- Removed dynamic `innerHTML` row assembly for network-size comparison output.
- Added a source check that locks in the text-cell rendering helper.

## Testing / Evidence

- `git diff --check`
- `python3 -m py_compile tests/test_mining_calculator_miners_payload.py`
- `python3 tests/test_mining_calculator_miners_payload.py`

## RTC Wallet

- `RTCc78142b4cc31531e913c4082bc5d771eb0a91ac1`
