### PR TITLE
fix(claims): correct 100x RTC unit error in settlement reporting

### DIFF
--- a/node/claims_settlement.py
+++ b/node/claims_settlement.py
@@ -34,6 +34,11 @@ except ImportError:
         return None
 
 
+# uRTC per 1 RTC — canonical denomination used across the claims modules
+# (matches claims_eligibility.URTC_PER_RTC and rewards_implementation_rip200.UNIT).
+URTC_PER_RTC = 1_000_000
+
+
 class SettlementError(Exception):
     """Base exception for settlement errors"""
     pass
@@ -735,7 +740,7 @@ def process_claims_batch(
         result["processed"] = True
         result["claims_count"] = len(claims_to_process)
         result["total_amount_urtc"] = total_amount
-        result["total_amount_rtc"] = total_amount / 100_000_000
+        result["total_amount_rtc"] = total_amount / URTC_PER_RTC
         result["error"] = "Dry run - no actual processing"
         return result
     
@@ -833,13 +838,13 @@ def process_claims_batch(
     result["processed"] = True
     result["claims_count"] = len(claims_to_process)
     result["total_amount_urtc"] = total_amount
-    result["total_amount_rtc"] = total_amount / 100_000_000
+    result["total_amount_rtc"] = total_amount / URTC_PER_RTC
     result["transaction_hash"] = tx_hash
     result["success_count"] = settled_count
     
     print(f"[SETTLEMENT] Batch {batch_id} processed:")
     print(f"  Claims: {settled_count}")
-    print(f"  Total: {total_amount / 100_000_000:.6f} RTC")
+    print(f"  Total: {total_amount / URTC_PER_RTC:.6f} RTC")
     print(f"  TX Hash: {tx_hash}")
     
     return result
@@ -904,7 +909,7 @@ def get_settlement_stats(
                 "period_days": days,
                 "settled_claims": settled_count,
                 "settled_amount_urtc": settled_amount,
-                "settled_amount_rtc": settled_amount / 100_000_000,
+                "settled_amount_rtc": settled_amount / URTC_PER_RTC,
                 "failed_claims": failed_count,
                 "success_rate": settled_count / max(1, settled_count + failed_count),
                 "avg_settlement_time_seconds": avg_time,

--- a/node/tests/test_claims_settlement.py
+++ b/node/tests/test_claims_settlement.py
@@ -46,6 +46,7 @@ from claims_settlement import (
     process_claims_batch,
     get_settlement_stats,
     settlement_batch_conditions_met,
+    URTC_PER_RTC,
 )
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -714,6 +715,9 @@ class TestGetSettlementStats:
         stats = get_settlement_stats(db, days=7)
         assert stats["settled_claims"] == 5
         assert stats["settled_amount_urtc"] == 15000  # 1000+2000+3000+4000+5000
+        # 15000 uRTC == 0.015 RTC (URTC_PER_RTC = 1_000_000), not 0.00015.
+        assert stats["settled_amount_rtc"] == 15000 / 1_000_000
+        assert stats["settled_amount_rtc"] == stats["settled_amount_urtc"] / URTC_PER_RTC
 
     def test_mixed_status_counts(self, tmp_path):
         db = str(tmp_path / "test.db")
@@ -921,7 +925,11 @@ class TestProcessClaimsBatch:
         assert result["success_count"] == 1
         assert result["transaction_hash"] == "0xsuccess"
         assert result["total_amount_urtc"] == 1500
-        assert result["total_amount_rtc"] == 1500 / 100_000_000
+        # reward_urtc is micro-RTC: 1 RTC = 1_000_000 uRTC (canonical
+        # URTC_PER_RTC, same factor as claims_eligibility / claims_submission
+        # apply to this identical field). 1500 uRTC == 0.0015 RTC.
+        assert result["total_amount_rtc"] == 1500 / 1_000_000
+        assert result["total_amount_rtc"] == result["total_amount_urtc"] / URTC_PER_RTC
         assert result["error"] is None
 
     def test_stale_verifying_claims_flagged(self, tmp_path, capsys):


### PR DESCRIPTION
## Summary
`node/claims_settlement.py` reports every RTC-denominated settlement figure **100× too small**.

`reward_urtc` is micro-RTC — **1 RTC = 1_000_000 uRTC**. This is the canonical factor everywhere else that converts this exact field:
- `claims_eligibility.py:70` → `URTC_PER_RTC = 1_000_000`
- `rewards_implementation_rip200.py:91` → `UNIT = 1_000_000  # uRTC per 1 RTC`
- `claims_submission.py:452,582,663` → `reward_urtc / 1_000_000`

`claims_settlement.py` was the lone outlier, dividing by `100_000_000` (1e8) in `total_amount_rtc`, `settled_amount_rtc`, and the print logs.

## Impact
A batch of `15000` uRTC (= `0.015` RTC) was reported as `total_amount_rtc = 0.00015`, and `get_settlement_stats` understated `settled_amount_rtc` the same way — corrupting API/telemetry output and operator-facing logs.

The on-chain amounts (`total_amount_urtc`, per-output `amount_urtc`) and the rewards-pool debit are integer uRTC and were **not** affected, so no funds moved incorrectly — this is a reporting/telemetry correctness fix.

## Fix
- add module constant `URTC_PER_RTC = 1_000_000`
- use it at all four conversion sites
- the existing test `test_successful_batch_updates_result` had been written to the buggy `1e8` divisor; corrected it and added cross-field consistency assertions for both `total_amount_rtc` and `settled_amount_rtc`

## Tests
`python3 -m pytest tests/test_claims_settlement.py` → **82 passed**.

/claim