### PR TITLE
fix(bridge-federation): /bridge/events window keyed on creation hides completions and voids of older transfers

### DIFF
--- a/node/bridge_federation_routes.py
+++ b/node/bridge_federation_routes.py
@@ -45,6 +45,12 @@ MAX_TRANSFERS_LIMIT = 200
 DEFAULT_EVENTS_WINDOW_SECONDS = 24 * 3600
 MAX_EVENTS_WINDOW_SECONDS = 30 * 24 * 3600
 
+# When a transfer last changed state. `created_at` alone is only the moment the
+# transfer was opened; a confirm/complete/void stamps `updated_at` (and
+# `completed_at`) later, so the latest of the three is the event time. One
+# definition, shared by the aggregate and the event feed.
+EVENT_AT_SQL = "max(updated_at, COALESCE(completed_at, 0), created_at)"
+
 
 def _get_db_path() -> str:
     """Resolve DB_PATH the same way bridge_api.py does."""
@@ -112,9 +118,7 @@ def _aggregate_bridge_state(conn: sqlite3.Connection) -> Dict[str, Any]:
     # Per-row max of updated_at / completed_at / created_at so a later status
     # change (confirm, complete, void) is not masked by an older value.
     last_event = cursor.execute(
-        "SELECT COALESCE(MAX("
-        "max(updated_at, COALESCE(completed_at, 0), created_at)"
-        "), 0) FROM bridge_transfers"
+        f"SELECT COALESCE(MAX({EVENT_AT_SQL}), 0) FROM bridge_transfers"
     ).fetchone()  # fetchall-ok: pragma-result (single MAX)
     last_event_at = int(last_event[0]) if last_event else 0
 
@@ -132,6 +136,12 @@ def _aggregate_bridge_state(conn: sqlite3.Connection) -> Dict[str, Any]:
 def _recent_events(conn: sqlite3.Connection, limit: int, window_seconds: int) -> List[Dict[str, Any]]:
     """List recent bridge state-change events, public-safe fields only.
 
+    The window is keyed on when the transfer last CHANGED STATE (`event_at`),
+    not on when it was opened. A long-lived lock that completes or is voided
+    today is an event today, even though it was created last week; keying on
+    `created_at` hid exactly those from the feed while `/bridge/state` counted
+    them in `last_event_at`.
+
     Returns a list of dicts of the form:
 
         {
@@ -143,7 +153,8 @@ def _recent_events(conn: sqlite3.Connection, limit: int, window_seconds: int) ->
             "status": ...,
             "external_confirmations": ...,
             "required_confirmations": ...,
-            "created_at": ...,
+            "created_at": <when the transfer was opened>,
+            "event_at": <when it last changed state; == created_at if untouched>,
         }
 
     Sensitive fields explicitly NOT exposed:
@@ -156,13 +167,14 @@ def _recent_events(conn: sqlite3.Connection, limit: int, window_seconds: int) ->
     cutoff = int(time.time()) - max(0, window_seconds)
     cursor = conn.cursor()
     cursor.execute(
-        """
+        f"""
         SELECT tx_hash, direction, source_chain, dest_chain,
                amount_rtc, status, external_confirmations,
-               required_confirmations, created_at
+               required_confirmations, created_at,
+               {EVENT_AT_SQL} AS event_at
         FROM bridge_transfers
-        WHERE created_at >= ?
-        ORDER BY created_at DESC, id DESC
+        WHERE {EVENT_AT_SQL} >= ?
+        ORDER BY event_at DESC, id DESC
         LIMIT ?
         """,
         (cutoff, limit),
@@ -179,6 +191,7 @@ def _recent_events(conn: sqlite3.Connection, limit: int, window_seconds: int) ->
             "external_confirmations": int(r[6]) if r[6] is not None else 0,
             "required_confirmations": int(r[7]) if r[7] is not None else 0,
             "created_at": int(r[8]),
+            "event_at": int(r[9]),
         }
         for r in rows
     ]
