### PR TITLE
fix(arch_cross_validation): flat fingerprints lose all features and are scored as spoofed

### DIFF
--- a/node/arch_cross_validation.py
+++ b/node/arch_cross_validation.py
@@ -285,7 +285,11 @@ def extract_all_features(fingerprint: Dict) -> Dict[str, Any]:
     if isinstance(checks, dict):
         for check_name, check_value in checks.items():
             if isinstance(check_value, dict):
-                data = check_value.get("data", {})
+                # A wrapped check nests its payload under "data"; a flat check IS
+                # the payload (no "data" key). Fall back to the value itself so
+                # the flat-fingerprint branch above is not silently emptied —
+                # matching the X.get("data", X) pattern the extract_* helpers use.
+                data = check_value.get("data", check_value)
                 if isinstance(data, dict):
                     all_features[check_name] = data
             elif isinstance(check_value, bool):

--- a/node/test_arch_cross_validation.py
+++ b/node/test_arch_cross_validation.py
@@ -36,6 +36,31 @@ def test_g4_real_hardware():
     assert score >= 0.8, f"G4 real hardware scored too low: {score}"
     print(f"  G4 real hardware: PASS (score={score})")
 
+def test_g4_flat_fingerprint_not_flagged():
+    # Same legitimate G4 evidence as test_g4_real_hardware, but in the FLAT
+    # form (no "checks" wrapper, no per-check "data" key). extract_all_features
+    # explicitly supports this layout, so it must score identically to the
+    # wrapped form and NOT be falsely flagged as spoofed.
+    wrapped = {
+        "checks": {
+            "simd_identity": {"passed": True, "data": {"has_altivec": True, "has_sse": False, "has_neon": False, "simd_type": "altivec"}},
+            "clock_drift": {"passed": True, "data": {"cv": 0.05, "samples": 200}},
+            "cache_timing": {"passed": True, "data": {"latencies": {"4KB": {"random_ns": 1.0}, "32KB": {"random_ns": 2.0}, "256KB": {"random_ns": 5.0}, "1024KB": {"random_ns": 10.0}}, "tone_ratios": [2.0, 2.5, 2.0]}},
+            "thermal_drift": {"passed": True, "data": {"thermal_drift_pct": 5.0}}
+        }
+    }
+    flat = {
+        "simd_identity": {"has_altivec": True, "has_sse": False, "has_neon": False, "simd_type": "altivec"},
+        "clock_drift": {"cv": 0.05, "samples": 200},
+        "cache_timing": {"latencies": {"4KB": {"random_ns": 1.0}, "32KB": {"random_ns": 2.0}, "256KB": {"random_ns": 5.0}, "1024KB": {"random_ns": 10.0}}, "tone_ratios": [2.0, 2.5, 2.0]},
+        "thermal_drift": {"thermal_drift_pct": 5.0}
+    }
+    wrapped_score, _ = validate_arch_consistency(wrapped, "g4")
+    flat_score, _ = validate_arch_consistency(flat, "g4")
+    assert flat_score >= 0.8, f"flat G4 fingerprint falsely flagged: {flat_score}"
+    assert flat_score == wrapped_score, f"flat {flat_score} != wrapped {wrapped_score}"
+    print(f"  G4 flat fingerprint: PASS (score={flat_score})")
+
 def test_g4_x86_spoofing():
     fp = {
         "checks": {
@@ -128,6 +153,7 @@ if __name__ == "__main__":
     print("\n=== arch_cross_validation unit tests ===\n")
     test_normalize_arch()
     test_g4_real_hardware()
+    test_g4_flat_fingerprint_not_flagged()
     test_g4_x86_spoofing()
     test_modern_x86_real()
     test_apple_silicon_real()


### PR DESCRIPTION
## Bug

`extract_all_features()` in `node/arch_cross_validation.py` has an explicit branch for the **flat** fingerprint layout (no `checks` wrapper) — it collects the known check keys straight off the fingerprint:

```python
if not checks and isinstance(fingerprint, dict):
    checks = {k: v for k, v in fingerprint.items()
              if k in ("clock_drift", "cache_timing", "simd_identity", ...)}
```

But the loop that follows reads each check with `check_value.get("data", {})` — and a flat check **is** the payload; it has no `"data"` key. So every flat check resolves to `{}`, the feature map comes back empty, and that flat branch is silently dead code.

The four sibling helpers (`extract_simd_features`, `extract_clock_features`, `extract_cache_features`, `extract_thermal_features`) all already handle both shapes with `X.get("data", X)` — this one place doesn't.

## Impact

An identical, legitimate G4 fingerprint scores differently depending only on its shape:

| fingerprint form | score | `>= 0.70` threshold | verdict |
|---|---|---|---|
| wrapped (`checks` + `data`) | **1.0** | pass | consistent |
| flat (same evidence) | **0.69** | **fail** | `SUSPICIOUS: significant arch mismatch` |

0.69 lands just under `ARCH_VALIDATION_SCORE_THRESHOLD = 0.70` in `fleet_immune_system.py`, so the decision actually flips: `passed=False` → `validated_bucket = "modern"` → the vintage miner loses the arch bonus it earned. Real hardware gets treated as a spoofer.

**Scope, stated honestly:** `run_and_store_arch_validation()` is reached via `fleet_immune_system`, whose own docstring says it "must be called from the attestation submission flow" — so as of this commit the hook isn't yet wired into the node's submit path. This is a latent correctness bug in the validation library, not live reward loss today. I'm not inflating it beyond that.

## Fix

One line — use the same `X.get("data", X)` fallback the sibling extractors use, so a flat check falls back to itself instead of emptying the branch.

## Verification

- `node/test_arch_cross_validation.py` — added `test_g4_flat_fingerprint_not_flagged`, asserting the flat form scores `>= 0.8` **and** equals the wrapped score.
  - **Fails on clean main:** `AssertionError: flat G4 fingerprint falsely flagged: 0.69`
  - **Passes with fix** (flat == wrapped == 1.0)
- Full `test_arch_cross_validation.py` suite green — including `test_g4_x86_spoofing`, confirming spoof detection is **not** weakened (a spoofed fingerprint still scores low).
- `tests/test_bucket_spoof_fix.py` (the dependent bucket/spoof suite): 6 passed.

Verified against `upstream/main` @ `96660f06`.

---
RTC: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
