### PR TITLE
fix(adm): settled=1 committed while paying zero rewards burns the epoch permanently

### DIFF
--- a/node/anti_double_mining.py
+++ b/node/anti_double_mining.py
@@ -674,6 +674,7 @@ def settle_epoch_with_anti_double_mining(
         # We use an UPDATE that only succeeds if settled is currently 0.
         # This prevents the race condition.
         res = db.execute("UPDATE epoch_state SET settled = 1, settled_ts = ? WHERE epoch = ? AND settled = 0", (int(time.time()), epoch))
+        claimed = res.rowcount > 0
         if res.rowcount == 0:
             # If no row was updated, it was either already settled or doesn't exist
             st = db.execute("SELECT settled FROM epoch_state WHERE epoch=?", (epoch,)).fetchone()
@@ -698,6 +699,19 @@ def settle_epoch_with_anti_double_mining(
         if not rewards:
             if own_conn:
                 db.rollback()
+            elif claimed:
+                # Shared connection: the caller owns the transaction and commits
+                # on return (see settle_epoch_rip200), so `own_conn`-gated rollback
+                # never runs and the claim above would be committed despite paying
+                # nothing — burning the epoch's emission and making every retry
+                # answer already_settled. Rolling back is not ours to do here, so
+                # undo only our own claim and leave the epoch retryable. This
+                # matches the standard path, which rolls back before returning the
+                # same error.
+                db.execute(
+                    "UPDATE epoch_state SET settled = 0, settled_ts = NULL WHERE epoch = ?",
+                    (epoch,)
+                )
             return {"ok": False, "error": "no_eligible_miners", "epoch": epoch}
 
         # Credit rewards to miners

--- a/node/tests/test_adm_no_eligible_miners_burns_epoch.py
+++ b/node/tests/test_adm_no_eligible_miners_burns_epoch.py
@@ -1,0 +1,109 @@
+"""Regression: ADM must not leave `settled=1` committed when it pays nothing.
+
+`settle_epoch_with_anti_double_mining` claims settlement (`UPDATE epoch_state SET
+settled = 1`) BEFORE it knows whether any miner is eligible. Its `no_eligible_miners`
+exit undoes that claim only `if own_conn` — but the live caller
+(`rewards_implementation_rip200.settle_epoch_rip200`) always passes `existing_conn=db`
+and then commits unconditionally, so the flag is durably committed while zero rewards
+are written. The epoch's whole PER_EPOCH_URTC is never distributed and every retry is
+answered `already_settled`.
+
+The standard (non-ADM) path in the same caller does an ungated `db.rollback()` before
+returning `no_eligible_miners`, which is the intended behaviour these tests pin.
+"""
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if NODE_DIR not in sys.path:
+    sys.path.insert(0, NODE_DIR)
+
+import rewards_implementation_rip200 as rmod
+
+
+def _db_with_only_ineligible_miner(epoch=1):
+    """Enrolled miner whose attestation failed -> zero weight -> rewards == {}."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    c = sqlite3.connect(path)
+    c.execute("CREATE TABLE epoch_state (epoch INTEGER PRIMARY KEY, settled INTEGER DEFAULT 0, settled_ts INTEGER)")
+    c.execute("CREATE TABLE epoch_enroll (epoch INTEGER, miner_pk TEXT, weight INTEGER DEFAULT 100)")
+    c.execute("CREATE TABLE miner_attest_recent (miner TEXT PRIMARY KEY, device_arch TEXT, ts_ok INTEGER, "
+              "fingerprint_passed INTEGER DEFAULT 1, entropy_score REAL, fingerprint_checks_json TEXT)")
+    c.execute("CREATE TABLE balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER DEFAULT 0)")
+    c.execute("CREATE TABLE ledger (id INTEGER PRIMARY KEY AUTOINCREMENT, ts INTEGER, epoch INTEGER, "
+              "miner_id TEXT, delta_i64 INTEGER, reason TEXT)")
+    c.execute("CREATE TABLE epoch_rewards (epoch INTEGER, miner_id TEXT, share_i64 INTEGER)")
+    # Created by the live node (rustchain_v2_integrated:3246); ADM joins against it.
+    c.execute("CREATE TABLE miner_fingerprint_history (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+              "miner TEXT NOT NULL, ts INTEGER NOT NULL, profile_json TEXT NOT NULL)")
+    # The live node pre-creates the epoch_state row (settled=0) before settling.
+    c.execute("INSERT INTO epoch_state (epoch, settled) VALUES (?, 0)", (epoch,))
+    c.execute("INSERT INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)", (epoch, "MINER_A", 100))
+    # fingerprint_passed = 0 -> no positive-weight miners -> empty reward map.
+    c.execute("INSERT INTO miner_attest_recent (miner, device_arch, ts_ok, fingerprint_passed, entropy_score) "
+              "VALUES (?, ?, ?, 0, 0.0)", ("MINER_A", "x86_64", 0))
+    c.commit()
+    c.close()
+    return path
+
+
+def _settled(path, epoch):
+    with sqlite3.connect(path) as c:
+        row = c.execute("SELECT settled FROM epoch_state WHERE epoch=?", (epoch,)).fetchone()
+    return bool(row and row[0] == 1)
+
+
+def _paid_rows(path, epoch):
+    with sqlite3.connect(path) as c:
+        rewards = c.execute("SELECT COUNT(*) FROM epoch_rewards WHERE epoch=?", (epoch,)).fetchone()[0]
+        balances = c.execute("SELECT COUNT(*) FROM balances").fetchone()[0]
+    return rewards, balances
+
+
+@unittest.skipUnless(rmod.ANTI_DOUBLE_MINING_AVAILABLE, "anti_double_mining module unavailable")
+class AdmNoEligibleMinersMustNotBurnEpochTest(unittest.TestCase):
+    """Exercises the REAL ADM function on the shared-connection (live) path."""
+
+    def setUp(self):
+        self.epoch = 1
+        self.path = _db_with_only_ineligible_miner(self.epoch)
+        self.addCleanup(lambda: os.path.exists(self.path) and os.unlink(self.path))
+
+    def test_failed_settlement_leaves_epoch_unsettled(self):
+        result = rmod.settle_epoch_rip200(self.path, epoch=self.epoch, enable_anti_double_mining=True)
+
+        self.assertFalse(result.get("ok"), f"expected failure, got {result}")
+        self.assertEqual(result.get("error"), "no_eligible_miners")
+        self.assertEqual(_paid_rows(self.path, self.epoch), (0, 0), "nothing should have been paid")
+        # The claim must be undone: a settlement that paid nothing is not a settlement.
+        self.assertFalse(
+            _settled(self.path, self.epoch),
+            "epoch was committed as settled=1 while paying zero rewards — "
+            "its emission is burned and retry is impossible",
+        )
+
+    def test_epoch_can_be_retried_after_failure(self):
+        rmod.settle_epoch_rip200(self.path, epoch=self.epoch, enable_anti_double_mining=True)
+
+        # Operator fixes the fleet: the miner now passes attestation.
+        with sqlite3.connect(self.path) as c:
+            c.execute("UPDATE miner_attest_recent SET fingerprint_passed = 1, entropy_score = 1.0 "
+                      "WHERE miner = ?", ("MINER_A",))
+            c.commit()
+
+        retry = rmod.settle_epoch_rip200(self.path, epoch=self.epoch, enable_anti_double_mining=True)
+
+        self.assertNotEqual(
+            retry.get("already_settled"), True,
+            "retry was refused with already_settled — the failed attempt burned the epoch",
+        )
+        rewards_rows, _ = _paid_rows(self.path, self.epoch)
+        self.assertGreater(rewards_rows, 0, "retry should have distributed the epoch's rewards")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

`settle_epoch_with_anti_double_mining` claims settlement **before** it knows whether there is anything to pay:

```python
res = db.execute("UPDATE epoch_state SET settled = 1, settled_ts = ? WHERE epoch = ? AND settled = 0", ...)
...
if not rewards:
    if own_conn:
        db.rollback()
    return {"ok": False, "error": "no_eligible_miners", "epoch": epoch}
```

The undo is gated on `own_conn` — but `own_conn` is `False` exactly when `existing_conn` is passed, **which is the only mode the live node uses**. `rewards_implementation_rip200.settle_epoch_rip200` passes `existing_conn=db` and then commits regardless of the result:

```python
result = settle_epoch_with_anti_double_mining(..., existing_conn=db)
db.commit()          # runs whether or not result["ok"]
return result
```

So the function reports failure while durably committing `settled = 1`. The epoch's entire `PER_EPOCH_URTC` is never distributed, and it can never be re-settled — the operator's retry is answered `already_settled`.

This contradicts the standard (non-ADM) path in the same caller, which does an ungated `db.rollback()` before returning the very same `no_eligible_miners` error, leaving the epoch retryable as the module intends.

## Repro (run, not hypothesised)

`epoch_state(epoch=1, settled=0)` (the live node pre-creates this row), one `epoch_enroll` row, and `miner_attest_recent.fingerprint_passed = 0` for that miner — a machine that failed attestation, so total weight is 0 and the reward map comes back empty:

```
settle_epoch_rip200(db, epoch=1, enable_anti_double_mining=True)
  -> {'ok': False, 'error': 'no_eligible_miners', 'epoch': 1}

epoch_state:   [(1, 1)]     # settled = 1, COMMITTED
epoch_rewards: []           # nothing paid
balances:      []           # nothing paid

retry: {'ok': True, 'epoch': 1, 'already_settled': True}   # epoch burned
```

Other ways into the same empty-rewards state: all enrolled weights 0 (RIP-309 filtering), or representatives with no `miner_attest_recent` row.

## The fix

The claim-first `UPDATE` is deliberate — it's the atomic check-and-set that closes the concurrent-settler race — so I did **not** move it after the reward calculation. Instead the failure path undoes *only our own claim* (tracked via `res.rowcount`) when we're sharing the caller's connection; calling `db.rollback()` there would discard transaction state we don't own.

## Scope, honestly

- **This is on a live path**, but it is the admin/operator `settle_epoch_rip200` entry, not `finalize_epoch` (which is intentionally not ADM-gated).
- It needs an epoch where every enrolled miner is ineligible. That's an operational edge, not an everyday occurrence — but it's exactly the case the `no_eligible_miners` return exists to handle, and when it hits, the loss (a burned epoch) is permanent and silent.

## Tests

`node/tests/test_adm_no_eligible_miners_burns_epoch.py` — 2 tests, both **fail on main**, pass with the fix:
- `settled=1` committed while paying zero rewards
- retry refused with `already_settled`

They exercise the real ADM function through the real caller on the shared-connection path (no stubbing of the function under test — the existing `test_adm_require_optin_t33.py` either disables ADM or stubs it to raise, so it always lands on the standard path's correct rollback and never reaches this branch).

Neighbouring suites green: `test_adm_require_optin_t33.py`, `test_rewards_settle_race.py`, `test_epoch_settlement_atomic.py`, `test_rewards_settle_endpoint.py`, `test_epoch_reward_settlement_parameter.py` (22 passed), plus `test_anti_double_mining.py` + `test_anti_double_mining_epoch_enroll.py` (25 passed).

Verified against `upstream/main` @ 96660f06.

RTC: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
