### PR TITLE
fix(beacon): do not re-activate barred agents on /beacon/join (#14589)

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -24,6 +24,11 @@ beacon_api = Blueprint('beacon_api', __name__)
 DB_PATH = 'rustchain_v2.db'
 BEACON_AUTH_WINDOW_SECONDS = 300
 
+# Statuses an administrator uses to bar an agent. A rejoin via /beacon/join
+# must never silently lift one of these — otherwise any holder of the
+# (immutable) pubkey can self-unban by re-sending the join request.
+BEACON_PROTECTED_STATUSES = frozenset({'banned', 'suspended', 'revoked'})
+
 # In-memory cache for bounties (synced from GitHub)
 bounty_cache = {
     'data': [],
@@ -586,7 +591,7 @@ def beacon_join():
         # Check if agent already exists
         db = get_db()
         existing = db.execute(
-            "SELECT pubkey_hex, coinbase_address FROM relay_agents WHERE agent_id = ?",
+            "SELECT pubkey_hex, coinbase_address, status FROM relay_agents WHERE agent_id = ?",
             (agent_id,)
         ).fetchone()
 
@@ -609,16 +614,28 @@ def beacon_join():
                              'payment address is immutable after registration'
                 }), 403
 
-            # Update mutable fields only
+            # Update mutable fields only.
+            # SECURITY: a rejoin must never re-activate an agent an admin has
+            # barred. If the current status is protected (banned/suspended/
+            # revoked) keep it; otherwise a rejoin brings the agent back
+            # 'active' as before. Without this guard a banned agent could
+            # self-unban simply by POSTing /beacon/join with its own pubkey.
+            current_status = (existing['status'] or 'active')
+            new_status = (
+                current_status
+                if current_status in BEACON_PROTECTED_STATUSES
+                else 'active'
+            )
             db.execute("""
                 UPDATE relay_agents
                 SET name = COALESCE(?, name),
-                    status = 'active',
+                    status = ?,
                     updated_at = ?
                 WHERE agent_id = ?
-            """, (name, now, agent_id))
+            """, (name, new_status, now, agent_id))
         else:
             # New agent — insert with pubkey_hex
+            new_status = 'active'
             db.execute("""
                 INSERT INTO relay_agents (agent_id, pubkey_hex, name, status, coinbase_address, created_at, updated_at)
                 VALUES (?, ?, ?, 'active', ?, ?, ?)
@@ -631,7 +648,7 @@ def beacon_join():
             'agent_id': agent_id,
             'pubkey_hex': pubkey_hex,
             'name': name,
-            'status': 'active',
+            'status': new_status,
             'timestamp': now,
         })
 

--- a/node/tests/test_beacon_api_join.py
+++ b/node/tests/test_beacon_api_join.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 from flask import Flask
 
 import beacon_api
@@ -12,6 +14,29 @@ def _client(tmp_path, monkeypatch):
     app.config["TESTING"] = True
     app.register_blueprint(beacon_api.beacon_api)
     return app.test_client()
+
+
+def _db_status(agent_id):
+    conn = sqlite3.connect(beacon_api.DB_PATH)
+    try:
+        row = conn.execute(
+            "SELECT status FROM relay_agents WHERE agent_id = ?", (agent_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+    return row[0] if row else None
+
+
+def _set_status(agent_id, status):
+    conn = sqlite3.connect(beacon_api.DB_PATH)
+    try:
+        conn.execute(
+            "UPDATE relay_agents SET status = ? WHERE agent_id = ?",
+            (status, agent_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def test_beacon_join_rejects_non_ed25519_pubkey_length(tmp_path, monkeypatch):
@@ -42,3 +67,52 @@ def test_beacon_join_accepts_32_byte_ed25519_pubkey(tmp_path, monkeypatch):
 
     assert response.status_code == 200
     assert response.get_json()["ok"] is True
+
+
+def _join(client, agent_id, pubkey_hex="22" * 32, name=None):
+    body = {"agent_id": agent_id, "pubkey_hex": pubkey_hex}
+    if name is not None:
+        body["name"] = name
+    return client.post("/beacon/join", json=body)
+
+
+def test_beacon_join_does_not_unban_banned_agent(tmp_path, monkeypatch):
+    """A rejoin must not lift an administrative ban (issue #14589)."""
+    client = _client(tmp_path, monkeypatch)
+
+    assert _join(client, "banned-agent").status_code == 200
+    # Admin bars the agent out of band.
+    _set_status("banned-agent", "banned")
+
+    # Attacker rejoins with the same (immutable) pubkey to self-unban.
+    response = _join(client, "banned-agent", name="renamed")
+
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "banned"
+    assert _db_status("banned-agent") == "banned"
+
+
+def test_beacon_join_keeps_suspended_and_revoked_status(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+
+    for agent_id, status in (("susp-agent", "suspended"), ("rev-agent", "revoked")):
+        assert _join(client, agent_id).status_code == 200
+        _set_status(agent_id, status)
+
+        response = _join(client, agent_id)
+
+        assert response.get_json()["status"] == status
+        assert _db_status(agent_id) == status
+
+
+def test_beacon_join_reactivates_inactive_agent(tmp_path, monkeypatch):
+    """Non-protected statuses (e.g. inactive) still come back online on rejoin."""
+    client = _client(tmp_path, monkeypatch)
+
+    assert _join(client, "idle-agent").status_code == 200
+    _set_status("idle-agent", "inactive")
+
+    response = _join(client, "idle-agent")
+
+    assert response.get_json()["status"] == "active"
+    assert _db_status("idle-agent") == "active"


### PR DESCRIPTION
## What

`beacon_join()` (node/beacon_api.py) upserts relay agents. On the **update** branch (existing agent) it ran:

```sql
UPDATE relay_agents SET name = COALESCE(?, name), status = 'active', updated_at = ? WHERE agent_id = ?
```

The `status = 'active'` is **unconditional**. The pubkey is immutable (already guarded above with a 403), but the agent still fully controls its own `agent_id` + pubkey, so any agent an admin has **banned/suspended** can silently **self-unban** by simply re-POSTing `/beacon/join` — the ban is overwritten with `active`. Closes #14589 (*Status Hijacking in Beacon Join / Unintentional Unban*).

## Fix (fail-closed, minimal)

- Added module constant `BEACON_PROTECTED_STATUSES = {banned, suspended, revoked}`.
- `SELECT` now also reads the current `status`.
- On update, a protected status is **preserved**; non-protected statuses (e.g. `inactive`) still transition back to `active` on rejoin — legit agents coming back online are unaffected.
- The response now returns the agent's **real** resulting status instead of a hardcoded `'active'`.

No behavior change for new registrations. Same file/class as the already-merged beacon/PoA hardening (#7793).

## Tests

Added to `node/tests/test_beacon_api_join.py`:
- `test_beacon_join_does_not_unban_banned_agent` — banned agent stays banned after rejoin.
- `test_beacon_join_keeps_suspended_and_revoked_status`
- `test_beacon_join_reactivates_inactive_agent` — legit inactive→active preserved.

Verified: the two ban-preservation tests **fail on pre-fix code** (status becomes `active`) and pass after the fix. `pytest tests/test_beacon_api_join.py` → **5 passed**.

/claim #14589