### PR TITLE
Fix Snap repository links

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -27,8 +27,8 @@ npm install rustchain-snap
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/Scottcjn/rustchain-bounties.git
-cd rustchain-bounties/snap
+git clone https://github.com/Scottcjn/Rustchain.git
+cd Rustchain/snap
 ```
 
 2. Install dependencies:

--- a/snap/package.json
+++ b/snap/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Scottcjn/rustchain-bounties.git"
+    "url": "https://github.com/Scottcjn/Rustchain.git"
   },
   "keywords": [
     "metamask",


### PR DESCRIPTION
## Summary

Updates the Snap package metadata and development clone instructions to point at the Rustchain repository instead of the rustchain-bounties repository.

## Verification

- Parsed snap/package.json with Node to confirm the file remains valid JSON.