### PR TITLE
fix(hall-of-rust): recompute rust_score on re-attestation in the live node blueprint

### DIFF
--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -193,8 +193,11 @@ def induct_machine():
         c = conn.cursor()
         
         # Check if already inducted
-        c.execute("SELECT id, total_attestations FROM hall_of_rust WHERE fingerprint_hash = ?", 
-                  (fingerprint_hash,))
+        c.execute("""
+            SELECT id, total_attestations, manufacture_year, device_arch, device_model,
+                   thermal_events
+            FROM hall_of_rust WHERE fingerprint_hash = ?
+        """, (fingerprint_hash,))
         existing = c.fetchone()
         
         now = int(time.time())
@@ -209,19 +212,33 @@ def induct_machine():
         device_family = device_family or 'Unknown'
         
         if existing:
-            # Update attestation count
+            # Update attestation count. Attestation loyalty feeds calculate_rust_score,
+            # so the score has to be recomputed here too — otherwise it stays frozen at
+            # whatever it was on induction day and the leaderboard never reflects the
+            # attestations this machine has kept filing.
+            new_attestations = existing[1] + 1
+            rust_score = calculate_rust_score({
+                'manufacture_year': existing[2],
+                'device_arch': existing[3] or 'modern',
+                'device_model': existing[4] or '',
+                'total_attestations': new_attestations,
+                'thermal_events': existing[5] or 0,
+                'id': existing[0]
+            })
             c.execute("""
-                UPDATE hall_of_rust 
-                SET total_attestations = total_attestations + 1,
-                    last_attestation = ?
+                UPDATE hall_of_rust
+                SET total_attestations = ?,
+                    last_attestation = ?,
+                    rust_score = ?
                 WHERE fingerprint_hash = ?
-            """, (now, fingerprint_hash))
+            """, (new_attestations, now, rust_score, fingerprint_hash))
             conn.commit()
             conn.close()
             return jsonify({
-                'inducted': False, 
+                'inducted': False,
                 'message': 'Already in Hall of Rust',
-                'attestation_count': existing[1] + 1
+                'attestation_count': new_attestations,
+                'rust_score': rust_score
             })
         
         # New induction!

--- a/node/test_hall_of_rust_reattestation_score.py
+++ b/node/test_hall_of_rust_reattestation_score.py
@@ -1,0 +1,103 @@
+"""Re-attestation must refresh rust_score on the live Hall of Rust blueprint.
+
+calculate_rust_score() awards RUST_WEIGHTS['attestation_count'] per attestation, but
+the /hall/induct re-attestation branch used to bump total_attestations without ever
+writing the score back. The leaderboard sorts on rust_score, so a machine that kept
+attesting stayed pinned at its induction-day score forever.
+"""
+
+import os
+import sqlite3
+import sys
+import tempfile
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import hall_of_rust
+from hall_of_rust import RUST_WEIGHTS, hall_bp, init_hall_tables
+
+
+MACHINE = {
+    'device_model': 'PowerMac3,1',
+    'device_arch': 'g4',
+    'cpu_serial': 'XYZ-REATTEST-001',
+    'miner_id': 'miner-reattest',
+}
+
+
+@pytest.fixture
+def client():
+    fd, db_path = tempfile.mkstemp(suffix='.db')
+    os.close(fd)
+    init_hall_tables(db_path)
+
+    app = Flask(__name__)
+    app.config['DB_PATH'] = db_path
+    app.config['TESTING'] = True
+    app.register_blueprint(hall_bp)
+
+    with app.test_client() as c:
+        c.db_path = db_path
+        yield c
+
+    os.unlink(db_path)
+
+
+def _stored_score(db_path):
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute(
+            "SELECT rust_score, total_attestations FROM hall_of_rust"
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+def test_reattestation_refreshes_rust_score(client):
+    induct = client.post('/hall/induct', json=MACHINE).get_json()
+    assert induct['inducted'] is True
+    induction_score = induct['rust_score']
+
+    # Same machine attests four more times.
+    for _ in range(4):
+        again = client.post('/hall/induct', json=MACHINE).get_json()
+        assert again['inducted'] is False
+
+    score, attestations = _stored_score(client.db_path)
+    assert attestations == 5
+
+    expected = round(induction_score + 4 * RUST_WEIGHTS['attestation_count'], 2)
+    assert score == expected, (
+        f"rust_score frozen at induction value {induction_score} after 5 attestations "
+        f"(stored {score}, expected {expected})"
+    )
+
+
+def test_reattestation_response_reports_current_score(client):
+    client.post('/hall/induct', json=MACHINE)
+    again = client.post('/hall/induct', json=MACHINE).get_json()
+
+    stored_score, _ = _stored_score(client.db_path)
+    assert again['attestation_count'] == 2
+    assert again['rust_score'] == stored_score
+
+
+def test_induction_score_unchanged(client):
+    """First induction still scores exactly as before (no regression)."""
+    induct = client.post('/hall/induct', json=MACHINE).get_json()
+    expected = hall_of_rust.calculate_rust_score({
+        'manufacture_year': hall_of_rust.estimate_manufacture_year(
+            MACHINE['device_model'], MACHINE['device_arch']),
+        'device_arch': MACHINE['device_arch'],
+        'device_model': MACHINE['device_model'],
+        'total_attestations': 1,
+        'id': 1,
+    })
+    assert induct['rust_score'] == expected
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
### Follow-up to #7967 (live file)

On #7967 you noted the re-attestation score bug was fixed only in `explorer/hall_of_rust.py`, an unwired duplicate, while the copy the node actually registers — `node/hall_of_rust.py` — still had it on `/hall/induct`. This PR fixes the live one.

### Problem

`calculate_rust_score()` awards `RUST_WEIGHTS['attestation_count']` (0.1) per attestation, but the re-attestation branch only did:

```sql
UPDATE hall_of_rust SET total_attestations = total_attestations + 1, last_attestation = ? ...
```

`rust_score` was written exactly once, at induction. Every attestation after that incremented the counter the score is derived from without ever refreshing the score, so the loyalty weight sat frozen at its induction-day value for the machine's whole life. `/hall/leaderboard` sorts `ORDER BY rust_score DESC`, so a machine that has attested for months ranks identically to the day it was inducted.

### Fix

Recompute from the stored row on re-attestation and write it back, mirroring the new-induction path (which already builds a `machine` dict and calls `calculate_rust_score`). The re-attestation response now also returns `rust_score`, matching the induction response.

The `SELECT` is widened to pull the fields the scorer needs (`manufacture_year`, `device_arch`, `device_model`, `thermal_events`) instead of just `id, total_attestations`.

### Test — `node/test_hall_of_rust_reattestation_score.py`

Fails on current main, passes with the fix:

```
FAILED node/test_hall_of_rust_reattestation_score.py::test_reattestation_refreshes_rust_score
FAILED node/test_hall_of_rust_reattestation_score.py::test_reattestation_response_reports_current_score
2 failed, 1 passed
```

With the fix: `3 passed`. The third case (`test_induction_score_unchanged`) is a no-regression guard on the first-induction score — it passes on main *and* with the fix.

### Scope

Branched off clean current main, touches only `node/hall_of_rust.py` and the new test. Independent of #7969 (arch-bonus ordering in `calculate_rust_score`) — different function, no overlap; either can land first.

Re your consolidation note: there are three divergent copies of this scorer, and this makes two of them agree. Happy to do the consolidation as a separate PR if you want it.

RTC payout address: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7