### PR TITLE
ci: refresh fetchall baseline for bridge_api.py additions

### DIFF
--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -27,6 +27,8 @@ node/beacon_x402.py:).fetchall()
 node/beacon_x402.py:).fetchall()
 node/beacon_x402.py:for row in cursor.fetchall()}
 node/bottube_feed_routes.py:rows = cursor_obj.fetchall()
+node/bridge_api.py:""").fetchall()
+node/bridge_api.py:rows = cursor.execute(query, params).fetchall()
 node/claims_eligibility.py:epochs = [row[0] for row in cursor.fetchall() if row[0] >= 0]
 node/claims_settlement.py:""", (batch_id, max_claims)).fetchall()
 node/claims_settlement.py:""", (max_claims,)).fetchall()
@@ -62,20 +64,20 @@ node/machine_passport.py:""", (machine_id,)).fetchall()
 node/machine_passport.py:""", (machine_id,)).fetchall()
 node/machine_passport.py:""", params).fetchall()
 node/migrate_machine_passport.py:result['tables'] = [row[0] for row in cursor.fetchall()]
+node/payout_worker.py:""").fetchall()
+node/payout_worker.py:""").fetchall()
 node/payout_worker.py:""", (cutoff,)).fetchall()
 node/payout_worker.py:""", (limit,)).fetchall()
-node/payout_worker.py:""").fetchall()
-node/payout_worker.py:""").fetchall()
 node/proposer_duty_calendar.py:).fetchall()
 node/rewards_implementation_rip200.py:).fetchall()
-node/rip_200_round_robin_1cpu1vote_v2.py:epoch_miners = cursor.fetchall()
-node/rip_200_round_robin_1cpu1vote_v2.py:for row in cursor.fetchall():
+node/rip0202_evidence.py:rows = conn.execute(sql, params).fetchall()
 node/rip_200_round_robin_1cpu1vote.py:cols = cursor.execute("PRAGMA table_info(miner_attest_recent)").fetchall()
 node/rip_200_round_robin_1cpu1vote.py:enrolled = cursor.fetchall()
 node/rip_200_round_robin_1cpu1vote.py:epoch_miners = cursor.fetchall()
 node/rip_200_round_robin_1cpu1vote.py:return cursor.fetchall()
+node/rip_200_round_robin_1cpu1vote_v2.py:epoch_miners = cursor.fetchall()
+node/rip_200_round_robin_1cpu1vote_v2.py:for row in cursor.fetchall():
 node/rip_node_sync.py:return set(row[0] for row in cursor.fetchall())
-node/rip0202_evidence.py:rows = conn.execute(sql, params).fetchall()
 node/rom_clustering_server.py:duplicate_keys = [(row[0], row[1]) for row in cur.fetchall()]
 node/rom_clustering_server.py:for row in cur.fetchall():
 node/rom_clustering_server.py:for row in cur.fetchall():
@@ -88,8 +90,8 @@ node/rustchain_block_producer.py:for row in cursor.fetchall()
 node/rustchain_block_producer.py:for row in cursor.fetchall():
 node/rustchain_block_producer.py:for row in cursor.fetchall():
 node/rustchain_block_producer.py:return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
-node/rustchain_dashboard.py:""", (epoch_data['epoch'],)).fetchall()
 node/rustchain_dashboard.py:""").fetchall()
+node/rustchain_dashboard.py:""", (epoch_data['epoch'],)).fetchall()
 node/rustchain_ergo_anchor.py:anchors = [dict(row) for row in cursor.fetchall()]
 node/rustchain_ergo_anchor.py:for row in cursor.fetchall():
 node/rustchain_migration.py:attestations = cursor.fetchall()
@@ -99,11 +101,11 @@ node/rustchain_p2p_gossip.py:""").fetchall()
 node/rustchain_p2p_gossip.py:""").fetchall()
 node/rustchain_p2p_gossip.py:""").fetchall()
 node/rustchain_p2p_gossip.py:attested_miners = {row[0] for row in cursor.fetchall()}
-node/rustchain_p2p_sync_secure.py:return [row[0] for row in cursor.fetchall()]
-node/rustchain_p2p_sync_secure.py:rows = cursor.fetchall()
 node/rustchain_p2p_sync.py:""", (cutoff, cap)).fetchall()
 node/rustchain_p2p_sync.py:""", (cutoff, fresh_n)).fetchall()
 node/rustchain_p2p_sync.py:""", (start, limit)).fetchall()
+node/rustchain_p2p_sync_secure.py:return [row[0] for row in cursor.fetchall()]
+node/rustchain_p2p_sync_secure.py:rows = cursor.fetchall()
 node/rustchain_sync.py:data = [dict(row) for row in cursor.fetchall()]
 node/rustchain_sync.py:rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
 node/rustchain_sync.py:rows = cursor.fetchall()
@@ -114,11 +116,10 @@ node/rustchain_tx_handler.py:pending_nonces = {row["nonce"] for row in cursor.fe
 node/rustchain_tx_handler.py:return {row["nonce"] for row in cursor.fetchall()}
 node/rustchain_tx_handler.py:tables = {row[0] for row in cursor.fetchall()}
 node/rustchain_tx_handler.py:transactions = [dict(row) for row in cursor.fetchall()]
-node/rustchain_v2_integrated_v2.2.1_rip200.py:_epoch_state_cols = {row[1] for row in c.execute("PRAGMA table_info(epoch_state)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:""").fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:""").fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:""").fetchall())
 node/rustchain_v2_integrated_v2.2.1_rip200.py:""", (limit, offset)).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:""").fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:""").fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:""").fetchall())
 node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
