### PR TITLE
fix(beacon): guard /api/bounties/<id>/claim against reverting completed/stealing claims

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -1121,13 +1121,30 @@ def claim_bounty(bounty_id):
             return field_error, status
 
         db = get_db()
+
+        # Verify bounty exists and is in a claimable state. Without these guards
+        # the blind UPDATE below would silently revert an already-completed bounty
+        # back to 'claimed' and let one agent overwrite another agent's claim.
+        bounty = db.execute(
+            "SELECT state, claimant_agent FROM beacon_bounties WHERE id = ?",
+            (bounty_id,)
+        ).fetchone()
+        if not bounty:
+            return jsonify({'error': 'Bounty not found'}), 404
+        if bounty['state'] == 'completed':
+            return jsonify({'error': 'Bounty already completed'}), 409
+        existing_claimant = bounty['claimant_agent']
+        if existing_claimant and existing_claimant != agent_id:
+            return jsonify({'error': 'Bounty already claimed by another agent'}), 409
+
         now = int(time.time())
         cursor = db.execute(
-            "UPDATE beacon_bounties SET state = 'claimed', claimant_agent = ?, updated_at = ? WHERE id = ?",
-            (agent_id, now, bounty_id)
+            "UPDATE beacon_bounties SET state = 'claimed', claimant_agent = ?, updated_at = ? "
+            "WHERE id = ? AND state != 'completed' AND (claimant_agent IS NULL OR claimant_agent = ?)",
+            (agent_id, now, bounty_id, agent_id)
         )
         if cursor.rowcount == 0:
-            return jsonify({'error': 'Bounty not found'}), 404
+            return jsonify({'error': 'Bounty state changed; retry claim'}), 409
         db.commit()
 
         return jsonify({'ok': True, 'bounty_id': bounty_id, 'claimant': agent_id})

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -384,6 +384,67 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         self.assertEqual(row['state'], 'claimed')
         self.assertEqual(row['claimant_agent'], 'bcn_claimer')
 
+    def test_claim_does_not_revert_completed_bounty(self):
+        """A completed bounty must not be reset back to 'claimed' by a later claim."""
+        created_at = int(time.time())
+        with sqlite3.connect(self.test_db_path) as conn:
+            conn.execute("""
+                INSERT INTO beacon_bounties
+                (id, title, reward_rtc, difficulty, state, claimant_agent, completed_by, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """, (
+                'gh_done_bounty', 'Done bounty (10 RTC)', 10.0, 'EASY',
+                'completed', 'bcn_worker', 'bcn_worker', created_at,
+            ))
+            conn.commit()
+
+        resp = self.client.post(
+            '/api/bounties/gh_done_bounty/claim',
+            data=json.dumps({'agent_id': 'bcn_other'}),
+            content_type='application/json',
+            headers={'X-Admin-Key': os.environ['RC_ADMIN_KEY']},
+        )
+        self.assertEqual(resp.status_code, 409)
+
+        with sqlite3.connect(self.test_db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT state, claimant_agent FROM beacon_bounties WHERE id = ?",
+                ('gh_done_bounty',),
+            ).fetchone()
+        self.assertEqual(row['state'], 'completed')
+        self.assertEqual(row['claimant_agent'], 'bcn_worker')
+
+    def test_claim_does_not_overwrite_other_agents_claim(self):
+        """A bounty claimed by one agent must not be silently stolen by another."""
+        created_at = int(time.time())
+        with sqlite3.connect(self.test_db_path) as conn:
+            conn.execute("""
+                INSERT INTO beacon_bounties
+                (id, title, reward_rtc, difficulty, state, claimant_agent, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            """, (
+                'gh_taken_bounty', 'Taken bounty (10 RTC)', 10.0, 'EASY',
+                'claimed', 'bcn_first', created_at,
+            ))
+            conn.commit()
+
+        resp = self.client.post(
+            '/api/bounties/gh_taken_bounty/claim',
+            data=json.dumps({'agent_id': 'bcn_second'}),
+            content_type='application/json',
+            headers={'X-Admin-Key': os.environ['RC_ADMIN_KEY']},
+        )
+        self.assertEqual(resp.status_code, 409)
+
+        with sqlite3.connect(self.test_db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT claimant_agent FROM beacon_bounties WHERE id = ?",
+                ('gh_taken_bounty',),
+            ).fetchone()
+        self.assertEqual(row['claimant_agent'], 'bcn_first')
+
     def test_bounty_complete_rejects_non_string_agent_id(self):
         """Admin bounty completion route rejects non-string agent IDs."""
         response = self.client.post(


### PR DESCRIPTION
## Problem

`claim_bounty` (`node/beacon_api.py`) ran a blind write with no state validation:

```python
db.execute("UPDATE beacon_bounties SET state = 'claimed', claimant_agent = ?, updated_at = ? WHERE id = ?", ...)
```

Its sibling `complete_bounty` right below carefully checks state before writing, but `claim` did not. Two concrete consequences:

1. **Completed bounties can be reverted.** Re-claiming an already-`completed` bounty resets it back to `claimed`, wiping `completed`/`completed_by` — the finished work silently disappears from the ledger.
2. **Claims can be stolen.** A claim by agent A is overwritten by any later claim naming agent B; `claimant_agent` is reassigned with no error.

## Fix

Mirror the guards `complete_bounty` already uses:

- `404` when the bounty does not exist
- `409` when it is already `completed`
- `409` when it is already `claimed` by a **different** agent (re-claim by the same agent stays idempotent → `200`)
- the `UPDATE` now carries `AND state != 'completed' AND (claimant_agent IS NULL OR claimant_agent = ?)` so a concurrent state change can't slip through

The happy path (open → claim → `200`, claimant persisted) is unchanged and still covered by the existing lifecycle tests.

## Tests

Added two regression tests in `tests/test_beacon_atlas_behavior.py`:
- `test_claim_does_not_revert_completed_bounty`
- `test_claim_does_not_overwrite_other_agents_claim`

Full file passes:

```
$ python3 -m pytest tests/test_beacon_atlas_behavior.py -q
31 passed
```

/claim