### PR TITLE
fix(airdrop): same Base wallet can claim twice via EIP-55 checksum casing (anti-Sybil bypass)

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -66,6 +66,11 @@ MIN_ETH_BALANCE_WEI = int(0.01 * 1e18)  # 0.01 ETH
 MIN_WALLET_AGE_DAYS = 7
 MIN_GITHUB_AGE_DAYS = 30
 GITHUB_USERNAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+# EVM addresses are case-insensitive: mixed case is only an EIP-55 display
+# checksum over the same 20 bytes. Solana addresses are base58 and ARE
+# case-sensitive, so they must never be folded.
+EVM_ADDRESS_RE = re.compile(r"0x[0-9a-fA-F]{40}")
+EVM_CHAINS = frozenset({"base"})
 MAX_BRIDGE_ADDRESS_LENGTH = 128
 MAX_BRIDGE_TX_LENGTH = 256
 
@@ -322,6 +327,22 @@ class AirdropV2:
     def _is_valid_github_username(github_username: str) -> bool:
         return bool(GITHUB_USERNAME_RE.fullmatch(github_username))
 
+    @staticmethod
+    def _normalize_wallet_address(wallet_address: str, chain: str) -> str:
+        """Canonicalize a wallet address for uniqueness comparison.
+
+        EVM (Base) addresses are case-insensitive — the mixed-case form is
+        only an EIP-55 checksum over the same 20 bytes — so they are folded
+        to lowercase. Without this, the same Base wallet can claim the
+        airdrop once per casing variant, defeating the "one claim per
+        GitHub/wallet" anti-Sybil rule. Solana addresses are base58 and are
+        case-sensitive, so they are left byte-exact.
+        """
+        address = (wallet_address or "").strip()
+        if chain in EVM_CHAINS and EVM_ADDRESS_RE.fullmatch(address):
+            return address.lower()
+        return address
+
     def check_eligibility(
         self,
         github_username: str,
@@ -355,6 +376,7 @@ class AirdropV2:
                 eligible=False,
                 reason=f"Unsupported chain: {chain}. Must be 'solana' or 'base'",
             )
+        wallet_address = self._normalize_wallet_address(wallet_address, chain_lower)
 
         checks = {}
 
@@ -695,6 +717,7 @@ class AirdropV2:
     ) -> bool:
         """Check if a GitHub account or wallet already claimed an airdrop."""
         github_username = self._normalize_github_username(github_username)
