### PR TITLE
fix(otc-bridge): scope high_24h/low_24h to the trailing 24h window

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -2048,11 +2048,24 @@ def market_stats():
             "SELECT COUNT(*), COALESCE(SUM(amount_micro_rtc), 0) FROM orders WHERE status = 'open' AND side = 'buy'"
         ).fetchone()
 
-        # Price stats from recent trades
-        prices = c.execute(
-            "SELECT price_per_rtc_nano_quote FROM trades ORDER BY completed_at DESC LIMIT 100"
-        ).fetchall()
-        price_list = [units_to_float(p[0], QUOTE_PRICE_SCALE) for p in prices]
+        # Last traded price = most recent trade overall.
+        last_row = c.execute(
+            "SELECT price_per_rtc_nano_quote FROM trades ORDER BY completed_at DESC LIMIT 1"
+        ).fetchone()
+        last_price = (
+            units_to_float(last_row[0], QUOTE_PRICE_SCALE) if last_row else RTC_REFERENCE_RATE
+        )
+
+        # 24h high/low must be scoped to the trailing 24h window (like volume_24h),
+        # not "the last 100 trades ever", otherwise a stale price outside the window
+        # is reported as a 24h extreme.
+        day_hilo = c.execute(
+            "SELECT MIN(price_per_rtc_nano_quote), MAX(price_per_rtc_nano_quote) "
+            "FROM trades WHERE completed_at >= ?",
+            (day_ago,)
+        ).fetchone()
+        low_24h = units_to_float(day_hilo[0], QUOTE_PRICE_SCALE) if day_hilo[0] is not None else None
+        high_24h = units_to_float(day_hilo[1], QUOTE_PRICE_SCALE) if day_hilo[1] is not None else None
 
         return jsonify({
             "ok": True,
@@ -2070,9 +2083,9 @@ def market_stats():
                     "count": open_buy[0],
                     "total_rtc": round(units_to_float(open_buy[1], RTC_UNIT), 2),
                 },
-                "last_price": price_list[0] if price_list else RTC_REFERENCE_RATE,
-                "high_24h": max(price_list) if price_list else None,
-                "low_24h": min(price_list) if price_list else None,
+                "last_price": last_price,
+                "high_24h": high_24h,
+                "low_24h": low_24h,
                 "reference_rate_usd": RTC_REFERENCE_RATE,
                 "supported_pairs": list(SUPPORTED_PAIRS.keys())
             }

--- a/otc-bridge/test_otc_bridge.py
+++ b/otc-bridge/test_otc_bridge.py
@@ -616,6 +616,39 @@ class OTCBridgeTestCase(unittest.TestCase):
         self.assertIn("total_trades", data["stats"])
         self.assertIn("supported_pairs", data["stats"])
 
+    def test_stats_high_low_are_24h_scoped(self):
+        """high_24h/low_24h must only reflect trades inside the trailing 24h."""
+        now = int(time.time())
+        rows = [
+            # (trade_id, completed_at, price_per_rtc)  -- price in quote units
+            ("old", now - 5 * 86400, 5.0),   # 5 days ago, outside 24h
+            ("new", now - 3600, 0.1),        # 1 hour ago, inside 24h
+        ]
+        with sqlite3.connect(TEST_DB) as conn:
+            c = conn.cursor()
+            for tid, ts, price in rows:
+                _, price_nano = otc_bridge.decimal_units(
+                    price, otc_bridge.QUOTE_PRICE_SCALE, "price"
+                )
+                _, amt_micro = otc_bridge.decimal_units(
+                    2, otc_bridge.RTC_UNIT, "amount"
+                )
+                c.execute(
+                    "INSERT INTO trades (trade_id, order_id, pair, side, maker_wallet, "
+                    "taker_wallet, amount_micro_rtc, price_per_rtc_nano_quote, "
+                    "total_quote_nano, completed_at) VALUES (?,?,?,?,?,?,?,?,?,?)",
+                    (tid, "o_" + tid, "RTC/USDC", "sell", "m", "t",
+                     amt_micro, price_nano, price_nano * 2, ts),
+                )
+            conn.commit()
+
+        stats = self.app.get("/api/stats").get_json()["stats"]
+        # Only the 1h-old trade (0.1) is inside the 24h window.
+        self.assertEqual(stats["high_24h"], 0.1)
+        self.assertEqual(stats["low_24h"], 0.1)
+        # last_price still tracks the most recent trade overall.
+        self.assertEqual(stats["last_price"], 0.1)
+
     def test_trades_empty(self):
         r = self.app.get("/api/trades")
         data = r.get_json()


### PR DESCRIPTION
### Problem
`GET /api/stats` reports `high_24h` / `low_24h`, but computes them from the **last 100 trades of all time**:

```python
prices = c.execute(
    "SELECT price_per_rtc_nano_quote FROM trades ORDER BY completed_at DESC LIMIT 100"
).fetchall()
...
"high_24h": max(price_list),
"low_24h":  min(price_list),
```

Meanwhile `volume_24h_rtc` in the same handler is correctly filtered with `WHERE completed_at >= day_ago`. So a price that last traded days ago is still reported as a 24h high/low.

### Repro
Two trades: one 5 days ago @ 5.0, one 1 hour ago @ 0.1. In the last 24h only 0.1 traded, so both `high_24h` and `low_24h` should be `0.1`, but the endpoint returns `high_24h = 5.0` — while `volume_24h_rtc` in the same response correctly ignores the old trade.

### Fix
Compute `high_24h`/`low_24h` with a `MIN`/`MAX` over `WHERE completed_at >= day_ago` (also drops the incidental 100-row cap on the extremes). `last_price` still tracks the most recent trade overall.

### Test
Adds `test_stats_high_low_are_24h_scoped` asserting the actual values (the existing stats test only checked key presence). It fails on `main`, passes with the fix. (Note: the suite has pre-existing failures on `main` unrelated to this change — order-matching/escrow paths; the stats tests pass.)

/claim