### PR TITLE
fix(tools): harden standalone miner dashboard row rendering

### DIFF
--- a/tests/test_standalone_miner_dashboard_security.py
+++ b/tests/test_standalone_miner_dashboard_security.py
@@ -47,3 +47,20 @@ def test_miner_dashboard_normalizes_miner_row_ids_before_lookup():
     assert 'return Object.assign({}, row, { miner: String(miner) });' in html
     assert "}).filter(Boolean);" in html
     assert 'String(m.miner || "").toLowerCase() === minerId.toLowerCase()' in html
+
+
+def test_miner_dashboard_timeline_rows_use_text_cells():
+    html = DASHBOARD_HTML.read_text(encoding="utf-8")
+
+    assert 'appendTextCell(tr, hour, "mono");' in html
+    assert 'appendTextCell(tr, hit ? "Seen" : "-");' in html
+    assert 'appendTextCell(tr, hit ? "attestation heartbeat" : "no signal");' in html
+    assert 'tr.innerHTML =' not in html
+
+
+def test_miner_dashboard_reward_rows_use_text_cells():
+    html = DASHBOARD_HTML.read_text(encoding="utf-8")
+
+    assert 'appendTextCell(tr, r.epoch, "mono");' in html
+    assert "appendTextCell(tr, fmtRtc(r.amount));" in html
+    assert "appendTextCell(tr, r.type);" in html

--- a/tools/miner_dashboard/index.html
+++ b/tools/miner_dashboard/index.html
@@ -511,10 +511,9 @@
         const hit = Number.isFinite(last) && last >= hourStart && last < hourEnd;
 
         const tr = document.createElement("tr");
-        tr.innerHTML =
-          "<td class=\"mono\">" + hour + "</td>" +
-          "<td>" + (hit ? "Seen" : "-") + "</td>" +
-          "<td>" + (hit ? "attestation heartbeat" : "no signal") + "</td>";
+        appendTextCell(tr, hour, "mono");
+        appendTextCell(tr, hit ? "Seen" : "-");
+        appendTextCell(tr, hit ? "attestation heartbeat" : "no signal");
         tbody.appendChild(tr);
       }
 
@@ -563,10 +562,9 @@
       tbody.innerHTML = "";
       for (const r of rows) {
         const tr = document.createElement("tr");
-        tr.innerHTML =
-          "<td class=\"mono\">" + r.epoch + "</td>" +
-          "<td>" + fmtRtc(r.amount) + "</td>" +
-          "<td>" + r.type + "</td>";
+        appendTextCell(tr, r.epoch, "mono");
+        appendTextCell(tr, fmtRtc(r.amount));
+        appendTextCell(tr, r.type);
         tbody.appendChild(tr);
       }
       state.rewardRows = rows;


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [ ] Add a tier label: `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- Replaced timeline and reward row templating in the standalone miner dashboard with text-cell helpers.
- Removed dynamic `innerHTML` row creation for attestation heartbeat and reward history tables.
- Added source checks covering both hardened render paths.

## Testing / Evidence

- `git diff --check`
- `python3 -m py_compile tests/test_standalone_miner_dashboard_security.py`
- `python3 tests/test_standalone_miner_dashboard_security.py`

## RTC Wallet

- `RTCc78142b4cc31531e913c4082bc5d771eb0a91ac1`
