### PR TITLE
fix(bridge): public bridge + reconciliation routes ignore RUSTCHAIN_DB_PATH and read the wrong database

### DIFF
--- a/node/bridge_federation_routes.py
+++ b/node/bridge_federation_routes.py
@@ -47,8 +47,19 @@ MAX_EVENTS_WINDOW_SECONDS = 30 * 24 * 3600
 
 
 def _get_db_path() -> str:
-    """Resolve DB_PATH the same way bridge_api.py does."""
-    return os.environ.get("DB_PATH", "rustchain_v2.db")
+    """Resolve the DB path exactly as the node does.
+
+    `bridge_api.py` gets this right by importing DB_PATH from the node module,
+    which resolves `RUSTCHAIN_DB_PATH` first — and that is the variable the
+    operator docs tell you to set (NODE_OPERATOR_GUIDE.md, DEVNET.md).
+    Honouring only DB_PATH here made these public read routes open a different
+    file than the one the bridge writes to.
+    """
+    return (
+        os.environ.get("RUSTCHAIN_DB_PATH")
+        or os.environ.get("DB_PATH")
+        or "rustchain_v2.db"
+    )
 
 
 def _parse_int_arg(value: Optional[str], default: int, min_value: int, max_value: int) -> int:

--- a/node/bridge_reconciliation.py
+++ b/node/bridge_reconciliation.py
@@ -77,7 +77,19 @@ MAX_RECENT_LIMIT = 200
 
 
 def _get_db_path() -> str:
-    return os.environ.get("DB_PATH", "rustchain_v2.db")
+    """Resolve the DB path exactly as the node does.
+
+    The node reads `RUSTCHAIN_DB_PATH` first (rustchain_v2_integrated: DB_PATH
+    = RUSTCHAIN_DB_PATH or DB_PATH or "./rustchain_v2.db"), and that is the
+    variable the operator docs tell you to set (NODE_OPERATOR_GUIDE.md,
+    DEVNET.md). Honouring only DB_PATH here made these read routes open a
+    different file than the one `record_reconciliation_snapshot` writes to.
+    """
+    return (
+        os.environ.get("RUSTCHAIN_DB_PATH")
+        or os.environ.get("DB_PATH")
+        or "rustchain_v2.db"
+    )
 
 
 def init_reconciliation_schema(cursor: sqlite3.Cursor) -> None:

--- a/node/tests/test_bridge_federation_routes.py
+++ b/node/tests/test_bridge_federation_routes.py
@@ -29,6 +29,7 @@ def db_path(tmp_path, monkeypatch):
         ba.init_bridge_schema(conn.cursor())
         conn.commit()
     monkeypatch.setenv("DB_PATH", str(p))
+    monkeypatch.delenv("RUSTCHAIN_DB_PATH", raising=False)
     return str(p)
 
 
@@ -347,3 +348,54 @@ def test_routes_ignore_admin_key_when_present(client, db_path):
     for path in ("/bridge/state", "/bridge/events", "/bridge/transfers/recent"):
         resp = client.get(path, headers=headers)
         assert resp.status_code == 200
