### PR TITLE
fix(web): harden mood indicator rendering

### DIFF
--- a/tests/test_mood_indicator_dom_security.py
+++ b/tests/test_mood_indicator_dom_security.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+
+SOURCE = Path(__file__).resolve().parents[1] / "web" / "mood-indicator.js"
+
+
+def test_mood_indicator_loading_state_uses_dom_nodes():
+    source = SOURCE.read_text(encoding="utf-8")
+
+    assert "function setLoadingIndicator(container)" in source
+    assert "indicator.textContent = '⏳';" in source
+    assert "container.innerHTML = '<span style=\"font-size: 18px; opacity: 0.5;\">⏳</span>'" not in source
+
+
+def test_mood_indicator_refresh_reuses_render_helper():
+    source = SOURCE.read_text(encoding="utf-8")
+
+    assert "function renderIndicator(container, moodData)" in source
+    assert "container.appendChild(createIndicatorElement(moodData));" in source
+    assert "container.innerHTML = '';" not in source

--- a/web/mood-indicator.js
+++ b/web/mood-indicator.js
@@ -64,6 +64,24 @@
     // Default mood
     const DEFAULT_MOOD = 'energetic';
 
+    function clearElement(element) {
+        element.replaceChildren();
+    }
+
+    function setLoadingIndicator(container) {
+        clearElement(container);
+        const indicator = document.createElement('span');
+        indicator.style.fontSize = '18px';
+        indicator.style.opacity = '0.5';
+        indicator.textContent = '⏳';
+        container.appendChild(indicator);
+    }
+
+    function renderIndicator(container, moodData) {
+        clearElement(container);
+        container.appendChild(createIndicatorElement(moodData));
+    }
+
     /**
      * Fetch mood data from API
      */
@@ -175,21 +193,19 @@
         }
 
         // Show loading state
-        container.innerHTML = '<span style="font-size: 18px; opacity: 0.5;">⏳</span>';
+        setLoadingIndicator(container);
 
         // Fetch and render
         fetchMoodData(agentId).then(moodData => {
             if (moodData) {
-                container.innerHTML = '';
-                container.appendChild(createIndicatorElement(moodData));
+                renderIndicator(container, moodData);
 
                 // Auto-refresh every 5 minutes
                 if (options.autoRefresh !== false) {
                     setInterval(() => {
                         fetchMoodData(agentId).then(newMoodData => {
                             if (newMoodData && newMoodData.current_mood !== moodData.current_mood) {
-                                container.innerHTML = '';
-                                container.appendChild(createIndicatorElement(newMoodData));
+                                renderIndicator(container, newMoodData);
                             }
                         });
                     }, 300000);  // 5 minutes


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [ ] Add a tier label: `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- Replaced mood-indicator loading and refresh clears with DOM helper functions.
- Removed direct `innerHTML` writes for the loading spinner and refresh path.
- Added source checks for the loading indicator and shared render helper.

## Testing / Evidence

- `git diff --check`
- `python3 -m py_compile tests/test_mood_indicator_dom_security.py`
- `python3 tests/test_mood_indicator_dom_security.py`

## RTC Wallet

- `RTCc78142b4cc31531e913c4082bc5d771eb0a91ac1`
