### PR TITLE
fix(setup): correct wallet balance check path in summary (closes #5712)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -398,7 +398,7 @@ summary() {
   echo -e "  cd $INSTALL_DIR && $PYTHON -u $MINER_SCRIPT --wallet $WALLET_NAME"
   echo ""
   echo -e "  ${BOLD}Check your balance:${NC}"
-  echo -e "  curl -sk '$NODE_URL/wallet/balance?miner_id=$WALLET_NAME' | python3 -m json.tool"
+  echo -e "  curl -sk '$NODE_URL/api/wallet/$WALLET_NAME' | python3 -m json.tool"
   echo ""
   echo -e "  ${BOLD}Join the community:${NC}"
   echo -e "  Discord: https://discord.gg/rustchain"


### PR DESCRIPTION
## Summary
- Fixed the balance-check command in setup.sh summary that pointed to a non-existent `/wallet/balance?miner_id=` route, returning 404
- Updated the path to the correct REST API endpoint `/api/wallet/$WALLET_NAME` as defined in the node server routes

## Changes
- `setup.sh`: Changed balance check curl command from `$NODE_URL/wallet/balance?miner_id=$WALLET_NAME` to `$NODE_URL/api/wallet/$WALLET_NAME`

## Verification
- The node server (`rips/python/rustchain/node.py:394`, `rips/src/network.rs:578-599`) registers the wallet endpoint at `/api/wallet/<address>` under `API_PREFIX = "/api"`
- The explorer dashboard (`explorer/rustchain_dashboard.py:848`) also uses `/api/wallet/<wallet_address>`

---

## 💰 Bounty Reward Info
- **Wallet Address:** `RTCfe13452d122263caf633ab1876bd9631133b68b1`
