### PR TITLE
fix(wrtc-price-bot): DexScreener parse always returns None (float / str divide)

### DIFF
--- a/tests/test_wrtc_price_bot_dexscreener.py
+++ b/tests/test_wrtc_price_bot_dexscreener.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: MIT
+"""Regression test: DexScreener returns numeric fields as JSON *strings*.
+
+fetch_dexscreener_price() must not blow up on them (and get_price() must not
+silently fall through to the Jupiter fallback as a result).
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "wrtc_price_bot" / "wrtc_price_bot.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("wrtc_price_bot_mod", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["wrtc_price_bot_mod"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class Response:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+# Exactly the shape api.dexscreener.com returns: every numeric field is a string.
+DEX_PAYLOAD = {
+    "pairs": [
+        {
+            "priceUsd": "0.25",
+            "priceNative": "0.002",
+            "priceChange": {"h24": "12.5"},
+            "liquidity": {"usd": "1500"},
+        }
+    ]
+}
+
+
+@pytest.fixture()
+def module(monkeypatch):
+    mod = load_module()
+    monkeypatch.setattr(mod.requests, "get", lambda url, timeout: Response(DEX_PAYLOAD))
+    return mod
+
+
+def test_dexscreener_parses_string_fields(module):
+    fetcher = module.PriceFetcher()
+    data = fetcher.fetch_dexscreener_price()
+
+    assert data is not None, "DexScreener parse returned None on a valid API payload"
+    assert data["price_usd"] == 0.25
+    assert data["price_sol"] == 0.002
+    assert data["change_24h"] == 12.5
+    assert data["liquidity"] == 1500.0
+    # 0.25 USD per wRTC / 0.002 SOL per wRTC == 125 USD per SOL
+    assert data["sol_price_usd"] == pytest.approx(125.0)
+
+
+def test_get_price_uses_dexscreener_not_jupiter_fallback(module):
+    fetcher = module.PriceFetcher()
+    data = fetcher.get_price()
+
+    assert data is not None
+    # The real bug's user-visible symptom: source silently degrades to jupiter,
+    # dropping 24h change / liquidity / SOL price to zero.
+    assert data["source"] == "dexscreener"
+    assert data["change_24h"] == 12.5
+    assert data["liquidity"] == 1500.0

--- a/wrtc_price_bot/wrtc_price_bot.py
+++ b/wrtc_price_bot/wrtc_price_bot.py
@@ -56,15 +56,19 @@ class PriceFetcher:
             if len(pairs) > 0:
                 pair = pairs[0]
                 price_usd = float(pair.get("priceUsd", 0))
+                # DexScreener returns numbers as strings, so priceNative has to be
+                # coerced before it can be divided by -- and "0" is truthy, so the
+                # zero check has to happen after the cast, not on the raw value.
+                price_sol = float(pair.get("priceNative", 0) or 0)
                 liquidity = float(pair.get("liquidity", {}).get("usd", 0))
                 change_24h = float(pair.get("priceChange", {}).get("h24", 0))
 
                 return {
                     "price_usd": price_usd,
-                    "price_sol": float(pair.get("priceNative", 0)),
+                    "price_sol": price_sol,
                     "change_24h": change_24h,
                     "liquidity": liquidity,
-                    "sol_price_usd": price_usd / pair.get("priceNative", 1) if pair.get("priceNative") else 0,
+                    "sol_price_usd": price_usd / price_sol if price_sol else 0,
                     "source": "dexscreener",
                 }
         except Exception as e:


### PR DESCRIPTION
### Problem

DexScreener returns every numeric field as a JSON string (`"priceUsd": "0.25"`, `"priceNative": "0.002"`) — which is exactly why every other field on the surrounding lines is wrapped in `float()`. One line divides the raw value:

```python
"sol_price_usd": price_usd / pair.get("priceNative", 1) if pair.get("priceNative") else 0,
```

`float / str` raises `TypeError`, the broad `except Exception` swallows it, and `fetch_dexscreener_price()` returns `None` on a **valid** API response. So the primary price source never returns anything, and `get_price()` silently degrades to the Jupiter fallback — which hardcodes `change_24h: 0`, `liquidity: 0`, `price_sol: 0`.

Downstream that means the bot reports "24h Change: +0.00%" and "Liquidity: N/A" permanently, and `check_price_alert()` can never fire, since every history entry carries an identical unchanged basis. It fails closed and logs nothing a user would read as an error.

That the sibling implementation in `bridge/dashboard_api.py:513-524` parses the same endpoint with `float()` on every field is what convinced me this is an oversight rather than intent.

### Fix

Cast `priceNative` once and reuse it. The `or 0` and the post-cast truthiness check also close a latent `ZeroDivisionError`: the string `"0"` is truthy, so the original guard would have let a zero-priced pair through to a divide-by-zero once the type issue was fixed.

### Test — `tests/test_wrtc_price_bot_dexscreener.py`

On current main (payload mirrors the real API shape, all-strings):

```
FAILED tests/test_wrtc_price_bot_dexscreener.py::test_dexscreener_parses_string_fields
FAILED tests/test_wrtc_price_bot_dexscreener.py::test_get_price_uses_dexscreener_not_jupiter_fallback
E   AssertionError: DexScreener parse returned None on a valid API payload
----------------------------- Captured stdout -----------------------------
[DexScreener API] Error: unsupported operand type(s) for /: 'float' and 'str'
2 failed
```

The captured stdout names the exact division. With the fix, these plus the existing `tests/test_wrtc_price_bot.py` and `wrtc_price_bot/test_price_fetch.py` → **6 passed**.

Branched off clean current main; touches only the bot and the new test.

RTC payout address: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7