### PR TITLE
fix(tier3): validator average_score divides by validated+rejected instead of validated count

### DIFF
--- a/tier3/agents/validator_agent.py
+++ b/tier3/agents/validator_agent.py
@@ -168,9 +168,13 @@ class ValidatorAgent:
         # Update stats
         if valid:
             self.stats["total_validated"] += 1
-            total = self.stats["total_validated"] + self.stats["total_rejected"]
+            # average_score is the running mean over VALIDATED scores only
+            # (rejected proofs never contribute a score to the numerator), so
+            # the divisor must be the count of validated proofs, not the
+            # combined validated+rejected total.
+            n = self.stats["total_validated"]
             self.stats["average_score"] = (
-                (self.stats["average_score"] * (total - 1) + score) / total
+                (self.stats["average_score"] * (n - 1) + score) / n
             )
         else:
             self.stats["total_rejected"] += 1

--- a/tier3/tests/test_pipeline.py
+++ b/tier3/tests/test_pipeline.py
@@ -155,7 +155,25 @@ class TestValidatorAgent:
         assert stats["total_validated"] == 5
         assert stats["total_rejected"] == 0
         assert stats["average_score"] > 0
-    
+
+    def test_average_score_excludes_rejected_from_denominator(self, validator_agent, sample_poa_submission):
+        """average_score is the mean over VALIDATED scores only; rejected proofs
+        (which contribute no score) must not dilute the denominator."""
+        # One rejected proof (missing every required field -> score 0, not summed).
+        rejected = validator_agent.validate_poa_proof({})
+        assert not rejected.valid
+
+        # One valid proof.
+        valid = validator_agent.validate_poa_proof(sample_poa_submission)
+        assert valid.valid
+
+        stats = validator_agent.get_stats()
+        assert stats["total_validated"] == 1
+        assert stats["total_rejected"] == 1
+        # Exactly one validated score was recorded, so the mean equals that score.
+        # On the buggy path the divisor was validated+rejected (2), halving it.
+        assert stats["average_score"] == pytest.approx(valid.score)
+
     def test_strict_validation_level(self, sample_poa_submission):
         """Test strict validation level applies harsher scoring"""
         strict_validator = ValidatorAgent(


### PR DESCRIPTION
## Problem

`ValidatorAgent.validate_poa_proof` (`tier3/agents/validator_agent.py`) maintains `average_score` as a running mean over **validated** scores — rejected proofs contribute no score to the numerator (the `else` branch only bumps `total_rejected`). But the update divided by the **combined** count:

```python
if valid:
    self.stats["total_validated"] += 1
    total = self.stats["total_validated"] + self.stats["total_rejected"]   # <-- wrong divisor
    self.stats["average_score"] = (
        (self.stats["average_score"] * (total - 1) + score) / total
    )
```

Because the numerator only ever sums valid scores, dividing by `validated + rejected` dilutes the mean whenever any proof was rejected.

## Impact

- Reject one proof, then validate one scoring 100 → `total_validated=1`, `total_rejected=1`, so `average_score = (0*1 + 100) / 2 = 50.0` instead of `100.0`.
- Sequence 90 (valid), reject, 60 (valid) → reports `80.0`, correct mean is `75.0`.

The error appears whenever any proof is rejected and surfaces through `get_stats()` and up through `PipelineOrchestrator.get_stats()` as `validator_stats`.

## Fix

Divide by `total_validated` — the count of scores actually summed — so numerator and denominator agree:

```python
if valid:
    self.stats["total_validated"] += 1
    n = self.stats["total_validated"]
    self.stats["average_score"] = (
        (self.stats["average_score"] * (n - 1) + score) / n
    )
```

The sibling `RewardAgent` (`tier3/agents/reward_agent.py`) already follows this rule for `average_reward` — it divides the summed value by `total_distributed`, the count actually accumulated.

## Test

Added `test_average_score_excludes_rejected_from_denominator` to `tier3/tests/test_pipeline.py`: reject one proof, validate one (score 100), assert `average_score == 100`. **Fails on main** (`50.0`), passes with the fix. The existing `test_validation_stats_tracking` only ever validates (no rejects), so it never exercised this path. Full `tier3/tests/test_pipeline.py` suite: **33 passed**.
