### PR TITLE
docs: add contributor ladder documentation (closes #343)

### DIFF
--- a/docs/community/contributor-ladder.md
+++ b/docs/community/contributor-ladder.md
@@ -1,0 +1,137 @@
+# RustChain Contributor Ladder
+
+Progress through the ranks. Each tier unlocks higher bounty access and governance rights.
+
+## Tiers
+
+| Tier | Name | Requirements | Rewards |
+|------|------|-------------|---------|
+| 1 | **Explorer** | First merged PR or detailed bug report | 5 RTC welcome bonus |
+| 2 | **Miner** | 3+ merged PRs over 30+ days | 25 RTC bonus + priority bounty claims |
+| 3 | **Foreman** | 10+ merged PRs, 90+ days, reviewed 3+ others' PRs | 100 RTC bonus + RIP voting rights |
+| 4 | **Architect** | 6+ months sustained, major feature or security contribution | 250 RTC bonus + RIP authorship + epoch multiplier |
+| 5 | **Guardian** | Found and reported critical security vulnerability | Permanent title + Hall of Fame + 500 RTC |
+
+## How It Works
+
+- **Automatic tracking** — we check your merged PRs, time active, and review history
+- **Tier-up bonuses are one-time** — you get them when you level up
+- **Higher tiers can claim higher-value bounties** — Explorer: up to 10 RTC, Miner: up to 50 RTC, Foreman: up to 150 RTC, Architect: unlimited
+- **Governance rights are real** — Foreman+ can vote on RustChain Improvement Proposals (RIPs), Architect+ can author them
+
+## Getting Started
+
+1. **Star the repo** — [Star RustChain](https://github.com/Scottcjn/Rustchain) to stay updated
+2. **Browse open bounties** — Check [Issues](https://github.com/Scottcjn/Rustchain/issues?q=is%3Aissue+is%3Aopen+label%3Abounty) labeled `bounty`
+3. **Find Good First Issues** — Check [Good First Issues](https://github.com/Scottcjn/Rustchain/issues?q=is%3Aissue+is%3Aopen+label%3A%22good%20first%20issue%22)
+4. **Comment on the issue** you want to work on
+5. **Fork and create a branch**
+6. **Submit a PR** referencing the issue number
+7. **Get paid** in RTC on merge
+
+## Tier Details
+
+### Tier 1: Explorer
+
+**Requirements:**
+- First merged PR OR detailed bug report
+
+**Rewards:**
+- 5 RTC welcome bonus
+- Explorer badge on your profile
+
+**How to reach:**
+- Fix a typo in any `.md` file
+- Add a missing link to the README
+- Clarify a confusing instruction
+- Add an example command that was missing
+
+### Tier 2: Miner
+
+**Requirements:**
+- 3+ merged PRs
+- 30+ days active
+
+**Rewards:**
+- 25 RTC bonus
+- Priority bounty claims
+- Miner badge
+
+**How to reach:**
+- Contribute consistently over a month
+- Work on multiple features or fixes
+- Help with documentation
+
+### Tier 3: Foreman
+
+**Requirements:**
+- 10+ merged PRs
+- 90+ days active
+- Reviewed 3+ others' PRs
+
+**Rewards:**
+- 100 RTC bonus
+- RIP voting rights
+- Foreman badge
+
+**How to reach:**
+- Sustained contributions over 3 months
+- Review community PRs
+- Help onboard new contributors
+
+### Tier 4: Architect
+
+**Requirements:**
+- 6+ months sustained contribution
+- Major feature or security contribution
+
+**Rewards:**
+- 250 RTC bonus
+- RIP authorship rights
+- Epoch multiplier bonus
+- Architect badge
+
+**How to reach:**
+- Lead a significant feature development
+- Conduct security research
+- Design and implement protocol improvements
+
+### Tier 5: Guardian
+
+**Requirements:**
+- Found and reported critical security vulnerability
+
+**Rewards:**
+- 500 RTC bonus
+- Permanent title
+- Hall of Fame entry
+- Guardian badge
+
+**How to reach:**
+- Conduct thorough security audits
+- Report vulnerabilities responsibly
+- Help fix critical issues
+
+## Current Leaderboard
+
+| Contributor | Merged PRs | Active Since | Current Tier |
+|------------|-----------|-------------|-------------|
+| createkr | 26 | Feb 2026 | Foreman |
+| liu971227-sys | 23 | Dec 2025 | Foreman |
+| David-code-tang | 20 | Feb 2026 | Miner |
+| autonomy414941 | 7 | Feb 2026 | Miner |
+| erdogan98 | 5 | Feb 2026 | Miner |
+
+*Leaderboard updated weekly. Claim your tier in the comments!*
+
+## Why This Matters
+
+Farmers want quick payouts. Real contributors want recognition, influence, and a project they helped build. The ladder rewards sustained quality over spray-and-pray PRs.
+
+## Code of Conduct
+
+All contributors must follow the [Code of Conduct](../CODE_OF_CONDUCT.md). Violations can result in tier demotion or removal from the project.
+
+---
+
+*Based on Kubernetes/CNCF contributor ladder model, adapted for RustChain.*


### PR DESCRIPTION
## Summary
Closes #343

## Changes
- Added comprehensive contributor ladder documentation at `docs/community/contributor-ladder.md`
- 5 tiers: Explorer, Miner, Foreman, Architect, Guardian
- Clear requirements, rewards, and how-to-reach sections for each tier
- Current leaderboard with top contributors
- Getting started guide for new contributors
- Links to issues, bounties, and code of conduct

## Testing
- [ ] Documentation renders correctly
- [ ] All links are valid
- [ ] Tier requirements are accurate

---

## 💰 Bounty Reward Info
- **Wallet Address:** `RTCfe13452d122263caf633ab1876bd9631133b68b1`
