### PR TITLE
fix(rip-200 v2): apply the modern_x86 loyalty bonus to epoch reward weight

### DIFF
--- a/node/rip_200_round_robin_1cpu1vote_v2.py
+++ b/node/rip_200_round_robin_1cpu1vote_v2.py
@@ -208,7 +208,8 @@ def get_device_multiplier(device_info: Dict, db_path: str = None, miner_id: str 
         return base + loyalty
 
 
-def get_time_aged_multiplier(device_arch: str, chain_age_years: float, device_info: Dict = None) -> float:
+def get_time_aged_multiplier(device_arch: str, chain_age_years: float, device_info: Dict = None,
+                             db_path: str = None, miner_id: str = None) -> float:
     """
     Calculate time-aged antiquity multiplier with decay
 
@@ -217,10 +218,12 @@ def get_time_aged_multiplier(device_arch: str, chain_age_years: float, device_in
     - Year 10: Significantly reduced
     - Year 16.67: Vintage bonus fully decayed to modern baseline
 
-    Modern x86 with loyalty bonus does NOT decay (reward for commitment)
+    Modern x86 with loyalty bonus does NOT decay (reward for commitment).
+    Pass db_path + miner_id so the modern-x86 loyalty bonus can be looked up;
+    without them the caller silently gets the un-loyal 0.1x base rate.
     """
     if device_info:
-        base_multiplier = get_device_multiplier(device_info)
+        base_multiplier = get_device_multiplier(device_info, db_path, miner_id)
     else:
         # Fallback to simple lookup
         base_multiplier = BASE_MULTIPLIERS.get(device_arch.lower(), 0.1)
@@ -230,7 +233,7 @@ def get_time_aged_multiplier(device_arch: str, chain_age_years: float, device_in
         return base_multiplier
 
     # Apple Silicon gets slight decay (it's modern hardware)
-    if device_arch.lower() in ["apple_silicon", "m1", "m2", "m3", "arm64_apple"]:
+    if (device_arch or "").lower() in ["apple_silicon", "m1", "m2", "m3", "arm64_apple"]:
         decay_rate = 0.05  # 5% per year (slower decay for premium)
     else:
         decay_rate = DECAY_RATE_PER_YEAR
@@ -336,8 +339,9 @@ def calculate_epoch_rewards_v2(
             "year": year or CURRENT_YEAR
         }
 
-        base_mult = get_device_multiplier(device_info, db_path, miner_id)
-        weight = get_time_aged_multiplier(arch, chain_age_years, device_info)
+        weight = get_time_aged_multiplier(
+            arch, chain_age_years, device_info, db_path, miner_id
+        )
 
         weighted_miners.append((miner_id, weight, device_info))
         total_weight += weight

--- a/tests/test_rip200_v2_loyalty_bonus_reward_weight.py
+++ b/tests/test_rip200_v2_loyalty_bonus_reward_weight.py
@@ -1,0 +1,139 @@
+"""Repro: RIP-200 v2 drops the modern_x86 loyalty bonus from reward weighting.
+
+Module docstring of rip_200_round_robin_1cpu1vote_v2.py states:
+    "Modern x86 (<5 years): Starts at 0.1x, earns 15%/year loyalty bonus"
+and __main__ prints "Loyalty bonuses do NOT decay (reward for commitment)".
+
+calculate_epoch_rewards_v2 computes the loyalty-aware multiplier into
+`base_mult` (passing db_path + miner_id) but then discards it, using
+`get_time_aged_multiplier(arch, chain_age_years, device_info)` instead --
+which internally calls get_device_multiplier(device_info) WITHOUT db_path /
+miner_id, so get_loyalty_bonus() is never reached and the weight collapses
+back to the 0.1 base rate.
+"""
+
+import importlib.util
+import os
+import sqlite3
+import sys
+import time
+
+import pytest
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SPEC = importlib.util.spec_from_file_location(
+    "rip200_v2", os.path.join(_REPO, "node", "rip_200_round_robin_1cpu1vote_v2.py")
+)
+rip200_v2 = importlib.util.module_from_spec(_SPEC)
+sys.modules["rip200_v2"] = rip200_v2
+_SPEC.loader.exec_module(rip200_v2)
+
+SECONDS_PER_YEAR = 365.25 * 24 * 3600
+
+
+def _make_db(path, miners):
+    """miners: list of (miner_id, arch, year, first_attest_ts)."""
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE miner_attest_recent ("
+        " miner TEXT, device_arch TEXT, device_family TEXT,"
+        " device_model TEXT, device_year INTEGER, ts_ok INTEGER)"
+    )
+    conn.execute("CREATE TABLE miner_attest_history (miner TEXT, ts_ok INTEGER)")
+
+    # Epoch 0 window, so attestations must land inside it.
+    epoch_ts = rip200_v2.GENESIS_TIMESTAMP + 100
+
+    for miner_id, arch, year, first_attest in miners:
+        conn.execute(
+            "INSERT INTO miner_attest_recent VALUES (?,?,?,?,?,?)",
+            (miner_id, arch, "", "", year, epoch_ts),
+        )
+        conn.execute(
+            "INSERT INTO miner_attest_history VALUES (?,?)", (miner_id, first_attest)
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_loyalty_bonus_is_honoured_in_epoch_reward_weight(tmp_path):
+    """A 4-year-loyal modern_x86 miner must out-earn a brand-new one."""
+    db = str(tmp_path / "chain.db")
+    now = int(time.time())
+
+    # veteran: first attested 4 years ago -> loyalty = 4 * 0.15 = 0.60
+    #          expected weight = 0.1 + 0.60 = 0.70
+    # rookie:  first attested today       -> loyalty ~ 0.0, weight = 0.1
+    _make_db(
+        db,
+        [
+            ("veteran", "modern_x86", 2023, now - int(4 * SECONDS_PER_YEAR)),
+            ("rookie", "modern_x86", 2023, now),
+        ],
+    )
+
+    # Sanity: the loyalty-aware path itself works when given db_path+miner_id.
+    veteran_mult = rip200_v2.get_device_multiplier(
+        {"arch": "modern_x86", "year": 2023}, db, "veteran"
+    )
+    assert veteran_mult == pytest.approx(0.70, abs=0.01), (
+        "precondition: get_device_multiplier must grant the loyalty bonus"
+    )
+
+    total_reward = 1_500_000  # uRTC
+    rewards = rip200_v2.calculate_epoch_rewards_v2(
+        db, epoch=0, total_reward_urtc=total_reward, current_slot=10
+    )
+
+    assert set(rewards) == {"veteran", "rookie"}
+    assert sum(rewards.values()) == total_reward
+
+    # weights 0.70 vs 0.10 -> veteran should receive 87.5% of the pot.
+    assert rewards["veteran"] > rewards["rookie"], (
+        "loyal miner must earn more than a brand-new miner, got "
+        f"veteran={rewards['veteran']} rookie={rewards['rookie']}"
+    )
+    assert rewards["veteran"] == pytest.approx(total_reward * 0.875, rel=0.01)
+    assert rewards["rookie"] == pytest.approx(total_reward * 0.125, rel=0.01)
+
+
+def test_vintage_weights_unchanged(tmp_path):
+    """No regression: PowerPC/vintage weighting must not shift.
+
+    A G4 has a fixed 2.5x base and takes the decay path; the loyalty lookup
+    must not touch it. Asserted against the decay formula through the public
+    reward path, so this holds both before and after the fix.
+    """
+    db = str(tmp_path / "chain.db")
+    now = int(time.time())
+    # The rookie has no loyalty history, so its weight is the flat 0.1 base
+    # either way -- isolating the G4 side of the split.
+    _make_db(db, [("g4box", "g4", 2003, now), ("rookie", "modern_x86", 2023, now)])
+
+    chain_age = rip200_v2.get_chain_age_years(10)
+    expected_g4 = 1.0 + 1.5 * (1 - rip200_v2.DECAY_RATE_PER_YEAR * chain_age)
+    expected_share = expected_g4 / (expected_g4 + 0.1)
+
+    total_reward = 1_000_000
+    rewards = rip200_v2.calculate_epoch_rewards_v2(
+        db, epoch=0, total_reward_urtc=total_reward, current_slot=10
+    )
+    assert rewards["g4box"] == pytest.approx(total_reward * expected_share, rel=0.01)
+
+
+def test_null_device_arch_does_not_crash(tmp_path):
+    """A loyal miner with a NULL device_arch column must still be weighted.
+
+    calculate_epoch_rewards_v2 passes the raw nullable `device_arch` column
+    through as `device_arch`. Once loyalty lifts the base above 0.1, the decay
+    branch reads `device_arch.lower()` for the first time, so a NULL arch has
+    to be tolerated there.
+    """
+    db = str(tmp_path / "chain.db")
+    now = int(time.time())
+    _make_db(db, [("nullarch", None, 2023, now - int(4 * SECONDS_PER_YEAR))])
+
+    rewards = rip200_v2.calculate_epoch_rewards_v2(
+        db, epoch=0, total_reward_urtc=1_000_000, current_slot=10
+    )
+    assert rewards == {"nullarch": 1_000_000}


### PR DESCRIPTION
### Wiring status first (so it's weighed correctly)

This fixes `node/rip_200_round_robin_1cpu1vote_v2.py`, which **nothing currently imports** — the live node (`node/rustchain_v2_integrated_v2.2.1_rip200.py`) and `node/claims_eligibility.py` both import the **v1** module, whose `get_time_aged_multiplier` has no loyalty concept at all. So this is not a live payout bug and no miner is losing RTC today; it's the v2 module failing its own documented contract before anyone wires it up. Flagging that up front rather than letting it ride under a scarier title.

### Problem

`calculate_epoch_rewards_v2` computes the loyalty-aware multiplier and then throws it away:

```python
base_mult = get_device_multiplier(device_info, db_path, miner_id)   # dead store
weight    = get_time_aged_multiplier(arch, chain_age_years, device_info)
```

`get_time_aged_multiplier` internally calls `get_device_multiplier(device_info)` **without** `db_path`/`miner_id`, so the `if db_path and miner_id:` guard is always false and `get_loyalty_bonus()` is unreachable from the reward path. Every `modern_x86` miner is weighted at the flat 0.1 base.

That contradicts the module's own docstring ("Modern x86 (<5 years): Starts at 0.1x, earns 15%/year loyalty bonus") and its `__main__` banner ("Loyalty bonuses do NOT decay"). The dead `base_mult` store is what convinced me this is an oversight and not a deliberate design choice — the intent to use the loyalty-aware value is right there.

Concretely: a miner with 4 years of attestation history should weigh 0.70 against a brand-new miner's 0.10 — 87.5% / 12.5% of the epoch. Instead both weigh 0.10 and split it **50/50**.

### Fix

Thread `db_path`/`miner_id` through `get_time_aged_multiplier` as optional args (default `None`, so every existing caller — including v1-style two-arg calls — is unaffected) and drop the dead store.

The `(device_arch or "")` hunk is load-bearing, not cosmetic: with loyalty applied, `base_multiplier` clears 0.1 and execution reaches `device_arch.lower()` for the first time. `calculate_epoch_rewards_v2` passes the raw nullable `device_arch` column, so without that guard the fix would introduce an `AttributeError` on NULL-arch miners. There's a test pinning it.

### Tests — `tests/test_rip200_v2_loyalty_bonus_reward_weight.py`

On current main:

```
FAILED test_loyalty_bonus_is_honoured_in_epoch_reward_weight
E   AssertionError: loyal miner must earn more than a brand-new miner, got veteran=750000 rookie=750000
1 failed, 2 passed
```

With the fix: `3 passed`.

The two that pass on main are deliberate no-regression guards, so they hold on both sides:
- `test_vintage_weights_unchanged` — a G4's decayed 2.5x weight is asserted against the decay formula through the public reward path; loyalty must not perturb it.
- `test_null_device_arch_does_not_crash` — covers the hunk above.

The failing test's precondition (`get_device_multiplier(..., db, "veteran") == 0.70`) passes on main, which is the proof that the loyalty machinery works and is simply never invoked.

Regression check: `tests/test_epoch_window_consistency.py`, `node/tests/test_time_aged_multiplier_penalty.py`, `node/tests/test_arch_multiplier_guard_t32.py` → **26 passed**.

RTC payout address: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7