### PR TITLE
Fix #7892: preserve sub-1.0 penalty multipliers in get_time_aged_multiplier

### DIFF
--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -502,8 +502,12 @@ def get_time_aged_multiplier(device_arch: str, chain_age_years: float) -> float:
     """
     base_multiplier = ANTIQUITY_MULTIPLIERS.get(device_arch.lower(), 1.0)
     
-    # Modern hardware doesn't decay
-    if base_multiplier <= 1.0:
+    # Penalty multipliers (sub-1.0) are anti-farm penalties — return as-is
+    if base_multiplier < 1.0:
+        return base_multiplier
+
+    # Baseline hardware (exactly 1.0) has no vintage bonus to decay
+    if base_multiplier == 1.0:
         return 1.0
     
     # Calculate decayed bonus

--- a/node/rip_200_round_robin_1cpu1vote.py
+++ b/node/rip_200_round_robin_1cpu1vote.py
@@ -483,8 +483,13 @@ def get_time_aged_multiplier(device_arch: str, chain_age_years: float) -> float:
     """
     base_multiplier = ANTIQUITY_MULTIPLIERS.get(device_arch.lower(), 1.0)
 
-    # Modern hardware doesn't decay (stays 1.0)
-    if base_multiplier <= 1.0:
+    # Penalty multipliers (sub-1.0) are returned as-is — they represent
+    # anti-farm penalties (e.g. ARM SBC = 0.0005x) and must not be inflated.
+    if base_multiplier < 1.0:
+        return base_multiplier
+
+    # Baseline hardware (exactly 1.0) has no vintage bonus to decay.
+    if base_multiplier == 1.0:
         return 1.0
 
     # Calculate decayed bonus

--- a/node/tests/test_time_aged_multiplier_penalty.py
+++ b/node/tests/test_time_aged_multiplier_penalty.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+"""Tests for get_time_aged_multiplier penalty preservation (#7892).
+
+Sub-1.0 multipliers (anti-farm penalties like ARM SBC = 0.0005x) must
+be returned as-is, not inflated to 1.0.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from rip_200_round_robin_1cpu1vote import get_time_aged_multiplier
+
+
+def test_arm_sbc_penalty_preserved():
+    """ARM SBC (0.0005x) must NOT be inflated to 1.0."""
+    result = get_time_aged_multiplier("aarch64", 0)
+    assert result == 0.0005, f"Expected 0.0005, got {result}"
+
+
+def test_modern_amd_penalty_preserved():
+    """modern_amd (0.8x) must NOT be inflated to 1.0."""
+    result = get_time_aged_multiplier("modern_amd", 0)
+    assert result == 0.8, f"Expected 0.8, got {result}"
+
+
+def test_apple_silicon_penalty_preserved():
+    """apple_silicon (0.8x) must NOT be inflated to 1.0."""
+    result = get_time_aged_multiplier("apple_silicon", 0)
+    assert result == 0.8, f"Expected 0.8, got {result}"
+
+
+def test_baseline_returns_1():
+    """Unknown arch defaults to 1.0 and should return 1.0."""
+    result = get_time_aged_multiplier("unknown_arch_xyz", 5)
+    assert result == 1.0
+
+
+def test_vintage_multiplier_still_decays():
+    """Vintage hardware (>1.0) should still get decay applied."""
+    # PowerPC G4 = 2.5x at year 0
+    result = get_time_aged_multiplier("g4", 0)
+    assert result == 2.5  # full multiplier at year 0
+
+    # At year 10, decay should bring it close to 1.0
+    result_year10 = get_time_aged_multiplier("g4", 10)
+    assert result_year10 < 2.5
+    assert result_year10 >= 1.0  # never drops below baseline
+
+
+def test_penalty_does_not_change_with_chain_age():
+    """Penalty multipliers should not change regardless of chain age."""
+    year0 = get_time_aged_multiplier("armv7", 0)
+    year5 = get_time_aged_multiplier("armv7", 5)
+    year10 = get_time_aged_multiplier("armv7", 10)
+    assert year0 == year5 == year10 == 0.0005


### PR DESCRIPTION
## Problem

`get_time_aged_multiplier()` in `node/rip_200_round_robin_1cpu1vote.py` has a guard:

```python
if base_multiplier <= 1.0:
    return 1.0
```

This treats penalty multipliers the same as baseline, so any architecture with a base multiplier below 1.0 gets floored up to 1.0x instead of applying its anti-farm penalty:

| Architecture | Base Multiplier | Buggy Output |
|---|---|---|
| ARM SBC (aarch64, armv7) | 0.0005x | 1.0x (2000x inflation) |
| modern_amd | 0.8x | 1.0x (25% inflation) |
| apple_silicon | 0.8x | 1.0x (25% inflation) |

The ARM SBC anti-farm penalty, the main defense against cheap SBC farming, is completely nullified by this bug.

## Fix

Split the guard into two branches so penalty multipliers are preserved:

```python
# Penalty multipliers (sub-1.0) are returned as-is — they represent
# anti-farm penalties (e.g. ARM SBC = 0.0005x) and must not be inflated.
if base_multiplier < 1.0:
    return base_multiplier

# Baseline hardware (exactly 1.0) has no vintage bonus to decay.
if base_multiplier == 1.0:
    return 1.0
```

Vintage decay logic (multipliers above 1.0) is unchanged.

## Relationship to #7909

This supersedes the multiplier-fix portion of #7909. That PR contained the same correct logic change but bundled it with 19 unrelated `.github/workflows/*.yml` deletions, which is why it could not pass CI gates and should not merge as-is. This PR extracts only the genuine fix:

- `node/rip_200_round_robin_1cpu1vote.py` — the guard fix
- `docs/WHITEPAPER.md` §5.3 — matching pseudocode
- `node/tests/test_time_aged_multiplier_penalty.py` — 6 tests covering penalty preservation, baseline, and vintage decay

No workflow files are touched. `.github/workflows/` is untouched, verified by `git diff --stat` against main (19 workflow files present before and after).

## Verification

```
node/tests/test_time_aged_multiplier_penalty.py::test_arm_sbc_penalty_preserved PASSED
node/tests/test_time_aged_multiplier_penalty.py::test_modern_amd_penalty_preserved PASSED
node/tests/test_time_aged_multiplier_penalty.py::test_apple_silicon_penalty_preserved PASSED
node/tests/test_time_aged_multiplier_penalty.py::test_baseline_returns_1 PASSED
node/tests/test_time_aged_multiplier_penalty.py::test_vintage_multiplier_still_decays PASSED
node/tests/test_time_aged_multiplier_penalty.py::test_penalty_does_not_change_with_chain_age PASSED
```

Also ran the existing `node/tests/test_rewards_settle_race.py` and `node/tests/test_claims_eligibility_helpers.py` (14 tests) alongside these — all pass, no regressions. 20/20 total.

Not merging — for review.