### PR TITLE
fix(hall_of_rust): Pentium 4 arch bonus never applied (substring order)

### DIFF
--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -140,7 +140,11 @@ def calculate_rust_score(machine, current_year=None):
         'retro': 40, 'apple_silicon': 5, 'modern': 0
     }
     arch = machine.get('device_arch', 'modern').lower()
-    for key, bonus in arch_bonus.items():
+    # Match the most specific key first: 'pentium' is a substring of 'pentium4',
+    # so iterating in dict order would match 'pentium' (100) for a Pentium 4 and
+    # never reach 'pentium4' (50), leaving that entry unreachable and inflating
+    # the leaderboard score. Longest key first makes the specific match win.
+    for key, bonus in sorted(arch_bonus.items(), key=lambda kv: -len(kv[0])):
         if key in arch:
             score += bonus
             break

--- a/node/test_hall_of_rust_pentium4_bonus.py
+++ b/node/test_hall_of_rust_pentium4_bonus.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+"""
+POC / regression test for the Hall of Rust Pentium 4 architecture-bonus bug.
+
+arch_bonus lists both 'pentium' (100) and 'pentium4' (50). The match loop does a
+substring test (``key in arch``) and stops at the first hit. Because 'pentium'
+is a substring of 'pentium4' and appeared first in dict-iteration order, a
+Pentium 4 machine matched 'pentium' and received 100 instead of its intended 50
+-- the 'pentium4' entry was unreachable dead code, and every Pentium 4 sat 50
+points too high on the ``ORDER BY rust_score DESC`` leaderboard.
+
+Fix: match the longest (most specific) key first.
+
+Run:
+    python3 -m pytest node/test_hall_of_rust_pentium4_bonus.py -q
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from hall_of_rust import calculate_rust_score
+
+
+def _isolated(arch):
+    # Only the arch bonus contributes: no mfg year, no attestations, no plague
+    # model, no thermal events, id default 999 (> 100 => no first-adopter bonus).
+    return calculate_rust_score({"device_arch": arch}, current_year=2026)
+
+
+def test_pentium4_gets_its_own_lower_bonus():
+    # FAILS on main: 'pentium' matches first and returns 100.0.
+    assert _isolated("pentium4") == 50.0
+
+
+def test_pentium4_variants_still_specific():
+    # Reported strings that embed 'pentium 4' / 'Pentium4' must resolve to 50.
+    assert _isolated("Pentium4 Northwood") == 50.0
+    assert _isolated("intel pentium4") == 50.0
+
+
+def test_plain_pentium_unchanged():
+    assert _isolated("pentium") == 100.0
+    assert _isolated("Pentium III") == 100.0
+
+
+def test_powerpc_bonus_unaffected():
+    # The longest-first ordering must not regress the PowerPC fix (#7956).
+    assert _isolated("g4") == 70.0
+    assert _isolated("486") == 150.0
+
+
+if __name__ == "__main__":
+    cases = [("pentium4", 50.0), ("Pentium4 Northwood", 50.0),
+             ("pentium", 100.0), ("g4", 70.0), ("486", 150.0)]
+    for arch, expected in cases:
+        got = _isolated(arch)
+        print(f"arch={arch!r:>20}  expected={expected:>6}  got={got:>6}  "
+              f"{'OK' if got == expected else 'FAIL'}")


### PR DESCRIPTION
## Problem
`node/hall_of_rust.py::calculate_rust_score()` scores a machine's architecture with a substring match that stops at the first hit:

```python
for key, bonus in arch_bonus.items():
    if key in arch:
        score += bonus
        break
```

`arch_bonus` lists both `'pentium': 100` and `'pentium4': 50`. Since `'pentium'` is a substring of `'pentium4'` **and** comes first in dict-iteration order, a Pentium 4 machine matches `'pentium'` and receives **100** instead of its intended **50**. The `'pentium4': 50` entry is therefore unreachable dead code, and every Pentium 4 sits **50 points too high** on the `ORDER BY rust_score DESC` Hall of Rust leaderboard (and gets the wrong badge tier).

Reproduced on current `main` (e8d372bd):
```
calculate_rust_score({'device_arch': 'pentium4'})  ->  100.0   # expected 50.0
```

## Fix
Iterate `arch_bonus` **longest-key-first** so the most specific substring wins:

```python
for key, bonus in sorted(arch_bonus.items(), key=lambda kv: -len(kv[0])):
```

This resolves the `pentium`/`pentium4` overlap, is robust to any future overlapping keys, and does **not** regress the PowerPC lower-case fix from #7956 (`g4`/`486`/`pentium` cases stay green).

## Test
Adds `node/test_hall_of_rust_pentium4_bonus.py`:
- **Fails on main** - `pentium4` and `Pentium4 Northwood` return `100.0`.
- **Passes with fix** - both return `50.0`; `pentium`, `g4`, `486` unchanged.

Existing `node/test_hall_of_rust_arch_bonus_poc.py` (the #7956 PowerPC regression suite) still passes - 9 passed together.

---
RTC payout address: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
