### PR TITLE
fix(tools): use text-based leaderboard sorting

### DIFF
--- a/tests/test_standalone_leaderboard_security.py
+++ b/tests/test_standalone_leaderboard_security.py
@@ -40,3 +40,19 @@ def test_leaderboard_error_row_uses_text_content():
     assert "cell.textContent = `Error: ${err.message}." in html
     assert "renderErrorRow(err);" in html
     assert 'class="error">Error: ${err.message}' not in html
+
+
+def test_leaderboard_sorting_uses_text_content():
+    html = LEADERBOARD_HTML.read_text(encoding="utf-8")
+
+    assert "x.textContent.toLowerCase()" in html
+    assert "y.textContent.toLowerCase()" in html
+    assert "x.innerHTML.toLowerCase()" not in html
+    assert "y.innerHTML.toLowerCase()" not in html
+
+
+def test_leaderboard_clears_rows_with_replace_children():
+    html = LEADERBOARD_HTML.read_text(encoding="utf-8")
+
+    assert "tbody.replaceChildren();" in html
+    assert "tbody.innerHTML = ''" not in html

--- a/tools/leaderboard.html
+++ b/tools/leaderboard.html
@@ -225,7 +225,7 @@
 
         function renderErrorRow(err) {
             const tbody = document.getElementById('leaderboard-body');
-            tbody.innerHTML = '';
+            tbody.replaceChildren();
             const row = tbody.insertRow();
             const cell = row.insertCell();
             cell.colSpan = 5;
@@ -249,7 +249,7 @@
             miners.sort((a, b) => Number(b.antiquity_multiplier || 0) - Number(a.antiquity_multiplier || 0));
 
             const tbody = document.getElementById('leaderboard-body');
-            tbody.innerHTML = '';
+            tbody.replaceChildren();
 
             miners.forEach((m, i) => {
                 const tr = document.createElement('tr');
@@ -298,12 +298,12 @@
                     x = rows[i].getElementsByTagName("TD")[n];
                     y = rows[i + 1].getElementsByTagName("TD")[n];
                     if (dir == "asc") {
-                        if (x.innerHTML.toLowerCase() > y.innerHTML.toLowerCase()) {
+                        if (x.textContent.toLowerCase() > y.textContent.toLowerCase()) {
                             shouldSwitch = true;
                             break;
                         }
                     } else if (dir == "desc") {
-                        if (x.innerHTML.toLowerCase() < y.innerHTML.toLowerCase()) {
+                        if (x.textContent.toLowerCase() < y.textContent.toLowerCase()) {
                             shouldSwitch = true;
                             break;
                         }


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [ ] Add a tier label: `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- Switched standalone leaderboard sorting from `innerHTML` comparisons to `textContent`.
- Replaced table clears with `replaceChildren()` for error and data refresh paths.
- Extended the security source checks to cover both behaviors.

## Testing / Evidence

- `git diff --check`
- `python3 -m py_compile tests/test_standalone_leaderboard_security.py`
- `python3 tests/test_standalone_leaderboard_security.py`

## RTC Wallet

- `RTCc78142b4cc31531e913c4082bc5d771eb0a91ac1`
