### PR TITLE
fix(hall_of_rust): explorer Rust Score drops PowerPC arch bonus (case-mismatch, twin of #7956)

### DIFF
--- a/explorer/hall_of_rust.py
+++ b/explorer/hall_of_rust.py
@@ -123,8 +123,11 @@ def calculate_rust_score(machine):
         score += RUST_WEIGHTS['first_attestation']
     
     # Architecture bonuses
+    # NOTE: keys must be lower-case — `arch` below is lower-cased before the
+    # substring match, so upper-case keys (e.g. 'G4') could never match and the
+    # PowerPC bonus was silently dropped. Mirrors the node sibling fix (#7956).
     arch_bonus = {
-        'G3': 80, 'G4': 70, 'G5': 60,
+        'g3': 80, 'g4': 70, 'g5': 60,
         '486': 150, 'pentium': 100, 'pentium4': 50,
         'retro': 40, 'apple_silicon': 5, 'modern': 0
     }

--- a/tests/test_explorer_hall_of_rust_arch_bonus.py
+++ b/tests/test_explorer_hall_of_rust_arch_bonus.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression test for the explorer Hall of Rust architecture-bonus case bug.
+
+explorer/hall_of_rust.py::calculate_rust_score() lower-cases the reported
+device_arch before matching, but the PowerPC entries in the arch_bonus table
+used UPPER-CASE keys ('G3'/'G4'/'G5'). Because ``key in arch`` is a
+case-sensitive substring test, 'G4' in 'g4' is False, so a PowerPC machine —
+the exact hardware the Hall of Rust exists to celebrate — never received its
+architecture bonus. This mirrors the already-merged node sibling fix (#7956);
+the explorer copy was missed.
+
+Run:
+    python3 -m pytest tests/test_explorer_hall_of_rust_arch_bonus.py -q
+"""
+import importlib.util
+import os
+
+_EXPLORER = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "explorer", "hall_of_rust.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("explorer_hall_of_rust", _EXPLORER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _score(arch):
+    # Isolated machine: no manufacture_year, no attestations, no plague model,
+    # no thermal events, id default 999 (> 100 => no first-adopter bonus).
+    # Only the architecture bonus contributes to the score.
+    return _load().calculate_rust_score({"device_arch": arch})
+
+
+def test_g3_gets_powerpc_bonus():
+    assert _score("G3") == 80.0
+
+
+def test_g4_gets_powerpc_bonus():
+    assert _score("G4") == 70.0
+
+
+def test_g5_gets_powerpc_bonus():
+    assert _score("G5") == 60.0
+
+
+def test_lowercase_g4_also_matches():
+    # Some attestation paths report arch already lower-cased; must match too.
+    assert _score("g4") == 70.0
+
+
+def test_modern_still_zero():
+    assert _score("modern") == 0.0
+
+
+def test_486_bonus_unaffected():
+    assert _score("486") == 150.0
+
+
+if __name__ == "__main__":
+    for arch, expected in [("G3", 80.0), ("G4", 70.0), ("G5", 60.0),
+                           ("g4", 70.0), ("modern", 0.0), ("486", 150.0)]:
+        got = _score(arch)
+        print(f"arch={arch!r:>8}  expected={expected:>6}  got={got:>6}  "
+              f"{'OK' if got == expected else 'FAIL'}")


### PR DESCRIPTION
## Problem

`explorer/hall_of_rust.py::calculate_rust_score()` lower-cases the reported `device_arch` before matching architecture bonuses, but the PowerPC entries in the `arch_bonus` table use **upper-case** keys:

```python
arch_bonus = {
    'G3': 80, 'G4': 70, 'G5': 60,   # upper-case keys
    ...
}
arch = machine.get('device_arch', 'modern').lower()   # value is lower-cased
for key, bonus in arch_bonus.items():
    if key in arch:                 # case-sensitive substring test
        score += bonus
```

`'G4' in 'g4'` is `False`, so **every PowerPC machine** — the exact vintage hardware the Hall of Rust exists to celebrate — silently loses its architecture bonus. It scores **0** instead of **60–80**, which corrupts `rust_score`, leaderboard ordering (`ORDER BY rust_score DESC`) and badge tiers.

Reproduced against the current module:

| `device_arch` | expected | actual (main) |
|---|---|---|
| `G3` | 80 | **0** |
| `G4` / `g4` | 70 | **0** |
| `G5` | 60 | **0** |
| `486` | 150 | 150 ✓ |

## Why this is the right fix

This is the **unfixed twin** of the node sibling `node/hall_of_rust.py`, which was corrected in **#7956** (`fix(hall_of_rust): PowerPC arch bonus never applied`). The explorer copy was missed. Additionally, the sibling `estimate_manufacture_year()` **in this same file** already uses `key.lower() in arch.lower()`, confirming lower-case is the intended convention.

The fix simply lower-cases the three PowerPC keys to match — the other keys are already lower-case. Minimal, mirrors the merged sibling fix exactly.

## Test

Adds `tests/test_explorer_hall_of_rust_arch_bonus.py` — fails on `main` for `G3`/`G4`/`G5`/`g4`, passes with the fix. Existing `tests/test_explorer_hall_of_rust_current_year.py` (10 tests) stays green.

```
# before fix: 4 failed, 2 passed
# after fix:  6 passed
```