@@ -360,6 +373,7 @@ __all__ = [
     "_recent_events",
     "_recent_transfers_public",
     "PUBLIC_STATUS_VALUES",
+    "EVENT_AT_SQL",
     "DEFAULT_EVENTS_LIMIT",
     "MAX_EVENTS_LIMIT",
     "DEFAULT_EVENTS_WINDOW_SECONDS",

--- a/node/tests/test_bridge_federation_routes.py
+++ b/node/tests/test_bridge_federation_routes.py
@@ -70,7 +70,12 @@ def _seed(db_path, rows):
                 "status": row.get("status", "pending"),
                 "lock_epoch": row.get("lock_epoch", 1),
                 "created_at": row.get("created_at", now - i),
-                "updated_at": row.get("updated_at", now - i),
+                # A transfer that has never changed state carries
+                # updated_at == created_at (bridge_api stamps both with the
+                # same `now` on insert). Defaulting updated_at to "now"
+                # regardless of created_at describes a row that just changed
+                # state, which is not what these fixtures mean by an old row.
+                "updated_at": row.get("updated_at", row.get("created_at", now - i)),
                 "tx_hash": row.get("tx_hash", f"hash_{i}"),
                 "completed_at": row.get("completed_at"),
             }
@@ -238,6 +243,63 @@ def test_events_window_seconds_clamps_old_rows(client, db_path):
     ])
     body = client.get("/bridge/events?window_seconds=100").get_json()
     assert [e["tx_hash"] for e in body["events"]] == ["recent"]
+
+
+def test_events_includes_transfer_created_before_window_but_completed_inside_it(client, db_path):
+    """A long-lived lock that completes today is an event today.
+
+    Keying the window on created_at hid it: /bridge/state counted the
+    completion in last_event_at while /bridge/events reported nothing.
+    """
+    base = int(time.time())
+    _seed(db_path, [{
+        "created_at": base - 25 * 3600,   # opened outside the 24h window
+        "updated_at": base - 60,          # completed one minute ago
+        "completed_at": base - 60,
+        "status": "completed",
+        "tx_hash": "long_lived_lock_just_completed",
+    }])
+
+    body = client.get("/bridge/events").get_json()
+    assert [e["tx_hash"] for e in body["events"]] == ["long_lived_lock_just_completed"]
+
+    # and the two public surfaces now agree about when that event happened
+    state = client.get("/bridge/state").get_json()["state"]
+    assert body["events"][0]["event_at"] == state["last_event_at"] == base - 60
+    assert body["events"][0]["created_at"] == base - 25 * 3600
+
+
+def test_events_excludes_transfer_whose_state_change_is_outside_the_window(client, db_path):
+    """The window still clamps: an old row that has not changed state stays out."""
+    base = int(time.time())
+    _seed(db_path, [
+        {"created_at": base - 10_000, "updated_at": base - 10_000, "tx_hash": "stale"},
+        {"created_at": base - 10_000, "updated_at": base - 10, "status": "voided",
+         "tx_hash": "voided_just_now"},
+    ])
+    body = client.get("/bridge/events?window_seconds=100").get_json()
+    assert [e["tx_hash"] for e in body["events"]] == ["voided_just_now"]
+
+
+def test_events_ordered_by_state_change_not_creation(client, db_path):
+    base = int(time.time())
+    _seed(db_path, [
+        {"created_at": base - 10, "updated_at": base - 10, "tx_hash": "created_last_still_pending"},
+        {"created_at": base - 900, "updated_at": base - 5, "completed_at": base - 5,
+         "status": "completed", "tx_hash": "created_first_completed_last"},
+    ])
+    body = client.get("/bridge/events").get_json()
+    assert [e["tx_hash"] for e in body["events"]] == [
+        "created_first_completed_last",
+        "created_last_still_pending",
+    ]
+
+
+def test_events_event_at_equals_created_at_for_untouched_transfer(client, db_path):
+    base = int(time.time())
+    _seed(db_path, [{"created_at": base - 30, "updated_at": base - 30, "tx_hash": "untouched"}])
+    e = client.get("/bridge/events").get_json()["events"][0]
+    assert e["event_at"] == e["created_at"] == base - 30
 
 
 def test_events_limit_clamped_to_max(client, db_path):


### PR DESCRIPTION
### Problem

`_recent_events` backs the public `/bridge/events` feed, documented as "recent bridge state-change **events**". It keys the window on `created_at`:

