### PR TITLE
Align remaining halving references with RIP-0004 fixed emission

### DIFF
--- a/docs/WHAT_IF_RTC_FUNDAMENTALS.md
+++ b/docs/WHAT_IF_RTC_FUNDAMENTALS.md
@@ -44,11 +44,10 @@ inflated, or conservative?**
 ## What-if #1: effective supply
 
 "Fully diluted" assumes all 8.39M RTC exist. At the code-pinned emission rate
-(≤548 RTC/year, falling with halvings), issuing the 7.88M mining allocation takes
+(≤548 RTC/year, fixed per RIP-0004), issuing the 7.88M mining allocation takes
 **millennia**. Over any 5-year horizon, effective supply is ~448K RTC — issued
 supply plus rounding. Annual dilution of issued supply: **~0.12%**, versus 2–10%
-for typical chains. Whichever emission schedule governs (fixed 1.5 or halving —
-see WHITEPAPER §6 vs node code), the conclusion only gets *stronger* under halving.
+for typical chains.
 
 ## What-if #2: replacement cost of the code
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -398,7 +398,7 @@ Pentium 4          1.5x         2000
 Retro x86          1.4x         pre-2010
 Apple Silicon      1.2x         M1/M2/M3
 Modern x86_64      1.0x         current</pre>
-      <p>Multipliers decay slowly over chain lifetime. Full vintage bonus lasts ~6.67 years before halving.</p>
+      <p>Multipliers decay slowly over chain lifetime: the vintage bonus shrinks ~15% per chain-year, reaching parity with modern hardware after ~6.67 years.</p>
     </div>
 
     <!-- Fingerprinting -->

--- a/rips/rustchain-core/config/chain_params.py
+++ b/rips/rustchain-core/config/chain_params.py
@@ -27,9 +27,8 @@ PREMINE_PER_FOUNDER: Decimal = Decimal("125829.12")  # 4 founders
 BLOCK_REWARD: Decimal = Decimal("1.5")  # RTC per block
 BLOCK_TIME_SECONDS: int = 600  # 10 minutes
 
-# Halving schedule
-HALVING_INTERVAL_BLOCKS: int = 210_000  # ~4 years
-HALVING_COUNT: int = 4  # After 4 halvings, tail emission
+# Emission is FIXED per RIP-0004: no halving schedule. The 1.5 RTC/epoch
+# rate holds until the 2^23 supply cap is exhausted.
 
 # Token precision
 DECIMALS: int = 8
@@ -141,12 +140,8 @@ def get_multiplier_for_tier(tier: str) -> float:
     return HARDWARE_TIERS.get(tier, {}).get("multiplier", 0.5)
 
 def calculate_block_reward(height: int) -> Decimal:
-    """Calculate block reward at a given height"""
+    """Block reward at a given height. Fixed emission per RIP-0004:
+    1.5 RTC per block/epoch, no halving, until the supply cap is reached."""
     if height < 0:
         raise ValueError(f"Block height cannot be negative: {height}")
-
-    halvings = height // HALVING_INTERVAL_BLOCKS
-    if halvings >= HALVING_COUNT:
-        # Tail emission after 4 halvings
-        return BLOCK_REWARD / Decimal(2 ** HALVING_COUNT)
-    return BLOCK_REWARD / Decimal(2 ** halvings)
+    return BLOCK_REWARD

--- a/tests/test_chain_params_block_reward.py
+++ b/tests/test_chain_params_block_reward.py
@@ -25,18 +25,17 @@ def test_block_reward_rejects_negative_height():
         chain_params.calculate_block_reward(-1)
 
 
-def test_block_reward_rejects_negative_halving_boundary():
+def test_block_reward_rejects_negative_height_large():
     chain_params = load_chain_params()
 
     with pytest.raises(ValueError, match="Block height cannot be negative: -210000"):
-        chain_params.calculate_block_reward(-chain_params.HALVING_INTERVAL_BLOCKS)
+        chain_params.calculate_block_reward(-210_000)
 
 
-def test_block_reward_keeps_genesis_and_halving_outputs():
+def test_block_reward_is_fixed_no_halving():
+    # RIP-0004: emission is fixed at 1.5 RTC/epoch, no halving, at every height.
     chain_params = load_chain_params()
 
     assert chain_params.calculate_block_reward(0) == Decimal("1.5")
