### PR TITLE
[UTXO-BUG] Fix inconsistent indentation in mempool_add() ROLLBACK calls

### DIFF
--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -1231,7 +1231,7 @@ class UtxoDB:
             fee = tx.get('fee_nrtc', 0)
             if not _is_nonnegative_int64(fee):
                 if manage_tx:
-                        conn.execute("ROLLBACK")
+                    conn.execute("ROLLBACK")
                 return False
 
             # MEDIUM FIX: Reject empty outputs to prevent DoS
@@ -1239,16 +1239,16 @@ class UtxoDB:
             outputs = self._normalize_outputs(outputs)
             if outputs is None:
                 if manage_tx:
-                        conn.execute("ROLLBACK")
+                    conn.execute("ROLLBACK")
                 return False
             if not outputs and tx_type not in MINTING_TX_TYPES:
                 if manage_tx:
-                        conn.execute("ROLLBACK")
+                    conn.execute("ROLLBACK")
                 return False
             # FIX(#9273): Reject transactions with too many outputs (UTXO bloat).
             if len(outputs) > MAX_OUTPUTS:
                 if manage_tx:
-                        conn.execute("ROLLBACK")
+                    conn.execute("ROLLBACK")
                 return False
 
             input_total = 0
@@ -1263,7 +1263,7 @@ class UtxoDB:
             output_total = sum(o['value_nrtc'] for o in outputs)
             if inputs and (output_total + fee) != input_total:
                 if manage_tx:
-                        conn.execute("ROLLBACK")
+                    conn.execute("ROLLBACK")
                 return False
 
             # Insert into mempool
@@ -1319,7 +1319,7 @@ class UtxoDB:
         except Exception:
             try:
                 if manage_tx:
-                        conn.execute("ROLLBACK")
+                    conn.execute("ROLLBACK")
             except Exception:
                 pass
             return False


### PR DESCRIPTION
## Fix for UTXO Red Team Audit Finding #3

**Refs:** Scottcjn/rustchain-bounties#2819

### Bug
6 pairs of `if manage_tx: / conn.execute("ROLLBACK")` in `mempool_add()` have the `ROLLBACK` call indented 8 spaces too deep (6 levels instead of 5).

While technically valid Python (no syntax error), this is a **code quality hazard**:
- Signals rushed/inconsistent patching
- Increases risk of future editing errors
- Makes code review harder

### Fix
Correct indent from 6 levels (24 spaces) to 5 levels (20 spaces) on all 6 ROLLBACK lines.

### Audit Finding
Full report: https://github.com/Scottcjn/rustchain-bounties/issues/2819#issuecomment-4954595626

Wallet: RTCad35e1c1746560097ce9989abc140e0529b87163