### PR TITLE
docs(README): fix dead rustchain.org/bcos/ links -> in-repo BCOS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ This isn't a roadmap. This is deployed and running:
 | **Execution** | [TrashClaw](https://github.com/Scottcjn/trashclaw) — zero-dep local LLM agent that runs on anything | Live |
 | **Social** | BoTTube — AI-native platform where agents create, trade, and engage | Live, 1,000+ videos |
 | **Bounties** | Agent-assisted contributions — AI helps humans earn RTC for real code | Live, 64,000+ RTC paid ([live](https://rustchain.org/payouts.json)) |
-| **Certification** | [BCOS](https://rustchain.org/bcos/) — blockchain-certified open source verification | Live, 44 certs issued |
+| **Certification** | [BCOS](BCOS.md) — blockchain-certified open source verification | Live, 44 certs issued |
 | **Provenance** | [Proof of Provenance (RIP-0310)](rips/docs/RIP-0310-proof-of-provenance.md) — binds agent identity + verified hardware to published content | Spec published ([DOI](https://doi.org/10.5281/zenodo.20502069)) |
 | **Frameworks** | Drop-in tools so any agent can query the network — [LangChain](https://github.com/Scottcjn/langchain-rustchain) (`pip install langchain-rustchain-tools`), plus CrewAI / AutoGen / Agno / smolagents in [`integrations/`](integrations/) | Live |
 
@@ -282,7 +282,7 @@ Payments run over the [Beacon](https://github.com/Scottcjn/beacon-skill) RustCha
 |------|-------|
 | 5 nodes across 3 continents (NA ×3, Asia ×1, Local ×1) | [Live explorer](https://rustchain.org/explorer/) |
 | 20+ miners attesting | `curl -fsS https://rustchain.org/api/miners` |
-| 44 BCOS certificates issued | [Certified repos](https://rustchain.org/bcos/) |
+| 44 BCOS certificates issued | [Certified repos](BCOS.md) |
 | 6 hardware fingerprint checks per machine | [Fingerprint docs](docs/attestation_fuzzing.md) |
 | 64,000+ RTC paid to 1,000+ recipients ([live counter](https://rustchain.org/payouts.json)) | [Public ledger](https://github.com/Scottcjn/rustchain-bounties/issues/104) |
 | Code merged upstream into OpenSSL (master + 5 release branches) | [#30437](https://github.com/openssl/openssl/pull/30437), [#30452](https://github.com/openssl/openssl/pull/30452) |


### PR DESCRIPTION
## What

Two README links to the BCOS certification page pointed at `https://rustchain.org/bcos/`, which currently returns **HTTP 404**:

```
$ curl -sI https://rustchain.org/bcos/   # 404
$ curl -sI https://rustchain.org/bcos    # 301 -> /bcos/ -> 404
```

Both the `/bcos` and `/bcos/` paths are down, so there is no working URL variant. Every other rustchain.org link in the README resolves fine (`/explorer/`, `/payouts.json`, `/api/miners`, `/api/tokenomics`, `/manifesto.html`, ... all 200).

## Fix

Repoint the two navigational BCOS links to the canonical in-repo doc **`BCOS.md`** (same relative-link style already used in the README for `rips/docs/RIP-0310-proof-of-provenance.md`, `docs/attestation_fuzzing.md`, etc.):

- Overview table: `[BCOS](https://rustchain.org/bcos/)` -> `[BCOS](BCOS.md)`
- Traction table: `[Certified repos](https://rustchain.org/bcos/)` -> `[Certified repos](BCOS.md)`

Single-file, docs-only diff. No behavior change.

## Scope note

Issues #7908 / #7886 / #7885 also flag `/api/tokenomics` as 404, but that endpoint now resolves **200**, so it is intentionally left unchanged — only the genuinely-dead `/bcos/` link is touched.

/claim