@@ -139,6 +140,8 @@ node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall():
 node/rustchain_v2_integrated_v2.2.1_rip200.py:).fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:WHERE active=1 ORDER BY signer_id""").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:_epoch_state_cols = {row[1] for row in c.execute("PRAGMA table_info(epoch_state)").fetchall()}
 node/rustchain_v2_integrated_v2.2.1_rip200.py:cols = {r[1] for r in cur.execute("PRAGMA table_info(balances)").fetchall()}
 node/rustchain_v2_integrated_v2.2.1_rip200.py:columns = conn.execute("PRAGMA table_info(epoch_enroll)").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:for r in c.execute("PRAGMA table_info(balances)").fetchall():
@@ -147,15 +150,14 @@ node/rustchain_v2_integrated_v2.2.1_rip200.py:return {row[1] for row in c.execut
 node/rustchain_v2_integrated_v2.2.1_rip200.py:return {row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
 node/rustchain_v2_integrated_v2.2.1_rip200.py:rows = conn.execute("SELECT epoch, miner_pk, weight FROM epoch_enroll").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:WHERE active=1 ORDER BY signer_id""").fetchall()
 node/rustchain_x402.py:columns = {row[1] for row in conn.execute("PRAGMA table_info(balances)").fetchall()}
 node/rustchain_x402.py:existing = {row[1] for row in cursor.fetchall()}
 node/slashing_penalties.py:return tuple(row[1] for row in conn.execute(f'PRAGMA table_info("{table_name}")').fetchall())
 node/sophia_attestation_inspector.py:).fetchall()
 node/sophia_attestation_inspector.py:).fetchall()
 node/sophia_attestation_inspector.py:).fetchall()
-node/sophia_elya_service.py:columns = {row[1] for row in conn.execute("PRAGMA table_info(epoch_state)").fetchall()}
 node/sophia_elya_service.py:columns = conn.execute("PRAGMA table_info(balances)").fetchall()
+node/sophia_elya_service.py:columns = {row[1] for row in conn.execute("PRAGMA table_info(epoch_state)").fetchall()}
 node/sophia_governor_inbox.py:).fetchall()
 node/sophia_governor_inbox.py:).fetchall()
 node/sophia_governor_inbox.py:).fetchall()


### PR DESCRIPTION
## Summary

The `test` job was red because `tests/test_fetchall_guard.py::test_fetchall_guard_passes_current_baseline` was failing. The baseline file `scripts/baselines/fetchall_existing.txt` had gone stale: two commits added new `.fetchall()` calls to `node/bridge_api.py` without updating it.

- `7925fe174` (bridge: account deposit locks against the source balance at create) added `migrate_deposits_to_hard_locks()`, which fetches rows filtered on `status IN ('pending','locked','confirming') AND source_debited = 0`. One-time startup migration over the active in-flight deposit set, not an unbounded scan.
- `7f3ffd02f` (bridge: deposit-create honors in-flight reservations (encumbrance-aware)) added `list_bridge_transfers()`, which always has `LIMIT` bound to `min(limit, 500)`. Also bounded.

I regenerated the baseline the way `scripts/check_fetchall.sh` itself documents (its own stale-baseline error message says to do this):

```
bash scripts/check_fetchall.sh --print-baseline > scripts/baselines/fetchall_existing.txt
```

No production code was touched, and no calls were annotated with `fetchall-ok`. The rest of the diff beyond the 2 new lines is pure reordering from the script's own sort output (locale-dependent), not a content change; net +2 lines matching the two new bridge_api.py calls exactly.

## Risk assessment

Neither new call looks like the unbounded-query pattern the guard exists to catch (issue #6627):
- `list_bridge_transfers` is capped at 500 rows via `LIMIT`.
- `migrate_deposits_to_hard_locks` is bounded by a status filter to the currently-active deposit set, and only runs once at migration/init time.

Both are reasonable candidates for a follow-up PR that adds explicit `# fetchall-ok: already-paginated` / `# fetchall-ok: bounded-by-schema` annotations, but I did not do that here since the ask was specifically to refresh the baseline, not touch `node/bridge_api.py`.

## Test plan
- [x] `python -m pytest tests/test_fetchall_guard.py -x -v` — all 11 tests pass
- [x] `bash scripts/check_fetchall.sh` — prints `OK: no new unannotated .fetchall() calls in node/.`
- [x] Confirmed no stale-baseline entries remain (diffed `--print-baseline` output against old baseline; only the two new bridge_api.py lines were added, everything else was line reordering)