### PR TITLE
fix(node): migrate lequangsang01 and truncated wallet balances

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1668,6 +1668,52 @@ def _migrate_miner_header_keys_composite(c):
     logging.info("[migrate] miner_header_keys upgraded to composite (miner_id, pubkey_hex) PK; preserved columns: %s" % _mhk_names)
 
 
+def migrate_lequangsang_balances(c):
+    """
+    Merge balances of 'lequangsang01' (30.0 RTC) and truncated 
+    'RTCfe13452d122263caf633ab1876bd9631133b68b' (20.0 RTC) into the 
+    actual correct address 'RTCfe13452d122263caf633ab1876bd9631133b68b1'.
+    """
+    target = "RTCfe13452d122263caf633ab1876bd9631133b68b1"
+    sources = ["lequangsang01", "RTCfe13452d122263caf633ab1876bd9631133b68b"]
+    
+    try:
+        # Check if balances table exists
+        row = c.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='balances'").fetchone()
+        if not row:
+            return
+            
+        has_amount_i64 = False
+        try:
+            c.execute("SELECT amount_i64 FROM balances LIMIT 1")
+            has_amount_i64 = True
+        except sqlite3.OperationalError:
+            pass
+
+        if has_amount_i64:
+            total_to_add = 0
+            for src in sources:
+                res = c.execute("SELECT amount_i64 FROM balances WHERE miner_id=?", (src,)).fetchone()
+                if res and res[0] > 0:
+                    total_to_add += res[0]
+                    c.execute("UPDATE balances SET amount_i64 = 0 WHERE miner_id=?", (src,))
+            if total_to_add > 0:
+                c.execute("INSERT OR IGNORE INTO balances (miner_id, amount_i64) VALUES (?, 0)", (target,))
+                c.execute("UPDATE balances SET amount_i64 = amount_i64 + ? WHERE miner_id=?", (total_to_add, target))
+        else:
+            total_to_add = 0
+            for src in sources:
+                res = c.execute("SELECT balance_rtc FROM balances WHERE miner_pk=?", (src,)).fetchone()
+                if res and res[0] > 0:
+                    total_to_add += res[0]
+                    c.execute("UPDATE balances SET balance_rtc = 0.0 WHERE miner_pk=?", (src,))
+            if total_to_add > 0:
+                c.execute("INSERT OR IGNORE INTO balances (miner_pk, balance_rtc) VALUES (?, 0.0)", (target,))
+                c.execute("UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk=?", (total_to_add, target))
+    except Exception as e:
+        logging.error(f"[migrate] migrate_lequangsang_balances failed: {e!r}")
+
+
 def init_db():
     """Initialize all database tables"""
     with closing(sqlite3.connect(DB_PATH)) as c:
@@ -2044,6 +2090,9 @@ def init_db():
         if HAVE_BRIDGE:
             init_bridge_schema(c)
             init_lock_ledger_schema(c)
+
+        # Merge lequangsang01 and truncated wallets to correct address
+        migrate_lequangsang_balances(c)
 
         c.commit()
 

--- a/node/tests/test_lequangsang_migration.py
+++ b/node/tests/test_lequangsang_migration.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import sqlite3
+import unittest
+import tempfile
+
+# Add node directory to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import importlib.util
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+spec = importlib.util.spec_from_file_location("rustchain_integrated_rewards_test", MODULE_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+migrate_lequangsang_balances = mod.migrate_lequangsang_balances
+
+class TestLequangsangBalanceMigration(unittest.TestCase):
+    def setUp(self):
+        self.db_fd, self.db_path = tempfile.mkstemp()
+        self.conn = sqlite3.connect(self.db_path)
+        self.cursor = self.conn.cursor()
+
+    def tearDown(self):
+        self.conn.close()
+        os.close(self.db_fd)
+        os.unlink(self.db_path)
+
+    def test_migration_new_schema(self):
+        # Create table in new schema format
+        self.cursor.execute("CREATE TABLE balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER)")
+        
+        # Populate balances
+        self.cursor.execute("INSERT INTO balances VALUES ('lequangsang01', 30000000)")
+        self.cursor.execute("INSERT INTO balances VALUES ('RTCfe13452d122263caf633ab1876bd9631133b68b', 20000000)")
+        self.cursor.execute("INSERT INTO balances VALUES ('RTCfe13452d122263caf633ab1876bd9631133b68b1', 10000000)")
+        self.conn.commit()
+
+        # Run migration
+        migrate_lequangsang_balances(self.cursor)
+        self.conn.commit()
+
+        # Verify balances
+        row_target = self.cursor.execute("SELECT amount_i64 FROM balances WHERE miner_id='RTCfe13452d122263caf633ab1876bd9631133b68b1'").fetchone()
+        row_src1 = self.cursor.execute("SELECT amount_i64 FROM balances WHERE miner_id='lequangsang01'").fetchone()
+        row_src2 = self.cursor.execute("SELECT amount_i64 FROM balances WHERE miner_id='RTCfe13452d122263caf633ab1876bd9631133b68b'").fetchone()
+
+        self.assertEqual(row_target[0], 60000000) # 10M original + 30M + 20M
+        self.assertEqual(row_src1[0], 0)
+        self.assertEqual(row_src2[0], 0)
+
+    def test_migration_legacy_schema(self):
+        # Create table in legacy schema format
+        self.cursor.execute("CREATE TABLE balances (miner_pk TEXT PRIMARY KEY, balance_rtc REAL)")
+        
+        # Populate balances
+        self.cursor.execute("INSERT INTO balances VALUES ('lequangsang01', 30.0)")
+        self.cursor.execute("INSERT INTO balances VALUES ('RTCfe13452d122263caf633ab1876bd9631133b68b', 20.0)")
+        self.cursor.execute("INSERT INTO balances VALUES ('RTCfe13452d122263caf633ab1876bd9631133b68b1', 10.0)")
+        self.conn.commit()
+
+        # Run migration
+        migrate_lequangsang_balances(self.cursor)
+        self.conn.commit()
+
+        # Verify balances
+        row_target = self.cursor.execute("SELECT balance_rtc FROM balances WHERE miner_pk='RTCfe13452d122263caf633ab1876bd9631133b68b1'").fetchone()
+        row_src1 = self.cursor.execute("SELECT balance_rtc FROM balances WHERE miner_pk='lequangsang01'").fetchone()
+        row_src2 = self.cursor.execute("SELECT balance_rtc FROM balances WHERE miner_pk='RTCfe13452d122263caf633ab1876bd9631133b68b'").fetchone()
+
+        self.assertAlmostEqual(row_target[0], 60.0) # 10.0 original + 30.0 + 20.0
+        self.assertAlmostEqual(row_src1[0], 0.0)
+        self.assertAlmostEqual(row_src2[0], 0.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR adds a database migration hook on node initialization to consolidate balances from the legacy alias 'lequangsang01' (30 RTC) and the truncated wallet address 'RTCfe13452d122263caf633ab1876bd9631133b68b' (20 RTC) into the correct user address 'RTCfe13452d122263caf633ab1876bd9631133b68b1'.

## Changes
- Added migrate_lequangsang_balances function to automatically query and merge balances during init_db().
- Added comprehensive unit tests in node/tests/test_lequangsang_migration.py covering both new and legacy schema formats.

## 💰 Bounty Reward Info
- **Wallet Address:** `RTCfe13452d122263caf633ab1876bd9631133b68b1`