### PR TITLE
fix(adm): warthog bonus uncapped on own-connection path settles epoch differently than existing-connection path

### DIFF
--- a/node/anti_double_mining.py
+++ b/node/anti_double_mining.py
@@ -575,8 +575,17 @@ def calculate_anti_double_mining_rewards(
                         "SELECT warthog_bonus FROM miner_attest_recent WHERE miner=?",
                         (miner_id,)
                     ).fetchone()
-                    if wart_row and wart_row[0] and wart_row[0] > 1.0:
-                        weight *= wart_row[0]
+                    # Apply capped warthog bonus (MAX = 2.0) to prevent reward inflation.
+                    # Must match _calculate_anti_double_mining_rewards_conn exactly, or the
+                    # same epoch settles to a different split depending on whether the caller
+                    # passed an existing connection (settle_epoch_with_anti_double_mining
+                    # dispatches to the two paths on that condition).
+                    if wart_row and wart_row[0]:
+                        bonus = float(wart_row[0])
+                        if 1.0 < bonus <= 2.0:
+                            weight *= bonus
+                        elif bonus > 2.0:
+                            weight *= 2.0
                 except Exception:
                     pass
             

--- a/node/tests/test_anti_double_mining.py
+++ b/node/tests/test_anti_double_mining.py
@@ -497,6 +497,36 @@ class TestAntiDoubleMiningEnrolledWeights(unittest.TestCase):
 
         self.assertEqual(rewards, {"miner-heavy": 10_000, "miner-light": 100})
 
+    def test_both_paths_cap_warthog_bonus_identically(self):
+        """Settlement must be deterministic w.r.t. connection ownership.
+
+        settle_epoch_with_anti_double_mining dispatches to the own-connection
+        path (calculate_anti_double_mining_rewards) or the existing-connection
+        path (_calculate_anti_double_mining_rewards_conn) purely on whether the
+        caller passed a live connection.  The _conn path caps the warthog bonus
+        at 2.0 "to prevent reward inflation"; the own-connection path used to
+        apply it uncapped, so an out-of-range warthog_bonus made the SAME epoch
+        settle to a different split depending on the caller -> ledger fork.
+        """
+        # Push miner-heavy's warthog_bonus above the 2.0 cap the _conn path enforces.
+        self.conn.execute(
+            "UPDATE miner_attest_recent SET warthog_bonus = 3.0 WHERE miner = 'miner-heavy'"
+        )
+        self.conn.commit()
+
+        own, _ = calculate_anti_double_mining_rewards(
+            self.test_db, epoch=7, total_reward_urtc=10_100, current_slot=7 * 144 + 1
+        )
+        existing, _ = _calculate_anti_double_mining_rewards_conn(
+            self.conn, epoch=7, total_reward_urtc=10_100, current_slot=7 * 144 + 1
+        )
+
+        # Both paths must produce the identical, capped split.  Pre-fix the
+        # own-connection path returned {'miner-heavy': 10066, 'miner-light': 34}
+        # (uncapped x3.0) while the _conn path returned the capped values below.
+        self.assertEqual(own, existing)
+        self.assertEqual(existing, {"miner-heavy": 10_049, "miner-light": 51})
+
 
 class TestIdempotency(unittest.TestCase):
     """Test idempotent re-runs of reward calculation."""


### PR DESCRIPTION
## Problem

`settle_epoch_with_anti_double_mining` dispatches to one of two reward calculators purely on whether the caller passes a live connection:

```python
if existing_conn is not None:
    rewards, telemetry = _calculate_anti_double_mining_rewards_conn(...)   # caps warthog bonus at 2.0
else:
    rewards, telemetry = calculate_anti_double_mining_rewards(...)          # applied it UNCAPPED
```

`_calculate_anti_double_mining_rewards_conn` is documented as *"Same as calculate_anti_double_mining_rewards but uses an existing connection"* and caps the warthog dual-mining bonus:

```python
# Apply capped warthog bonus (MAX = 2.0) to prevent reward inflation
if 1.0 < bonus <= 2.0:
    weight *= bonus
elif bonus > 2.0:
    weight *= 2.0
```

But the own-connection sibling applied it with no cap (`if wart_row[0] > 1.0: weight *= wart_row[0]`). So for any miner whose `warthog_bonus` exceeds 2.0, the **same epoch settles to a different reward split depending on which entry point the caller used** — a non-deterministic ledger fork between the two settlement paths. The cap comment in the sibling establishes that 2.0 is the intended safeguard against exactly this reward inflation.

## Fix

Apply the identical `MAX = 2.0` cap in the own-connection path so the two documented-equivalent functions actually agree.

## Verification

Added `test_both_paths_cap_warthog_bonus_identically` — settles the same epoch (one miner with `warthog_bonus = 3.0`) through both paths and asserts identical output.

- **On main:** own-connection `{'miner-heavy': 10066, 'miner-light': 34}` (uncapped ×3.0) vs existing-connection `{'miner-heavy': 10049, 'miner-light': 51}` (capped ×2.0) → **FAIL**
- **With fix:** both return the capped `{'miner-heavy': 10049, 'miner-light': 51}` → **PASS**

Full `test_anti_double_mining.py` + `test_anti_double_mining_epoch_enroll.py` suites green (23 + epoch-enroll).