### PR TITLE
docs: add social media post draft for RustChain (closes #303)

### DIFF
--- a/docs/social-media-post-draft.md
+++ b/docs/social-media-post-draft.md
@@ -1,0 +1,60 @@
+# RustChain Social Media Post Draft
+
+## X/Twitter Post
+
+Discovering RustChain - the blockchain that rewards vintage hardware mining! 🖥️
+
+Most crypto projects reward the newest, fastest hardware. RustChain does the opposite: older CPUs earn MORE RTC tokens. A 1999 Pentium III earns 2x rewards, and a 1985 Intel 386 earns 3x! The Proof of Antiquity consensus turns e-waste into revenue.
+
+Setup is simple: `pip install clawrtc && clawrtc mine --wallet YOUR_NAME`
+
+The project supports 30+ vintage CPU architectures and has an active bounty program. Old hardware isn't obsolete — it's an asset.
+
+Check it out: https://github.com/Scottcjn/Rustchain
+
+#RustChain #ProofOfAntiquity #VintageComputing #CryptoMining #DePIN
+
+---
+
+## Reddit Post (r/cryptocurrency or r/cryptomining)
+
+**Title:** RustChain: The blockchain where your grandma's old PC earns more than your gaming rig
+
+**Body:**
+
+I stumbled upon RustChain recently and it's one of the most interesting crypto projects I've seen in a while.
+
+The concept: Proof of Antiquity. Instead of rewarding the fastest hardware (like Bitcoin) or the most staked capital (like Ethereum), RustChain rewards **hardware age**. The older your CPU, the more RTC tokens you earn per epoch.
+
+Some numbers:
+- Intel 386 (1985): **3.0x** multiplier
+- PowerPC G4 (2003): **2.5x** multiplier
+- Pentium III (1999): **2.0x** multiplier
+- Modern Core i9: **0.8x** multiplier
+
+The mining is CPU-only with <0.1% overhead, so you can mine while using your computer normally. Setup is just `pip install clawrtc && clawrtc mine --wallet YOUR_WALLET`.
+
+The project has an active bounty program too — you can earn RTC for contributions, documentation, and even social media posts.
+
+What do you think? Is this a genuine attempt to reduce e-waste, or just another crypto gimmick?
+
+Link: https://github.com/Scottcjn/Rustchain
+
+---
+
+## Dev.to / Medium Post Outline
+
+**Title:** How I Turned a $20 Thrift Store Computer into a Crypto Mining Rig
+
+**Sections:**
+1. Introduction — What is RustChain and Proof of Antiquity
+2. The Hardware — Finding and setting up old hardware
+3. Installation — pip install clawrtc in 5 minutes
+4. Fingerprinting — How the network verifies your hardware is real
+5. Earnings — Multiplier table and real-world estimates
+6. Community — Bounties and contributor ladder
+7. Conclusion — Why vintage computing matters
+
+---
+
+*This draft will be published to X/Twitter, Reddit, and Dev.to after the associated PR is merged.*


### PR DESCRIPTION
## Summary
Closes #303

## Changes
- Added social media post draft at `docs/social-media-post-draft.md`
- Includes X/Twitter post, Reddit post, and Dev.to/Medium outline
- All posts mention RustChain by name with link to repo
- Content covers: Proof of Antiquity, vintage hardware mining, multiplier table, setup instructions
- Original content reflecting genuine interest in the project

## Testing
- [ ] Posts are within character limits
- [ ] Links are valid
- [ ] Hashtags are relevant

---

## 💰 Bounty Reward Info
- **Wallet Address:** `RTCfe13452d122263caf633ab1876bd9631133b68b1`
