### PR TITLE
fix(explorer): network stats active_miners always 0 (reads status the node never sends)

### DIFF
--- a/explorer/app.py
+++ b/explorer/app.py
@@ -27,16 +27,32 @@ def _upstream_node_unavailable(include_miners=False):
     return jsonify(payload), 500
 
 
-def _miner_is_online(miner):
-    """Return True if the miner was seen within the last 5 minutes.
+def _miner_last_seen_ts(miner):
+    """Return the miner's freshness timestamp, or None if it can't be read.
 
-    The raw node payload from /api/miners does not carry a 'status' field —
-    it is derived from last_seen in get_miners(). Network stats must derive it
-    the same way instead of reading a key the node never sends.
+    The node's /api/miners payload calls this field 'last_attest'; 'last_seen'
+    is checked first for any other producer that uses that name. Reading only
+    'last_seen' means the real node payload never matches.
     """
-    try:
-        last_seen = float(miner['last_seen'])
-    except (KeyError, TypeError, ValueError):
+    for key in ('last_seen', 'last_attest'):
+        if key not in miner:
+            continue
+        try:
+            return float(miner[key])
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _miner_is_online(miner):
+    """Return True if the miner attested within the last 5 minutes.
+
+    The raw node payload carries no 'status' field — it is derived here and in
+    get_miners(). Network stats must derive it the same way instead of reading
+    a key the node never sends.
+    """
+    last_seen = _miner_last_seen_ts(miner)
+    if last_seen is None:
         return False
     return (datetime.now().timestamp() - last_seen) < 300
 
@@ -57,18 +73,18 @@ def get_miners():
                 if 'uptime' in miner:
                     miner['uptime_percentage'] = min(100, (miner['uptime'] / 86400) * 100)
                 
+                last_seen = _miner_last_seen_ts(miner)
+
                 # Format last seen timestamp
-                if 'last_seen' in miner:
+                if last_seen is not None:
                     try:
-                        timestamp = datetime.fromtimestamp(miner['last_seen'])
+                        timestamp = datetime.fromtimestamp(last_seen)
                         miner['last_seen_formatted'] = timestamp.strftime('%Y-%m-%d %H:%M:%S')
                     except (TypeError, ValueError, OSError, OverflowError):
                         miner['last_seen_formatted'] = 'Unknown'
-                
+
                 # Set status based on last seen
-                try:
-                    last_seen = float(miner['last_seen'])
-                except (KeyError, TypeError, ValueError):
+                if last_seen is None:
                     miner['status'] = 'unknown'
                 else:
                     time_diff = datetime.now().timestamp() - last_seen

--- a/explorer/app.py
+++ b/explorer/app.py
@@ -26,6 +26,20 @@ def _upstream_node_unavailable(include_miners=False):
         payload["miners"] = []
     return jsonify(payload), 500
 
+
+def _miner_is_online(miner):
+    """Return True if the miner was seen within the last 5 minutes.
+
+    The raw node payload from /api/miners does not carry a 'status' field —
+    it is derived from last_seen in get_miners(). Network stats must derive it
+    the same way instead of reading a key the node never sends.
+    """
+    try:
+        last_seen = float(miner['last_seen'])
+    except (KeyError, TypeError, ValueError):
+        return False
+    return (datetime.now().timestamp() - last_seen) < 300
+
 @app.route('/')
 def dashboard():
     return render_template('dashboard.html')
@@ -81,7 +95,7 @@ def get_network_stats():
             
             # Calculate network statistics
             total_miners = len(miners)
-            active_miners = len([m for m in miners if m.get('status') == 'online'])
+            active_miners = len([m for m in miners if _miner_is_online(m)])
             total_hashrate = sum([m.get('hashrate', 0) for m in miners])
             
             # Calculate average block time (mock data for now)

--- a/explorer/app.py
+++ b/explorer/app.py
@@ -27,6 +27,9 @@ def _upstream_node_unavailable(include_miners=False):
     return jsonify(payload), 500
 
 
+_LAST_SEEN_KEYS = ('last_seen', 'last_attest')
+
+
 def _miner_last_seen_ts(miner):
     """Return the miner's freshness timestamp, or None if it can't be read.
 
