### PR TITLE
fix(claims): get_eligible_epochs marks unclaimed epochs as claimed when miner is ineligible

### DIFF
--- a/node/claims_eligibility.py
+++ b/node/claims_eligibility.py
@@ -696,9 +696,13 @@ def get_eligible_epochs(
             detailed=False
         )
         
-        claimed = not eligibility["checks"]["no_pending_claim"] or \
-                  (eligibility["checks"]["no_pending_claim"] and not eligibility["eligible"])
-        
+        # "claimed" means a claim actually exists for this epoch. A pending
+        # claim shows up as no_pending_claim == False here; a settled claim is
+        # detected by the query below. Ineligibility for any *other* reason
+        # (epoch not settled, no participation, wallet not registered, ...) must
+        # NOT be reported as claimed.
+        claimed = not eligibility["checks"]["no_pending_claim"]
+
         # Check if already claimed (status = settled)
         try:
             with sqlite3.connect(db_path) as conn:

--- a/node/tests/test_claims_eligibility.py
+++ b/node/tests/test_claims_eligibility.py
@@ -533,6 +533,31 @@ class TestGetEligibleEpochs(unittest.TestCase):
         self.assertEqual(result["epochs"], [])
         self.assertEqual(result["total_unclaimed_urtc"], 0)
 
+    def test_ineligible_epoch_without_claim_not_marked_claimed(self):
+        """An epoch a miner is ineligible for (but never claimed) must report
+        claimed=False. Regression: the flag used to be derived from the
+        eligibility verdict, so any not-eligible epoch was marked claimed even
+        with zero claim rows."""
+        for miner in ("test-miner-fail", "test-miner-nowallet"):
+            with self.subTest(miner=miner):
+                # Sanity: this miner has no claim rows in the fixture.
+                conn = sqlite3.connect(self.db_path)
+                n = conn.execute(
+                    "SELECT COUNT(*) FROM claims WHERE miner_id = ?",
+                    (miner,)).fetchone()[0]
+                conn.close()
+                self.assertEqual(n, 0)
+
+                result = get_eligible_epochs(
+                    self.db_path, miner,
+                    self.current_slot, self.now, limit=6)
+                self.assertTrue(result["epochs"])
+                for e in result["epochs"]:
+                    # No claim exists, so nothing can be "claimed".
+                    self.assertFalse(
+                        e["claimed"],
+                        f"epoch {e['epoch']} marked claimed with no claim row")
+
 
 class TestEdgeCases(unittest.TestCase):
     """Edge cases and boundary conditions"""


### PR DESCRIPTION
## Problem

`get_eligible_epochs` (`node/claims_eligibility.py`) derives each epoch's `claimed` flag from the eligibility verdict:

```python
claimed = not eligibility["checks"]["no_pending_claim"] or \
          (eligibility["checks"]["no_pending_claim"] and not eligibility["eligible"])
```

With `P = no_pending_claim`, this is `(not P) or (P and not eligible)`, which reduces to **`not P or not eligible`**. So an epoch is reported `claimed` whenever the miner is **not eligible**, regardless of whether any claim exists.

`check_claim_eligibility` returns early on the first failed gate — epoch not settled, not attested, no participation, fingerprint failed, wallet not registered — *before* the pending-claim check runs. In those paths `no_pending_claim` keeps its default `True` and `eligible=False`, so `claimed = not True or not False = True`.

## Impact

Any epoch a miner is ineligible for (for a reason other than an existing claim) is reported as `claimed=True` even with **zero claim rows** — the API/UI shows "already claimed" for epochs the miner never claimed and cannot yet claim.

`total_unclaimed_urtc` is unaffected — it independently re-gates on `eligible` (line 725) — so this is a reporting/UX correctness bug, not a fund leak.

## Fix

`claimed` should reflect an actual claim: a pending claim (`no_pending_claim == False`) or the settled-claim lookup immediately below (lines 703-711), which is exactly how the correct branch already determines it.

```python
claimed = not eligibility["checks"]["no_pending_claim"]
```

The very next block already sets `claimed = True` when a `settled` row exists in the `claims` table — the intended source of truth. The removed clause was inferring "claimed" from the eligibility verdict instead.

## Test

Added `test_ineligible_epoch_without_claim_not_marked_claimed` to `node/tests/test_claims_eligibility.py`: it uses the existing fixture's ineligible miners (`test-miner-fail` = failed fingerprint, `test-miner-nowallet` = no wallet), each with **zero claim rows**, and asserts every returned epoch has `claimed=False`. **Fails on main** (both report `claimed=True`), passes with the fix. `test_claims_eligibility.py`: 54 passed; adjacent claims suites: 27 passed.
