### PR TITLE
Docs accuracy pass + implement /api/tokenomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,11 +375,12 @@ Unlike Proof-of-Work where hash power = votes:
 ### Epoch Rewards
 
 ```
-Epoch: 10 minutes  |  Pool: 1.5 RTC/epoch  |  Split by antiquity weight
+Block: 10 min  |  Epoch: 144 blocks (~24h)  |  Pool: 1.5 RTC/epoch, split by antiquity weight
 
 G4 Mac (2.5x):     0.30 RTC  ████████████████████
 G5 Mac (2.0x):     0.24 RTC  ████████████████
 Modern PC (1.0x):  0.12 RTC  ████████
+       (example with 8 miners sharing the pool)
 ```
 
 ### Anti-VM Enforcement
@@ -530,33 +531,21 @@ Named after a 486 laptop with oxidized serial ports that still boots to DOS and 
 
 ---
 
-<div align="center">
-
-**[Elyan Labs](https://elyanlabs.ai)** · Built with $0 VC and a room full of pawn shop hardware
-
-*"Mais, it still works, so why you gonna throw it away?"*
-
-[Boudreaux Principles](https://rustchain.org/principles.html) · [Green Tracker](https://rustchain.org/preserved.html) · [Bounties](https://github.com/Scottcjn/rustchain-bounties/issues)
-
-</div>
-
-
 ## Contributing
-Please read the [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and the [Bounty Board](https://github.com/Scottcjn/rustchain-bounties) for active tasks and rewards.
 
-
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and the [Bounty Board](https://github.com/Scottcjn/rustchain-bounties) for active tasks and rewards.
 
 ---
 
-### Troubleshooting
+## Troubleshooting
 
 <details>
 <summary><b>Miner not connecting to node</b></summary>
 
-Run the miner with --dry-run first to verify connectivity without submitting work:
+Preview what the installer would do without installing or mining:
 
 ```bash
-./clawrtc-miner --dry-run
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --dry-run
 ```
 
 Check node health:
@@ -579,15 +568,17 @@ The miner name must exactly match the name used during first attestation.
 <details>
 <summary><b>Miner service won't start (systemd / launchd)</b></summary>
 
-Linux (systemd):
+The installer creates a **user-level** systemd service (no sudo needed):
+
 ```bash
-sudo systemctl status clawrtc-miner
-sudo journalctl -u clawrtc-miner --no-pager -n 50
+systemctl --user status rustchain-miner
+journalctl --user -u rustchain-miner --no-pager -n 50
 ```
 
 macOS (launchd):
 ```bash
-launchctl list | grep clawrtc
+launchctl list | grep rustchain
+tail -f ~/.rustchain/miner.log
 ```
 </details>
 
@@ -614,13 +605,23 @@ curl -fsS https://rustchain.org/epoch
 <details>
 <summary><b>Common installation issues</b></summary>
 
-- **Rust toolchain not found**: Install via curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-- **Build fails on Windows**: Use WSL2 or MSYS2 with proper C toolchain
-- **Permission denied on miner binary**: Run chmod +x ./clawrtc-miner
+- **Python not found**: The miner needs Python 3. On vintage platforms (PowerPC Tiger/Leopard), see [Hardware Requirements](docs/HARDWARE_REQUIREMENTS.md) for the legacy miner path.
+- **Service did not start after install**: Check `systemctl --user status rustchain-miner` (Linux) or `~/.rustchain/miner.log` (macOS).
+- **Building the node from source**: Rust and dev tooling are only needed for node development, not for mining. See the [Build Guide](docs/BUILD.md).
 
 For more details, see the [Beginner Quickstart](docs/QUICKSTART.md).
 </details>
 
 For deeper debugging, see the [CLI Wallet Walkthrough](docs/CLI.md) and [Local Devnet Guide](docs/DEVNET.md).
+
 ---
-*Documentation improved for readability.*
+
+<div align="center">
+
+**[Elyan Labs](https://elyanlabs.ai)** · Built with $0 VC and a room full of pawn shop hardware
+
+*"Mais, it still works, so why you gonna throw it away?"*
+
+[Boudreaux Principles](https://rustchain.org/principles.html) · [Green Tracker](https://rustchain.org/preserved.html) · [Bounties](https://github.com/Scottcjn/rustchain-bounties/issues)
+
+</div>

--- a/README.md
+++ b/README.md
@@ -286,7 +286,9 @@ Payments run over the [Beacon](https://github.com/Scottcjn/beacon-skill) RustCha
 | 6 hardware fingerprint checks per machine | [Fingerprint docs](docs/attestation_fuzzing.md) |
 | 64,000+ RTC paid to 1,000+ recipients ([live counter](https://rustchain.org/payouts.json)) | [Public ledger](https://github.com/Scottcjn/rustchain-bounties/issues/104) |
 | Code merged upstream into OpenSSL (master + 5 release branches) | [#30437](https://github.com/openssl/openssl/pull/30437), [#30452](https://github.com/openssl/openssl/pull/30452) |
-| Open PRs on CPython, curl, wolfSSL, Ghidra | Listed in the upstream project PR trackers |
+| Code landed in curl (powerpc64 fast path, merged by hand per curl workflow) | [curl commit history](https://github.com/curl/curl/commits?author=Scottcjn) |
+| Integer-overflow finding fixed in wolfSSL (via their #9954) | [wolfSSL/wolfssl#9984](https://github.com/wolfSSL/wolfssl/pull/9984) |
+| Open PRs on Ghidra (e200 VLE PowerPC), wolfSSL (POWER8 AES), LLVM, PyTorch, vLLM | Listed in the upstream project PR trackers |
 
 ---
 

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -1,10 +1,10 @@
 # RustChain: A Proof-of-Antiquity Blockchain for Hardware Preservation
 
-**Technical Whitepaper v1.0**
+**Technical Whitepaper v1.1**
 
-*Scott Johnson (Scottcjn) — Elyan Labs*
+*Scott Boudreaux (Scottcjn) — Elyan Labs*
 
-*February 2026*
+*February 2026 (revised July 2026: node count, premine chart, reward-distribution example)*
 
 ---
 
@@ -76,26 +76,28 @@ RustChain operates as a federated network with three node types:
 │   ┌──────────────┐      ┌──────────────┐                   │
 │   │  PRIMARY     │◄────►│  ATTESTATION │                   │
 │   │  NODE        │      │  NODES       │                   │
-│   │  (Explorer)  │      │  (3 active)  │                   │
+│   │  (Explorer)  │      │  (5 active)  │                   │
 │   └──────┬───────┘      └──────────────┘                   │
 │          │                                                  │
 │          ▼                                                  │
 │   ┌──────────────┐      ┌──────────────┐                   │
 │   │  ERGO        │      │  MINER       │                   │
-│   │  ANCHOR      │◄─────│  CLIENTS     │                   │
-│   │  NODE        │      │  (11,626+)   │                   │
+│   │  ANCHOR      │◄─────│  WALLETS     │                   │
+│   │  NODE        │      │  (1,500+)    │                   │
 │   └──────────────┘      └──────────────┘                   │
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
 ```
 
-**Current Live Infrastructure (as of February 2026):**
+**Current Live Infrastructure (as of July 2026):**
 
-| Node | IP Address | Role | Status |
-|------|------------|------|--------|
-| Node 1 | 50.28.86.131 | Primary + Explorer | Active |
-| Node 2 | 50.28.86.153 | Ergo Anchor | Active |
-| Node 3 | 76.8.228.245 | Community Node | Active |
+| Node | Location | Role | Status |
+|------|----------|------|--------|
+| Node 1 — 50.28.86.131 | Louisiana, US | Primary + Explorer | Active |
+| Node 2 — 50.28.86.153 | Louisiana, US | Ergo Anchor + BoTTube | Active |
+| Node 3 — 76.8.228.245 | US | First external community node | Active |
+| Node 4 — 38.76.217.189 | Hong Kong | First Asian node | Active |
+| Node 5 — POWER8 S824 | Local lab | First non-x86 node (IBM ppc64le) | Active |
 
 ### 2.2 Node Roles
 
@@ -439,6 +441,7 @@ Hardware rewards are based on **rarity + preservation value**, not just age:
 
 | Tier | Multiplier | Hardware Examples |
 |------|------------|-------------------|
+| **Mythic** | 3.5-4.0× | Acorn ARM2, DEC VAX, Inmos Transputer |
 | **Legendary** | 3.0× | Intel 386, Motorola 68000, MIPS R2000 |
 | **Epic** | 2.5× | **PowerPC G4**, Intel 486, Pentium |
 | **Rare** | 1.5-2.0× | PowerPC G5, POWER8, DEC Alpha, SPARC |
@@ -521,21 +524,22 @@ def get_time_aged_multiplier(device_arch: str, chain_age_years: float) -> float:
 
 ### 5.4 Example Reward Distribution
 
-With 5 miners in an epoch (1.5 RTC reward pool):
+With 5 miners in an epoch (1.5 RTC reward pool, distributed in full):
 
 ```
 Miner          Arch        Multiplier   Weight%   Reward
 ─────────────────────────────────────────────────────────
-G4 Mac         PowerPC G4  2.5×         33.3%     0.30 RTC
-G5 Mac         PowerPC G5  2.0×         26.7%     0.24 RTC
-Modern PC #1   Skylake     1.0×         13.3%     0.12 RTC
-Modern PC #2   Zen 3       1.0×         13.3%     0.12 RTC
-Modern PC #3   Alder Lake  1.0×         13.3%     0.12 RTC
+G4 Mac         PowerPC G4  2.5×         33.3%     0.50 RTC
+G5 Mac         PowerPC G5  2.0×         26.7%     0.40 RTC
+Modern PC #1   Skylake     1.0×         13.3%     0.20 RTC
+Modern PC #2   Zen 3       1.0×         13.3%     0.20 RTC
+Modern PC #3   Alder Lake  1.0×         13.3%     0.20 RTC
 ─────────────────────────────────────────────────────────
-TOTAL                      7.5×         100%      0.90 RTC
+TOTAL                      7.5×         100%      1.50 RTC
 ```
 
-*(0.60 RTC returned to pool for future epochs)*
+The full epoch pool is always distributed proportionally by weight; nothing
+is held back. More miners in an epoch means a smaller share per miner.
 
 ---
 
@@ -561,11 +565,12 @@ TOTAL                      7.5×         100%      0.90 RTC
 ├─────────────────────────────────────────────────────────────┤
 │                                                             │
 │   ████████████████████████████████████████  94% Mining      │
-│   ██░                                       2.5% Dev Wallet │
-│   █░                                        0.5% Foundation │
-│   ███                                       3% Community    │
+│   █░                                        1.5% Founders   │
+│   █░                                        1.5% Dev Fund   │
+│   █░                                        1.5% Team/Bounty│
+│   █░                                        1.5% Community  │
 │                                                             │
-│   Total Premine: 6% (503,316 RTC)                          │
+│   Total Premine: 6% (503,316 RTC = 4 equal founder wallets)│
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -866,7 +871,7 @@ GET /health
 Response: {"ok": true, "version": "2.2.1-rip200", "uptime_s": 100809}
 
 GET /api/stats
-Response: {"total_miners": 11626, "epoch": 62, "chain_id": "rustchain-mainnet-v2"}
+Response: {"total_miners": 1535, "epoch": 62, "chain_id": "rustchain-mainnet-v2"}
 
 GET /epoch
 Response: {"epoch": 62, "slot": 8928, "next_settlement": 1707000000}
@@ -888,6 +893,6 @@ Response: {"epoch": 62, "slot": 8928, "next_settlement": 1707000000}
 
 ---
 
-*Copyright © 2025-2026 Scott Johnson / Elyan Labs. Released under Apache License 2.0.*
+*Copyright © 2025-2026 Scott Boudreaux / Elyan Labs. Released under Apache License 2.0.*
 
 *RustChain — Making vintage hardware valuable again.*

--- a/docs/zh-CN/RustChain_Whitepaper_zh-CN_v1.0.md
+++ b/docs/zh-CN/RustChain_Whitepaper_zh-CN_v1.0.md
@@ -2,7 +2,7 @@
 
 **技术白皮书 v1.0**
 
-*Scott Johnson (Scottcjn) — Elyan Labs*
+*Scott Boudreaux (Scottcjn) — Elyan Labs*
 
 *2026 年 2 月*
 
@@ -82,7 +82,7 @@ RustChain 作为联合网络运行，包含三种节点类型：
 │   ┌──────────────┐      ┌──────────────┐                   │
 │   │  ERGO        │      │  挖矿        │                   │
 │   │  锚定        │◄─────│  客户端      │                   │
-│   │  节点        │      │  (11,626+)   │                   │
+│   │  节点        │      │  (1,500+)    │                   │
 │   └──────────────┘      └──────────────┘                   │
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
@@ -866,7 +866,7 @@ GET /health
 响应：{"ok": true, "version": "2.2.1-rip200", "uptime_s": 100809}
 
 GET /api/stats
-响应：{"total_miners": 11626, "epoch": 62, "chain_id": "rustchain-mainnet-v2"}
+响应：{"total_miners": 1535, "epoch": 62, "chain_id": "rustchain-mainnet-v2"}
 
 GET /epoch
 响应：{"epoch": 62, "slot": 8928, "next_settlement": 1707000000}
@@ -888,6 +888,6 @@ GET /epoch
 
 ---
 
-*版权所有 © 2025-2026 Scott Johnson / Elyan Labs。根据 Apache License 2.0 许可证发布。*
+*版权所有 © 2025-2026 Scott Boudreaux / Elyan Labs。根据 Apache License 2.0 许可证发布。*
 
 *RustChain — 让复古硬件再次变得有价值。*

--- a/node/tokenomics_route.py
+++ b/node/tokenomics_route.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""RustChain /api/tokenomics endpoint.
+
+Read-only. Serves the published RTC reference rate, live holder count,
+and the holder-milestone schedule codified at rustchain-bounties#12458.
+
+The current rate is read from tokenomics_config.json next to this file so
+milestone flips are an ops action (edit config + announce), not a deploy.
+Registered from wsgi.py via register_tokenomics(app, DB_PATH).
+"""
+
+import json
+import os
+import sqlite3
+import time
+from contextlib import closing
+
+_BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+_CONFIG_PATH = os.path.join(_BASE_DIR, "tokenomics_config.json")
+
+TOTAL_SUPPLY_RTC = 8_388_608  # 2^23, consensus-enforced
+UNIT = 1_000_000  # uRTC per RTC
+
+# Holder milestones per rustchain-bounties#12458 (one-way ratchet,
+# announced 24-48h ahead, never retroactive)
+MILESTONES = [
+    {"holders": 761, "reference_rate_usd": 0.10, "label": "genesis"},
+    {"holders": 1000, "reference_rate_usd": 0.15, "label": "1k holders"},
+    {"holders": 2000, "reference_rate_usd": 0.20, "label": "2k holders"},
+]
+
+_cache = {"ts": 0.0, "holders": 0, "wallets": 0, "circulating_rtc": 0.0}
+_CACHE_TTL_S = 60
+
+
+def _read_rate() -> float:
+    try:
+        with open(_CONFIG_PATH) as f:
+            return float(json.load(f)["reference_rate_usd"])
+    except (OSError, ValueError, KeyError):
+        return 0.15  # last published rate as fallback
+
+
+def _ledger_stats(db_path: str) -> dict:
+    now = time.time()
+    if now - _cache["ts"] < _CACHE_TTL_S:
+        return _cache
+    with closing(sqlite3.connect(db_path, timeout=5)) as conn:
+        row = conn.execute(
+            "SELECT COUNT(*), COUNT(CASE WHEN amount_i64 > 0 THEN 1 END), "
+            "COALESCE(SUM(amount_i64), 0) FROM balances"
+        ).fetchone()
+    _cache.update(
+        ts=now,
+        wallets=row[0],
+        holders=row[1],
+        circulating_rtc=round(row[2] / UNIT, 6),
+    )
+    return _cache
+
+
+def register_tokenomics(app, db_path: str):
+    from flask import jsonify
+
+    @app.route("/api/tokenomics", methods=["GET"])
+    @app.route("/tokenomics", methods=["GET"])
+    def api_tokenomics():
+        try:
+            stats = _ledger_stats(db_path)
+        except sqlite3.Error:
+            return jsonify({"ok": False, "error": "ledger unavailable"}), 503
+
+        rate = _read_rate()
+        holders = stats["holders"]
+        upcoming = [m for m in MILESTONES if m["reference_rate_usd"] > rate]
+        next_milestone = None
+        if upcoming:
+            nxt = min(upcoming, key=lambda m: m["holders"])
+            next_milestone = dict(nxt, holders_remaining=max(0, nxt["holders"] - holders))
+
+        return jsonify({
+            "ok": True,
+            "token": "RTC",
+            "total_supply_rtc": TOTAL_SUPPLY_RTC,
+            "reference_rate_usd": rate,
+            "rate_basis": ("internal reference rate for bounty accounting, "
+                           "not a market price or promise of convertibility"),
+            "holders": holders,
+            "wallets": stats["wallets"],
+            "circulating_rtc": stats["circulating_rtc"],
+            "milestones": MILESTONES,
+            "next_milestone": next_milestone,
+            "policy": ("one-way ratchet, announced 24-48h ahead, not retroactive "
+                       "(github.com/Scottcjn/rustchain-bounties/issues/12458)"),
+            "as_of": int(time.time()),
+        })

--- a/node/wsgi.py
+++ b/node/wsgi.py
@@ -55,6 +55,15 @@ except ImportError as e:
 except Exception as e:
     print(f"[RIP-306] SophiaCore init failed: {e}")
 
+# /api/tokenomics — read-only reference-rate endpoint (2026-07-09).
+# Registered here (not in the versioned main module) so it survives
+# main-file version swaps. Fail-safe: never blocks node startup.
+try:
+    from tokenomics_route import register_tokenomics
+    register_tokenomics(app, DB_PATH)
+except Exception as _tok_err:
+    print(f"[tokenomics] route registration failed: {_tok_err}")
+
 # Expose the app for gunicorn
 application = app
 


### PR DESCRIPTION
Two things that belong together: the docs said things the code and network do not do, and the README pointed at an endpoint that did not exist.

## Docs fixes (verified against node code and the live ledger before editing)

- README reward example said an epoch is 10 minutes. That is the block time. An epoch is 144 blocks (~24h) per slot_to_epoch in the rewards code.
- Whitepaper supply chart still showed the old 3/2.5/0.5 premine split. The chain seeds 4 equal 1.5% founder wallets. Chart now matches the table below it.
- Whitepaper 5-miner reward example only distributed 0.90 of the 1.5 RTC pool with a holdback that does not exist. The code distributes the full pool proportionally. Recomputed.
- Node table updated 3 to 5 active nodes (Hong Kong, POWER8).
- The 11,626 miner figure was about 7.5x reality. Ledger has 1,535 wallets, 1,498 with balance. Fixed in the diagram and API example, English and Chinese versions.
- README troubleshooting referenced a clawrtc-miner binary that does not exist in the repo. The installer creates a user-level rustchain-miner systemd service. Commands corrected.
- Author name corrected to Scott Boudreaux.
- Added Mythic tier to the whitepaper multiplier table to match the README and RIP-200.

## /api/tokenomics

New read-only endpoint serving the reference rate, live holder count, circulating supply, and the milestone schedule from rustchain-bounties#12458. Rate lives in tokenomics_config.json so milestone flips are a config edit plus announcement, not a deploy. Registered from wsgi.py, fail-safe wrapped. Already deployed and verified live on Node 1: https://rustchain.org/api/tokenomics