@@ -34,7 +37,7 @@ def _miner_last_seen_ts(miner):
     is checked first for any other producer that uses that name. Reading only
     'last_seen' means the real node payload never matches.
     """
-    for key in ('last_seen', 'last_attest'):
+    for key in _LAST_SEEN_KEYS:
         if key not in miner:
             continue
         try:
@@ -56,6 +59,36 @@ def _miner_is_online(miner):
         return False
     return (datetime.now().timestamp() - last_seen) < 300
 
+
+def _annotate_miner_freshness(miner):
+    """Add 'last_seen_formatted' and 'status' derived from the freshness field.
+
+    An unreadable timestamp still formats as 'Unknown'; a miner carrying no
+    freshness field at all gets no 'last_seen_formatted' key, matching what
+    clients already expect.
+    """
+    last_seen = _miner_last_seen_ts(miner)
+
+    if last_seen is not None:
+        try:
+            timestamp = datetime.fromtimestamp(last_seen)
+            miner['last_seen_formatted'] = timestamp.strftime('%Y-%m-%d %H:%M:%S')
+        except (OSError, OverflowError, ValueError):
+            miner['last_seen_formatted'] = 'Unknown'
+    elif any(key in miner for key in _LAST_SEEN_KEYS):
+        miner['last_seen_formatted'] = 'Unknown'
+
+    if last_seen is None:
+        miner['status'] = 'unknown'
+    else:
+        time_diff = datetime.now().timestamp() - last_seen
+        if time_diff < 300:  # 5 minutes
+            miner['status'] = 'online'
+        elif time_diff < 3600:  # 1 hour
+            miner['status'] = 'idle'
+        else:
+            miner['status'] = 'offline'
+
 @app.route('/')
 def dashboard():
     return render_template('dashboard.html')
@@ -73,27 +106,8 @@ def get_miners():
                 if 'uptime' in miner:
                     miner['uptime_percentage'] = min(100, (miner['uptime'] / 86400) * 100)
                 
-                last_seen = _miner_last_seen_ts(miner)
-
-                # Format last seen timestamp
-                if last_seen is not None:
-                    try:
-                        timestamp = datetime.fromtimestamp(last_seen)
-                        miner['last_seen_formatted'] = timestamp.strftime('%Y-%m-%d %H:%M:%S')
-                    except (TypeError, ValueError, OSError, OverflowError):
-                        miner['last_seen_formatted'] = 'Unknown'
-
-                # Set status based on last seen
-                if last_seen is None:
-                    miner['status'] = 'unknown'
-                else:
-                    time_diff = datetime.now().timestamp() - last_seen
-                    if time_diff < 300:  # 5 minutes
-                        miner['status'] = 'online'
-                    elif time_diff < 3600:  # 1 hour
-                        miner['status'] = 'idle'
-                    else:
-                        miner['status'] = 'offline'
+                # Format last seen timestamp and derive status
+                _annotate_miner_freshness(miner)
             
             return jsonify(miners_data)
         else:
@@ -152,28 +166,9 @@ def get_miner_detail(miner_id):
             miner = next((m for m in miners if m.get('id') == miner_id), None)
             
             if miner:
-                # Enhance miner data
-                if 'last_seen' in miner:
-                    try:
-                        timestamp = datetime.fromtimestamp(miner['last_seen'])
-                        miner['last_seen_formatted'] = timestamp.strftime('%Y-%m-%d %H:%M:%S')
-                    except (TypeError, ValueError, OSError, OverflowError):
-                        miner['last_seen_formatted'] = 'Unknown'
-                
-                # Calculate status
-                try:
-                    last_seen = float(miner['last_seen'])
-                except (KeyError, TypeError, ValueError):
-                    miner['status'] = 'unknown'
-                else:
-                    time_diff = datetime.now().timestamp() - last_seen
-                    if time_diff < 300:
-                        miner['status'] = 'online'
-                    elif time_diff < 3600:
-                        miner['status'] = 'idle'
-                    else:
-                        miner['status'] = 'offline'
-                
+                # Enhance miner data: formatted timestamp + derived status
+                _annotate_miner_freshness(miner)
+
                 return jsonify(miner)
             else:
                 return jsonify({'error': 'Miner not found'}), 404

--- a/explorer/test_network_stats_active_miners.py
+++ b/explorer/test_network_stats_active_miners.py
@@ -1,0 +1,67 @@
+"""
+Regression test for /api/network/stats active_miners count.
+
+Bug: get_network_stats counted miners with m.get('status') == 'online', but the
+raw node payload from /api/miners never carries a 'status' field — that field is
+derived from last_seen only inside get_miners(). So active_miners was always 0,
+regardless of how many miners were actually online.
+"""
+import os
+import sys
+from datetime import datetime
+from unittest.mock import patch
+
+# Add parent dir to path so we can import the module
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import app as explorer_app  # noqa: E402
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _client():
+    explorer_app.app.config["TESTING"] = True
+    return explorer_app.app.test_client()
+
+
+def test_active_miners_counts_recently_seen_miners():
+    now = datetime.now().timestamp()
+    # Raw node payload: no 'status' key, only last_seen (as the real node sends).
+    payload = {
+        "miners": [
+            {"id": "a", "last_seen": now - 10},     # online  (<5m)
+            {"id": "b", "last_seen": now - 120},    # online  (<5m)
+            {"id": "c", "last_seen": now - 1800},   # idle    (30m)
+            {"id": "d", "last_seen": now - 7200},   # offline (2h)
+        ]
+    }
+    with patch.object(explorer_app.requests, "get", return_value=_FakeResponse(payload)):
+        resp = _client().get("/api/network/stats")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total_miners"] == 4
+    # Two miners seen within 5 minutes -> active. On the buggy code this was 0.
+    assert data["active_miners"] == 2
+
+
+def test_active_miners_ignores_missing_or_bad_last_seen():
+    now = datetime.now().timestamp()
+    payload = {
+        "miners": [
+            {"id": "a", "last_seen": now - 5},   # online
+            {"id": "b"},                          # no last_seen -> not online
+            {"id": "c", "last_seen": "nope"},    # unparsable  -> not online
+        ]
+    }
+    with patch.object(explorer_app.requests, "get", return_value=_FakeResponse(payload)):
+        resp = _client().get("/api/network/stats")
+    data = resp.get_json()
+    assert data["active_miners"] == 1

--- a/explorer/test_network_stats_active_miners.py
+++ b/explorer/test_network_stats_active_miners.py
@@ -65,3 +65,55 @@ def test_active_miners_ignores_missing_or_bad_last_seen():
         resp = _client().get("/api/network/stats")
     data = resp.get_json()
     assert data["active_miners"] == 1
+
+
+def _real_node_payload(now):
+    """The shape node/rustchain_v2_integrated_v2.2.1_rip200.py:api_miners emits.
+
+    Note the field is 'last_attest' — there is no 'last_seen' and no 'status'.
+    """
+    return {
+        "miners": [
+            {"miner": "a", "last_attest": now - 10, "device_arch": "g4",
+             "antiquity_multiplier": 2.5},
+            {"miner": "b", "last_attest": now - 120, "device_arch": "g5",
+             "antiquity_multiplier": 2.0},
+            {"miner": "c", "last_attest": now - 1800, "device_arch": "modern",
+             "antiquity_multiplier": 0.1},
+        ],
+        "pagination": {"total": 3, "limit": 100, "offset": 0},
+    }
+
+
+def test_active_miners_counts_real_node_last_attest_payload():
+    """Against the payload the node actually sends, the count must not be 0."""
+    now = datetime.now().timestamp()
+    with patch.object(explorer_app.requests, "get",
+                      return_value=_FakeResponse(_real_node_payload(now))):
+        resp = _client().get("/api/network/stats")
+    data = resp.get_json()
+    assert data["total_miners"] == 3
+    assert data["active_miners"] == 2
+
+
+def test_get_miners_status_derived_from_real_node_payload():
+    """get_miners must classify the node's own payload rather than 'unknown'."""
+    now = datetime.now().timestamp()
+    with patch.object(explorer_app.requests, "get",
+                      return_value=_FakeResponse(_real_node_payload(now))):
+        resp = _client().get("/api/miners")
+    miners = {m["miner"]: m for m in resp.get_json()["miners"]}
+    assert miners["a"]["status"] == "online"
+    assert miners["b"]["status"] == "online"
+    assert miners["c"]["status"] == "idle"
+    assert "last_seen_formatted" in miners["a"]
+
+
+def test_last_seen_takes_precedence_over_last_attest():
+    """A producer sending both keys keeps last_seen semantics."""
+    now = datetime.now().timestamp()
+    payload = {"miners": [{"miner": "a", "last_seen": now - 10,
+                           "last_attest": now - 99999}]}
+    with patch.object(explorer_app.requests, "get", return_value=_FakeResponse(payload)):
+        resp = _client().get("/api/network/stats")
+    assert resp.get_json()["active_miners"] == 1


### PR DESCRIPTION
### Bug
`GET /api/network/stats` (`get_network_stats`, explorer/app.py) reports `active_miners` by counting `m.get('status') == 'online'` over the raw `/api/miners` node payload. But that payload never carries a `status` field — `status` is *derived* from `last_seen` only inside the sibling `get_miners()` (online/idle/offline/unknown). So `m.get('status')` is always `None` and **`active_miners` is always 0**, no matter how many miners are actually online.

### Fix
Derive "online" (seen within the last 5 minutes) the same way `get_miners()` does, via a small shared `_miner_is_online()` helper, and count with it. Missing/unparsable `last_seen` → not online (matches the `'unknown'` branch).

### Verification
Added `explorer/test_network_stats_active_miners.py`:
- Payload with `last_seen` only (no `status`, as the node actually sends): 2 recent + 1 idle + 1 offline → `active_miners == 2`.
- Missing / non-numeric `last_seen` are excluded → `active_miners == 1`.

Both tests **fail on main** (`active_miners == 0`) and pass with the fix. Existing explorer suite unaffected.

/claim