### PR TITLE
fix(encoding): declare UTF-8 encoding for markdown files in .gitattributes (closes #6793)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -57,6 +57,14 @@ docs/media/*.mp3 -diff
 *.rar binary
 
 # =============================================================================
+# Encoding
+# =============================================================================
+
+# Ensure all markdown files are treated as UTF-8 to prevent mojibake
+# on systems with legacy code pages (e.g. Windows cp850/cp1252).
+*.md text eol=lf encoding=utf-8
+
+# =============================================================================
 # Line ending normalization
 # =============================================================================
 
@@ -73,7 +81,6 @@ docs/media/*.mp3 -diff
 *.html text eol=lf
 *.css text eol=lf
 *.scss text eol=lf
-*.md text eol=lf
 *.json text eol=lf
 *.yaml text eol=lf
 *.yml text eol=lf


### PR DESCRIPTION
## Summary
Closes #6793

## Changes
- Added explicit `encoding=utf-8` for `*.md` files in `.gitattributes`
- Prevents mojibake on systems with legacy code pages (e.g. Windows cp850/cp1252)
- The README contains multilingual content (Chinese, Japanese, Russian, Korean, Hindi, Vietnamese) that requires proper UTF-8 handling
- Removed duplicate `*.md` entry from the line-ending section since it is now declared with encoding=utf-8 above

## Root Cause
The README.md contains characters from multiple non-Latin scripts. Without explicit UTF-8 encoding declaration in `.gitattributes`, Git may auto-detect encoding on legacy systems, leading to mojibake (garbled characters).

## Testing
- [x] All existing tests pass
- [x] Verified `.gitattributes` is valid
- [x] Verified README renders correctly in UTF-8

---

## 💰 Bounty Reward Info
- **Wallet Address:** `RTCfe13452d122263caf633ab1876bd9631133b68b1`
