### PR TITLE
fix(relationships): clear beef_start_time when a beef ends via collaboration

### DIFF
--- a/agent_relationships.py
+++ b/agent_relationships.py
@@ -685,7 +685,13 @@ class RelationshipEngine:
         new_state = self._determine_state_transition(rel, EventType.COLLABORATION)
         if new_state:
             rel.state = new_state
-        
+            # Leaving a beef (e.g. BEEF -> RIVALS) must clear the beef start
+            # time, like every other beef exit does. Otherwise a later,
+            # brand-new beef inherits this stale timestamp and is treated as
+            # already expired the moment it starts.
+            if new_state != RelationshipState.BEEF:
+                rel.beef_start_time = None
+
         event = RelationshipEvent(
             event_id=self._generate_event_id(),
             timestamp=now,

--- a/test_agent_relationships.py
+++ b/test_agent_relationships.py
@@ -263,6 +263,44 @@ class TestRelationshipEngine(unittest.TestCase):
         self.assertEqual(rel["state"], "neutral")
         self.assertIsNone(rel["beef_start_time"])
     
+    def test_beef_start_time_cleared_when_beef_ends_via_collaboration(self):
+        """Leaving a beef through collaboration must clear beef_start_time.
+
+        Every other beef exit (reconciliation, admin intervention, duration
+        auto-resolve, expiration pass) resets beef_start_time. Collaboration
+        must too, otherwise a later brand-new beef inherits the old episode's
+        start time and is treated as already-expired.
+        """
+        self.engine.initialize_relationship("agent_a", "agent_b")
+
+        for i in range(10):
+            self.engine.record_disagreement(
+                "agent_a", "agent_b", f"topic{i}", f"Disagreement {i}"
+            )
+        rel = self.engine.get_relationship("agent_a", "agent_b")
+        self.assertEqual(rel["state"], "beef")
+        self.assertIsNotNone(rel["beef_start_time"])
+
+        # Backdate the beef so a leftover start time would look long-expired.
+        with self.engine._get_connection() as conn:
+            conn.execute(
+                "UPDATE relationships SET beef_start_time = ? "
+                "WHERE agent_a = ? AND agent_b = ?",
+                (time.time() - 20 * 86400, rel["agent_a"], rel["agent_b"]),
+            )
+            conn.commit()
+
+        # Reconcile via collaborations until the pair leaves the beef state.
+        for _ in range(10):
+            self.engine.record_collaboration("agent_a", "agent_b", "made up")
+            if self.engine.get_relationship("agent_a", "agent_b")["state"] != "beef":
+                break
+
+        rel = self.engine.get_relationship("agent_a", "agent_b")
+        self.assertNotEqual(rel["state"], "beef")
+        # The stale start time from the finished beef must be gone.
+        self.assertIsNone(rel["beef_start_time"])
+
     def test_get_active_beefs(self):
         """Test retrieving active beef relationships."""
         self.engine.initialize_relationship("agent_a", "agent_b")


### PR DESCRIPTION
### Problem
`record_collaboration` transitions a pair out of beef (e.g. `BEEF → RIVALS` when trust ≥ 40) but does **not** clear `beef_start_time`. Every other beef exit does:

- `record_reconciliation` → `rel.beef_start_time = None`
- `_check_beef_duration` auto-resolve → `beef_start_time = None`
- `admin_intervene` / `process_beef_expirations` → `beef_start_time = NULL`

Because the re-arm guards use `not rel.beef_start_time`, the stale value can't be replaced when a fresh beef starts later — the new beef inherits the old episode's timestamp.

### Impact (reproduced end-to-end)
Two agents beef, make peace via collaboration (state leaves beef, but `beef_start_time` stays), then fight again weeks later. The brand-new beef keeps the old start time, so it's instantly "expired": invisible to `get_active_beefs()` and force-resolved to neutral on the next `process_beef_expirations()` pass — the opposite of the intended 14-day drama window.

### Fix
Clear `beef_start_time` on any collaboration-driven transition out of beef:

```python
if new_state:
    rel.state = new_state
    if new_state != RelationshipState.BEEF:
        rel.beef_start_time = None
```

### Test
Adds `test_beef_start_time_cleared_when_beef_ends_via_collaboration` (beef → collaboration exit). It fails on `main`, passes with the fix. Full suite: `41 passed`.

/claim