-    assert chain_params.calculate_block_reward(chain_params.HALVING_INTERVAL_BLOCKS) == Decimal("0.75")
-    assert chain_params.calculate_block_reward(
-        chain_params.HALVING_INTERVAL_BLOCKS * chain_params.HALVING_COUNT
-    ) == Decimal("0.09375")
+    assert chain_params.calculate_block_reward(210_000) == Decimal("1.5")
+    assert chain_params.calculate_block_reward(10_000_000) == Decimal("1.5")

--- a/tests/test_chain_params_boundaries.py
+++ b/tests/test_chain_params_boundaries.py
@@ -42,11 +42,11 @@ def test_get_multiplier_for_tier_returns_configured_and_fallback_values():
     assert chain_params.get_multiplier_for_tier("unknown") == 0.5
 
 
-def test_calculate_block_reward_halving_boundaries_and_tail_emission():
-    interval = chain_params.HALVING_INTERVAL_BLOCKS
+def test_calculate_block_reward_is_fixed_no_halving():
+    # RIP-0004: fixed 1.5 RTC/epoch emission, no halving, at every height.
     assert chain_params.calculate_block_reward(0) == Decimal("1.5")
-    assert chain_params.calculate_block_reward(interval - 1) == Decimal("1.5")
-    assert chain_params.calculate_block_reward(interval) == Decimal("0.75")
-    assert chain_params.calculate_block_reward(interval * 2) == Decimal("0.375")
-    assert chain_params.calculate_block_reward(interval * 4) == Decimal("0.09375")
-    assert chain_params.calculate_block_reward(interval * 5) == Decimal("0.09375")
+    assert chain_params.calculate_block_reward(209_999) == Decimal("1.5")
+    assert chain_params.calculate_block_reward(210_000) == Decimal("1.5")
+    assert chain_params.calculate_block_reward(420_000) == Decimal("1.5")
+    assert chain_params.calculate_block_reward(840_000) == Decimal("1.5")
+    assert chain_params.calculate_block_reward(1_050_000) == Decimal("1.5")

--- a/website/static/classic.html
+++ b/website/static/classic.html
@@ -398,7 +398,7 @@ Pentium 4          1.5x         2000
 Retro x86          1.4x         pre-2010
 Apple Silicon      1.2x         M1/M2/M3
 Modern x86_64      1.0x         current</pre>
-      <p>Multipliers decay slowly over chain lifetime. Full vintage bonus lasts ~6.67 years before halving.</p>
+      <p>Multipliers decay slowly over chain lifetime: the vintage bonus shrinks ~15% per chain-year, reaching parity with modern hardware after ~6.67 years.</p>
     </div>
 
     <!-- Fingerprinting -->


### PR DESCRIPTION
RIP-0004 and the production node emit a fixed 1.5 RTC per epoch with no halving. The whitepaper section 6 was already corrected, but four places in the repo still contradicted it. This PR closes them out:

1. rips/rustchain-core/config/chain_params.py implemented an actual Bitcoin-style halving schedule (210,000 block interval, 4 halvings, tail emission) directly under a header that says Monetary Policy (RIP-0004). calculate_block_reward now returns the fixed 1.5 RTC at every height. Verified: same result at height 0 and height 10,000,000. The only caller is consensus/poa.py, which uses the function through its unchanged signature.

2. docs/WHAT_IF_RTC_FUNDAMENTALS.md hedged with whichever emission schedule governs (fixed 1.5 or halving). That conflict is resolved, so the hedge is gone and the dilution math now cites the fixed rate.

3. docs/index.html and website/static/classic.html said the vintage bonus lasts ~6.67 years before halving. That was wrong twice: the bonus never halves at 6.67 years, it decays 15% per chain-year (half at ~3.3 years) and reaches parity at ~6.67. New wording states the decay correctly.

No functional change to the deployed node, which already emits fixed 1.5 RTC per epoch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)