+
+
+# ---------- DB path resolution ----------------------------------------------
+
+
+def test_get_db_path_prefers_rustchain_db_path(monkeypatch):
+    """The node resolves RUSTCHAIN_DB_PATH first; these routes must agree.
+
+    docs/DEVNET.md and docs/NODE_OPERATOR_GUIDE.md tell the operator to set
+    RUSTCHAIN_DB_PATH. Reading only DB_PATH opened a different file than the
+    bridge writes to.
+    """
+    monkeypatch.setenv("RUSTCHAIN_DB_PATH", "/tmp/node_real.db")
+    monkeypatch.delenv("DB_PATH", raising=False)
+    assert fed._get_db_path() == "/tmp/node_real.db"
+
+
+def test_get_db_path_rustchain_wins_over_db_path(monkeypatch):
+    """Same precedence as the node, which ORs them in this order."""
+    monkeypatch.setenv("RUSTCHAIN_DB_PATH", "/tmp/node_real.db")
+    monkeypatch.setenv("DB_PATH", "/tmp/other.db")
+    assert fed._get_db_path() == "/tmp/node_real.db"
+
+
+def test_get_db_path_falls_back_to_db_path_then_default(monkeypatch):
+    monkeypatch.delenv("RUSTCHAIN_DB_PATH", raising=False)
+    monkeypatch.setenv("DB_PATH", "/tmp/only_db_path.db")
+    assert fed._get_db_path() == "/tmp/only_db_path.db"
+    monkeypatch.delenv("DB_PATH", raising=False)
+    assert fed._get_db_path() == "rustchain_v2.db"
+
+
+def test_routes_read_the_db_the_operator_configured(tmp_path, monkeypatch):
+    """End-to-end: operator sets RUSTCHAIN_DB_PATH only, as the docs say."""
+    p = tmp_path / "devnet.db"
+    with sqlite3.connect(p) as conn:
+        ba.init_bridge_schema(conn.cursor())
+        conn.commit()
+    monkeypatch.setenv("RUSTCHAIN_DB_PATH", str(p))
+    monkeypatch.delenv("DB_PATH", raising=False)
+    _seed(str(p), [{"tx_hash": "real_transfer", "amount_rtc": 4.0, "status": "locked"}])
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    fed.register_federation_routes(app)
+    client = app.test_client()
+
+    resp = client.get("/bridge/state")
+    assert resp.status_code == 200
+    assert resp.get_json()["state"]["by_status"]["locked"]["total_rtc"] == 4.0
+    assert [e["tx_hash"] for e in client.get("/bridge/events").get_json()["events"]] == ["real_transfer"]

--- a/node/tests/test_bridge_reconciliation.py
+++ b/node/tests/test_bridge_reconciliation.py
@@ -27,6 +27,7 @@ def db_path(tmp_path, monkeypatch):
         rec.init_reconciliation_schema(conn.cursor())
         conn.commit()
     monkeypatch.setenv("DB_PATH", str(p))
+    monkeypatch.delenv("RUSTCHAIN_DB_PATH", raising=False)
     return str(p)
 
 
@@ -286,3 +287,36 @@ def test_schema_has_unique_epoch_constraint(db_path):
                 "voided_in_rtc, bridged_supply_committed, state_hash"
                 ") VALUES (1, 0, 0.0, 0.0, 0.0, 0.0, 'x')"
             )
+
+
+# ---------- DB path resolution ----------------------------------------------
+
+
+def test_get_db_path_prefers_rustchain_db_path(monkeypatch):
+    """Snapshots are written to the node's DB (RUSTCHAIN_DB_PATH); the read
+    routes must open that same file, not ./rustchain_v2.db."""
+    monkeypatch.setenv("RUSTCHAIN_DB_PATH", "/tmp/node_real.db")
+    monkeypatch.delenv("DB_PATH", raising=False)
+    assert rec._get_db_path() == "/tmp/node_real.db"
+
+
+def test_reconciliation_routes_read_the_db_the_operator_configured(tmp_path, monkeypatch):
+    """Write a snapshot the way POST /rewards/settle does, then read it back
+    over HTTP with only RUSTCHAIN_DB_PATH set, as docs/DEVNET.md instructs."""
+    p = tmp_path / "devnet.db"
+    with sqlite3.connect(p) as conn:
+        ba.init_bridge_schema(conn.cursor())
+        rec.init_reconciliation_schema(conn.cursor())
+        conn.commit()
+        rec.record_reconciliation_snapshot(conn, epoch=7)
+        conn.commit()
+    monkeypatch.setenv("RUSTCHAIN_DB_PATH", str(p))
+    monkeypatch.delenv("DB_PATH", raising=False)
+
+    a = Flask(__name__)
+    a.config["TESTING"] = True
+    rec.register_reconciliation_routes(a)
+    resp = a.test_client().get("/bridge/reconciliation/latest")
+
+    assert resp.status_code == 200
+    assert resp.get_json()["snapshot"]["epoch"] == 7


### PR DESCRIPTION
### Problem

The node resolves its database once, honouring `RUSTCHAIN_DB_PATH` first:

```python
# rustchain_v2_integrated_v2.2.1_rip200.py:1422
DB_PATH = os.environ.get("RUSTCHAIN_DB_PATH") or os.environ.get("DB_PATH") or "./rustchain_v2.db"
```

That is also the variable the docs tell operators to set — `docs/NODE_OPERATOR_GUIDE.md:174` lists `RUSTCHAIN_DB_PATH` as *the* database-path variable, and `docs/DEVNET.md:31` is literally `export RUSTCHAIN_DB_PATH=.dev/rustchain-devnet.db`.