```python
cutoff = int(time.time()) - max(0, window_seconds)
...
WHERE created_at >= ?
ORDER BY created_at DESC, id DESC
```

But `created_at` is only the moment the transfer was *opened*. A confirm/complete stamps `updated_at` + `completed_at` (`bridge_api.py:809-815`), a void stamps `updated_at` (`bridge_api.py:672-677`) — days later, potentially. So a long-lived lock that completes today is an event today, and the feed does not show it.

The sibling function in the same file already gets this right, deliberately:

```python
# last_event_at: most recent state-change timestamp across all transfers.
# Per-row max of updated_at / completed_at / created_at so a later status
# change (confirm, complete, void) is not masked by an older value.
```

So the two public surfaces contradict each other. Reproduced against a DB built from the real `bridge_transfers` schema — one transfer, created 25h ago, completed 60s ago:

```
/bridge/state  -> last_event_at is 60s ago   (an event JUST happened)
/bridge/events -> events: [], count = 0      (default 24h window)
```

This is the case reconciliation actually cares about: a federation reconciler polling `/bridge/events?window_seconds=3600` sees newly-opened transfers only, never the completions and voids of older ones — the very state changes it needs to compare against the other side (§6.4).

### Why this reads as an oversight rather than intent

`last_event_at` in this same module defines an event as the max of the three timestamps, with a comment explaining why, and four tests pin that (`test_state_last_event_at_uses_updated_when_newer_than_created`, `..._uses_completed_when_newer_than_updated`, `..._picks_row_with_latest_state_change`). The event *feed* just never got the same treatment — no test seeds a transfer whose `updated_at` differs from its `created_at`, so the gap was invisible.

### Fix

One shared definition of event time, replacing the aggregate's inline copy:

```python
EVENT_AT_SQL = "max(updated_at, COALESCE(completed_at, 0), created_at)"
```

`_recent_events` now filters, orders and reports on it. `event_at` is exposed **alongside** `created_at` (nothing removed), so a consumer can distinguish when a transfer was opened from when it last moved. Untouched rows have `event_at == created_at`, so their behaviour is unchanged.

Scoped to the event feed: `/bridge/transfers/recent` is a transfer listing, not an event feed, so its `created_at` ordering is left alone. No writes, no schema change.

### On the one fixture line I touched

`_seed` defaulted `updated_at` to `now - i` **independently of** `created_at`, so a row seeded as "created 10,000s ago" silently claimed it had changed state *this second*. `bridge_api` stamps `created_at` and `updated_at` with the same `now` on insert (`bridge_api.py:449-451`), so that combination cannot occur for an untouched transfer. The default is now `row.get("updated_at", created_at)`.

Worth being explicit, since changing a fixture to make a fix pass deserves scrutiny: **it doesn't here.** No existing assertion changed, and all 22 pre-existing tests pass against unpatched `main` with the new fixture default — so the fixture change is behaviour-neutral on its own. It was masking, not asserting: those tests passed only because the endpoint ignored `updated_at`.

### Tests

Four added, all failing on `main`, passing here:

- `test_events_includes_transfer_created_before_window_but_completed_inside_it` — the headline case; also asserts `/bridge/events` and `/bridge/state` now agree on when it happened.
- `test_events_excludes_transfer_whose_state_change_is_outside_the_window` — the window still clamps; an old row that never moved stays out.
- `test_events_ordered_by_state_change_not_creation`
- `test_events_event_at_equals_created_at_for_untouched_transfer`

`node/tests/test_bridge_federation_routes.py` 26 passed. Neighbouring `test_bridge_api.py` + `test_bridge_reconciliation.py` green except two pre-existing `TestValidateChainAddressFormat` failures that reproduce identically on clean `main` (address-format validation, unrelated to this file).

### Severity, honestly

Read-only reporting bug on public endpoints — no funds move, no auth surface, nothing mis-settles. Blast radius is the federation reconciliation view on the live node (`register_federation_routes`, wired at `rustchain_v2_integrated_v2.2.1_rip200.py:162`). It matters because it's a reconciliation surface whose whole job is showing state changes, and it was silently disagreeing with `/bridge/state`.

RTC: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