+        wallet_address = self._normalize_wallet_address(wallet_address, chain)
         conn = self._get_conn()
         cursor = conn.cursor()
         cursor.execute(
@@ -794,6 +817,7 @@ class AirdropV2:
         if not self._is_valid_github_username(github_username):
             return False, "Invalid GitHub username", None
         chain_lower = chain.lower()
+        wallet_address = self._normalize_wallet_address(wallet_address, chain_lower)
 
         if self._has_claimed(github_username, wallet_address, chain_lower):
             return False, "Claim already exists for this GitHub account or wallet", None

--- a/node/tests/test_airdrop_evm_wallet_case_double_claim.py
+++ b/node/tests/test_airdrop_evm_wallet_case_double_claim.py
@@ -1,0 +1,99 @@
+"""Regression: the same Base (EVM) wallet must not claim the airdrop twice
+just by varying the address' EIP-55 checksum casing.
+
+EVM addresses are case-insensitive: the mixed-case form is only an EIP-55
+display checksum over the same 20 bytes. `_has_claimed` compares
+`wallet_address = ?` byte-exactly, so `0x5683...9c6` and `0x5683...9c6`
+lowercased are treated as two different wallets, defeating the
+"One claim per GitHub/wallet" anti-Sybil rule (RIP-305).
+
+Solana addresses are base58 and ARE case-sensitive, so they must keep
+byte-exact comparison.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from airdrop_v2 import AirdropV2  # noqa: E402
+
+# Real EIP-55 checksummed address (the project's own wRTC contract on Base).
+EVM_CHECKSUMMED = "0x5683C10596AaA09AD7F4eF13CAB94b9b74A669c6"
+EVM_LOWERCASE = EVM_CHECKSUMMED.lower()
+EVM_UPPERCASE = "0x" + EVM_CHECKSUMMED[2:].upper()
+
+
+@pytest.fixture
+def airdrop():
+    return AirdropV2(":memory:")
+
+
+def _claimed_uwrtc(airdrop, chain):
+    conn = airdrop._get_conn()
+    row = conn.execute(
+        "SELECT claimed_uwrtc FROM airdrop_allocation WHERE chain = ?", (chain,)
+    ).fetchone()
+    return row["claimed_uwrtc"]
+
+
+def test_same_base_wallet_different_checksum_case_rejected(airdrop):
+    """Same EVM wallet, different casing, different GitHub -> must be rejected."""
+    ok, msg, _ = airdrop.claim_airdrop(
+        github_username="alice",
+        wallet_address=EVM_CHECKSUMMED,
+        chain="base",
+        tier="core",
+        skip_antisybil=True,
+    )
+    assert ok, msg
+
+    ok2, msg2, _ = airdrop.claim_airdrop(
+        github_username="mallory",
+        wallet_address=EVM_LOWERCASE,
+        chain="base",
+        tier="core",
+        skip_antisybil=True,
+    )
+    assert not ok2, (
+        "same Base wallet claimed twice via checksum-case variation: "
+        f"{EVM_CHECKSUMMED} then {EVM_LOWERCASE}"
+    )
+
+    # 200 wRTC (core tier), not 400.
+    assert _claimed_uwrtc(airdrop, "base") == 200 * 1_000_000
+
+
+def test_same_base_wallet_uppercase_variant_rejected(airdrop):
+    ok, _, _ = airdrop.claim_airdrop(
+        "alice", EVM_LOWERCASE, "base", "core", skip_antisybil=True
+    )
+    assert ok
+    ok2, _, _ = airdrop.claim_airdrop(
+        "mallory", EVM_UPPERCASE, "base", "core", skip_antisybil=True
+    )
+    assert not ok2
+
+
+def test_has_claimed_matches_base_wallet_in_any_case(airdrop):
+    ok, _, _ = airdrop.claim_airdrop(
+        "alice", EVM_CHECKSUMMED, "base", "core", skip_antisybil=True
+    )
+    assert ok
+    assert airdrop._has_claimed("mallory", EVM_LOWERCASE, "base")
+    assert airdrop._has_claimed("mallory", EVM_UPPERCASE, "base")
+
+
+def test_solana_addresses_remain_case_sensitive(airdrop):
+    """Base58 Solana addresses are case-sensitive - must NOT be folded."""
+    addr_a = "7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK"
+    addr_b = "7eqqdeulxwcravx3mxkfjc84lhckmgzckrudpvcmwjek"  # different wallet
+    ok, _, _ = airdrop.claim_airdrop(
+        "alice", addr_a, "solana", "core", skip_antisybil=True
+    )
+    assert ok
+    ok2, msg2, _ = airdrop.claim_airdrop(
+        "mallory", addr_b, "solana", "core", skip_antisybil=True
+    )
+    assert ok2, f"distinct Solana wallet wrongly rejected: {msg2}"


### PR DESCRIPTION
### Problem

`_has_claimed` normalizes the GitHub username but compares the wallet byte-exactly:

```python
github_username = self._normalize_github_username(github_username)   # .strip().casefold()
...
AND (github_username = ? OR wallet_address = ?)
```

EVM addresses are case-insensitive — the mixed-case form is only an EIP-55 display checksum over the same 20 bytes. So `0x5683C105…9c6` and `0x5683c105…9c6` are **the same Base wallet**, but they read as two different ones. `UNIQUE(github_username, wallet_address, chain)` doesn't catch it either, since the stored strings genuinely differ.

Net effect: RIP-305's "One claim per wallet address" is bypassable on Base. N GitHub accounts can funnel N × 200 wRTC into a single wallet by varying only the casing. Reproduced: `claimed_uwrtc` for `base` reaches 400 wRTC for one wallet.

### Why this reads as an oversight rather than intent

The username *is* normalized on the very next line, and the suite already pins both symmetric halves of this rule — `test_duplicate_github_with_different_case_rejected` (case folding matters) and `test_duplicate_wallet_with_different_github_rejected` (wallet dedup matters). Only the wallet × case combination was never covered.

### Fix

A chain-aware `_normalize_wallet_address()`, applied at the three entry points (`check_eligibility`, `claim_airdrop`, `_has_claimed`):

```python
address = (wallet_address or "").strip()
if chain in EVM_CHAINS and EVM_ADDRESS_RE.fullmatch(address):
    return address.lower()
return address
```

**Solana is deliberately excluded**: base58 addresses are genuinely case-sensitive, and folding them would merge distinct wallets — a worse bug than the one being fixed. The regex fullmatch also means a non-EVM-shaped string on `base` is left untouched rather than silently mangled.

Only the comparison is canonicalized; this is not a migration. Any pre-existing mixed-case rows stay as they are — happy to add a backfill if you want the historical rows collapsed too.

### Tests — `node/tests/test_airdrop_evm_wallet_case_double_claim.py`

On current main:

```
FAILED test_same_base_wallet_different_checksum_case_rejected
FAILED test_same_base_wallet_uppercase_variant_rejected
FAILED test_has_claimed_matches_base_wallet_in_any_case
E   assert not True   # second claim on the same wallet succeeded
3 failed, 1 passed
```

With the fix: `4 passed`.

The one that passes on main is `test_solana_addresses_remain_case_sensitive`, the guard for the exclusion above — it must pass on both sides, and does.

Regression: `node/test_airdrop_v2.py`, `tests/test_airdrop_bridge_admin_auth.py`, `tests/test_airdrop_frontend_security.py` → **73 passed**.

### Separate issue, not fixed here

While in this file: `_determine_tier()` derives `total_prs` from `GET /search/commits?q=author:X merged:true` — that's a **commit** count across all of GitHub, not merged PRs, and not scoped to the org RIP-305 specifies (GitHub returns 200 and treats `merged:true` as free text; `author:torvalds` → `total_count: 74054`). So ~any user with 5 commits in their own repos maps to `CORE` = 200 wRTC. Left alone because the fix needs a product decision on repo/org scoping — flagging it rather than bundling it under this title. Happy to take it if you say how tiers should be scoped.

RTC payout address: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7