Two route modules resolve it themselves, and read only `DB_PATH`:

```python
# node/bridge_federation_routes.py:51  and  node/bridge_reconciliation.py:80
return os.environ.get("DB_PATH", "rustchain_v2.db")
```

So for an operator who followed the docs, the **write** path and the **read** path point at different files. The bridge writes transfers, and `record_reconciliation_snapshot` writes snapshots, into `$RUSTCHAIN_DB_PATH`; these six public routes open `./rustchain_v2.db` — sqlite happily creates it, empty, in the working directory, and every route then 503s on the missing table.

Reproduced with `RUSTCHAIN_DB_PATH` set and `DB_PATH` unset, exactly per DEVNET.md, against the real module:

```
node's DB (RUSTCHAIN_DB_PATH) holds: (1, 4.0)      # one locked transfer, 4 RTC
route resolves DB path -> rustchain_v2.db
GET /bridge/state -> 503 {'error': 'db_error: OperationalError', 'ok': False}
stray empty db created in cwd: True
```

Affected: `/bridge/state`, `/bridge/events`, `/bridge/transfers/recent`, `/bridge/reconciliation/latest`, `/bridge/reconciliation/by_epoch/<n>`, `/bridge/reconciliation/recent`.

### Why this reads as an oversight rather than intent

The docstring on the federation copy says:

```python
"""Resolve DB_PATH the same way bridge_api.py does."""
```

but `bridge_api.py:31-39` does the opposite of this — it *imports* `DB_PATH` from the node module (so it inherits the `RUSTCHAIN_DB_PATH` resolution for free) and only falls back to an env var when running standalone. The intent was clearly to match the node; the implementation just didn't.

Corroboration: `testnet/deploy_testnet.sh:141-142` sets **both** `RUSTCHAIN_DB_PATH` and `DB_PATH` to the same value. That works, but it is a workaround for this defect — the operator guide does not ask for both, and nothing else in the tree needs `DB_PATH`.

### Fix

Both copies now mirror the node's resolution order, with a comment saying so instead of pointing at `bridge_api.py`:

```python
return (
    os.environ.get("RUSTCHAIN_DB_PATH")
    or os.environ.get("DB_PATH")
    or "rustchain_v2.db"
)
```

`DB_PATH`-only deployments are unaffected — it stays in the chain, one rung lower, exactly as in the node. No schema change, no writes, no route behaviour change beyond opening the right file.

I kept the resolver local to each module rather than hoisting it into a shared helper: the two are sibling route modules, and importing one from the other to share three lines seemed worse than the duplication. Happy to hoist it if you'd prefer a single definition.

### Tests

Six added, five failing on `main`:

- `test_get_db_path_prefers_rustchain_db_path` (both modules) — fails on main.
- `test_get_db_path_rustchain_wins_over_db_path` — pins the node's precedence. Fails on main.
- `test_routes_read_the_db_the_operator_configured` — end-to-end: seed a transfer, set only `RUSTCHAIN_DB_PATH`, assert `/bridge/state` and `/bridge/events` return it. Fails on main with 503.
- `test_reconciliation_routes_read_the_db_the_operator_configured` — writes a snapshot the way `POST /rewards/settle` does, reads it back over HTTP. Fails on main with 503.
- `test_get_db_path_falls_back_to_db_path_then_default` — passes on main too; it pins the existing behaviour so the fallback can't regress later.

Both fixtures now `delenv("RUSTCHAIN_DB_PATH")`, so a developer who has it exported doesn't get mysterious cross-talk.

`test_bridge_federation_routes.py` 43 passed, `test_bridge_reconciliation.py` 19 passed. The two `TestValidateChainAddressFormat` failures in `test_bridge_api.py` reproduce identically on clean `main` (address-format validation, unrelated).

### Severity, honestly

Config-dependent and read-only: it needs `RUSTCHAIN_DB_PATH` set without `DB_PATH`, and no funds or settlement are touched — snapshots are still written correctly, they just become unreadable over HTTP. The reason I don't think it's "just config" is that the config in question is the one the operator guide documents, while the undocumented one is what the code requires.

Kept separate from #7977 (event-time windowing), which touches the same file but is a different concern.

RTC: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
