### PR TITLE
[UTXO-BUG] Skip same-input mempool block candidates

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -1115,6 +1115,54 @@ class TestUtxoDB(unittest.TestCase):
         self.assertEqual([tx['tx_id'] for tx in candidates], ['spend_oracle' * 5])
         self.assertTrue(self.db.mempool_check_double_spend(alice_box['box_id']))
 
+    def test_mempool_block_candidates_skip_same_input_conflicts(self):
+        """Candidate selection must be defensive against stale input claims.
+
+        Normal mempool_add() rejects two live transactions that spend the same
+        box. However, stale/corrupt rows can exist after a crash, failed
+        migration, manual repair, or earlier cleanup bug. Block-template
+        selection is the final safety boundary and must never return two
+        candidates that cannot both apply sequentially.
+        """
+        self._apply_coinbase('alice', 100 * UNIT, block_height=1)
+        box = self.db.get_unspent_for_address('alice')[0]
+        now = int(time.time())
+        high = {
+            'tx_id': 'same_input_high',
+            'inputs': [{'box_id': box['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT - 5000}],
+            'fee_nrtc': 5000,
+        }
+        low = {
+            'tx_id': 'same_input_low',
+            'inputs': [{'box_id': box['box_id']}],
+            'outputs': [{'address': 'carol', 'value_nrtc': 100 * UNIT - 1000}],
+            'fee_nrtc': 1000,
+        }
+
+        conn = self.db._conn()
+        try:
+            # Simulate an inconsistent mempool snapshot with two tx payloads
+            # for one spend input. Only one input-claim row can exist because
+            # utxo_mempool_inputs.box_id is the primary key.
+            for tx in (high, low):
+                conn.execute(
+                    """INSERT INTO utxo_mempool
+                       (tx_id, tx_data_json, fee_nrtc, submitted_at, expires_at)
+                       VALUES (?,?,?,?,?)""",
+                    (tx['tx_id'], json.dumps(tx), tx['fee_nrtc'], now, now + 3600),
+                )
+            conn.execute(
+                "INSERT INTO utxo_mempool_inputs (box_id, tx_id) VALUES (?,?)",
+                (box['box_id'], high['tx_id']),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        candidates = self.db.mempool_get_block_candidates(max_count=10)
+        self.assertEqual([tx['tx_id'] for tx in candidates], ['same_input_high'])
+
     def test_mempool_nonexistent_input_rejected(self):
         tx = {
             'tx_id': 'cccc' * 16,

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -1468,6 +1468,11 @@ class UtxoDB:
                 else:
                     input_set = set(input_ids)
                     data_input_set = set(data_inputs)
+                    # Data inputs are read-only witnesses: they may be reused
+                    # by multiple block-template candidates.  Only reject
+                    # candidates where a box is both spent and witnessed across
+                    # the selected set, or where two candidates spend the same
+                    # box.
                     if (
                         input_set & selected_spend_inputs
                         or input_set & selected_data_inputs

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -1469,7 +1469,8 @@ class UtxoDB:
                     input_set = set(input_ids)
                     data_input_set = set(data_inputs)
                     if (
-                        input_set & selected_data_inputs
+                        input_set & selected_spend_inputs
+                        or input_set & selected_data_inputs
                         or data_input_set & selected_spend_inputs
                     ):
                         continue


### PR DESCRIPTION
## Summary
- Harden UTXO mempool block-template selection against same-input candidate conflicts.
- Adds a regression test that simulates an inconsistent/stale mempool snapshot containing two payloads spending the same box.
- Ensures only the highest-fee candidate is returned, so a block producer cannot build an internally invalid double-spend candidate set.

## Bounty
Addresses UTXO Red Team bounty Scottcjn/rustchain-bounties#2819.

## Verification
- `python3 -m pytest -q test_utxo_db.py::TestUtxoDB::test_mempool_block_candidates_skip_same_input_conflicts test_utxo_db.py::TestUtxoDB::test_mempool_block_candidates_skip_cross_transaction_data_input_conflicts test_utxo_db.py::TestUtxoDB::test_mempool_block_candidates`
- `python3 -m pytest -q test_utxo_db.py test_utxo_endpoints.py`
