### PR TITLE
fix(api-v1): /anchors queries columns no schema has -> permanent 503 masked as "database busy"

### DIFF
--- a/node/api_v1.py
+++ b/node/api_v1.py
@@ -168,8 +168,14 @@ def register_api_v1(app, *, db_path, current_slot, slot_to_epoch,
     @bp.route("/anchors/recent")
     @json_safe
     def v1_anchors():
+        # Column names must match the only ergo_anchors schema that exists:
+        # rustchain_ergo_anchor._ensure_anchor_table (mirrored by the node's
+        # _ensure_fallback_anchor_table and rustchain_migration). It stores
+        # commitment_hash/ergo_tx_id, and has no miner_count at all -- selecting
+        # commitment/miner_count/tx_id raised OperationalError on every call.
         rows = _rows(
-            "SELECT id, commitment, miner_count, tx_id, status, ergo_height, "
+            "SELECT id, commitment_hash AS commitment, ergo_tx_id AS tx_id, "
+            "status, ergo_height, rustchain_height, confirmations, "
             "created_at FROM ergo_anchors ORDER BY id DESC LIMIT ?",
             (_limit(),),
         )

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -28,9 +28,15 @@ def client(tmp_path):
         CREATE TABLE miner_attest_recent (miner TEXT, ts_ok INTEGER,
             device_family TEXT, device_arch TEXT, entropy_score REAL,
             fingerprint_passed INTEGER);
-        CREATE TABLE ergo_anchors (id INTEGER PRIMARY KEY, commitment TEXT,
-            miner_count INTEGER, miner_data TEXT, rc_slot INTEGER,
-            ergo_height INTEGER, tx_id TEXT, status TEXT, created_at INTEGER);
+        -- Real schema: rustchain_ergo_anchor._ensure_anchor_table (mirrored by
+        -- the node's _ensure_fallback_anchor_table and rustchain_migration).
+        -- Must stay in sync with the producer -- a fabricated shape here pins
+        -- the query instead of testing it.
+        CREATE TABLE ergo_anchors (id INTEGER PRIMARY KEY AUTOINCREMENT,
+            rustchain_height INTEGER NOT NULL, rustchain_hash TEXT NOT NULL,
+            commitment_hash TEXT NOT NULL, ergo_tx_id TEXT NOT NULL,
+            ergo_height INTEGER, confirmations INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'pending', created_at INTEGER NOT NULL);
         CREATE TABLE epoch_enroll (epoch INTEGER, miner TEXT);
         CREATE TABLE epoch_state (epoch INTEGER, settled INTEGER, settled_ts INTEGER);
         CREATE TABLE balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER);
@@ -42,7 +48,9 @@ def client(tmp_path):
     conn.execute("INSERT INTO headers VALUES (1700,'minerA','','','',?)", (now,))
     conn.execute("INSERT INTO headers VALUES (1701,'minerB','','','',?)", (now,))
     conn.execute("INSERT INTO miner_attest_recent VALUES ('minerA',?, 'POWER8','power8',0.9,1)", (now,))
-    conn.execute("INSERT INTO ergo_anchors (commitment,miner_count,tx_id,status,created_at) VALUES ('abc',5,'txid1','confirmed',?)", (now,))
+    conn.execute("INSERT INTO ergo_anchors (rustchain_height,rustchain_hash,commitment_hash,"
+                 "ergo_tx_id,ergo_height,confirmations,status,created_at) "
+                 "VALUES (1700,'rchash','abc','txid1',5000,3,'confirmed',?)", (now,))
     conn.execute("INSERT INTO epoch_enroll VALUES (10,'minerA')")
     conn.execute("INSERT INTO epoch_state VALUES (10,0,0)")
     conn.execute("INSERT INTO balances VALUES ('minerA', 5000000)")
@@ -93,6 +101,23 @@ def test_blocks_and_latest_and_by_slot(client):
     assert client.get("/api/v1/blocks/latest").get_json()["block"]["slot"] == 1701
     assert client.get("/api/v1/blocks/1700").get_json()["block"]["miner_id"] == "minerA"
     assert client.get("/api/v1/blocks/999999").status_code == 404
+
+
+def test_anchors_against_real_producer_schema(client):
+    """The query must run against the schema rustchain_ergo_anchor actually writes.
+
+    Regression: it selected commitment/miner_count/tx_id, none of which exist on
+    ergo_anchors, so every call raised OperationalError and json_safe turned it
+    into a 503 "database busy" -- a permanent schema bug reported as transient.
+    """
+    r = client.get("/api/v1/anchors")
+    assert r.status_code == 200, f"expected 200, got {r.status_code} {r.get_json()}"
+    anchor = r.get_json()["anchors"][0]
+    assert anchor["tx_id"] == "txid1"          # ergo_tx_id
+    assert anchor["commitment"] == "abc"       # commitment_hash
+    assert anchor["status"] == "confirmed"
+    assert anchor["ergo_height"] == 5000
+    assert client.get("/api/v1/anchors/recent").status_code == 200
 
 
 def test_anchors_and_leaderboard_and_governance(client):


### PR DESCRIPTION
## The bug

`v1_anchors` selects columns that **exist in no schema in this repo**:

```python
"SELECT id, commitment, miner_count, tx_id, status, ergo_height, "
"created_at FROM ergo_anchors ORDER BY id DESC LIMIT ?"
```

`ergo_anchors` has exactly one schema, defined identically in three places and never `ALTER`ed (`grep -rn "ALTER TABLE ergo_anchors"` → zero hits):

- `node/rustchain_ergo_anchor.py:51` — the producer (`AnchorService`, whose only INSERT writes `rustchain_height, rustchain_hash, commitment_hash, ergo_tx_id, status, created_at`)
- `node/rustchain_v2_integrated_v2.2.1_rip200.py:1544` — `_ensure_fallback_anchor_table`
- `node/rustchain_migration.py:295`

Real columns: `id, rustchain_height, rustchain_hash, commitment_hash, ergo_tx_id, ergo_height, confirmations, status, created_at`.

The query asks for `commitment`, `miner_count`, `tx_id`. The real names are `commitment_hash` / `ergo_tx_id`, and `miner_count` has no counterpart at all. The names look lifted from the unrelated `node/ergo_miner_anchor.py:130` table (`id, tx_id, commitment, miner_count, rc_slot, created_at`) — but *that* schema has no `status` or `ergo_height`. The query is a hybrid that **fails against either table**; there is no DB state in which it succeeds.

### Why it went unnoticed

The failure is `sqlite3.OperationalError: no such column: commitment`, which `json_safe` catches and converts to:

```json
503 {"error": "temporarily_unavailable", "hint": "database busy, retry"}
```

So a hard, permanent schema bug is reported to explorers and operators as transient DB contention — inviting infinite retries against an endpoint that has never returned data.

## Repro (run against the real blueprint + the producer's real schema)

```
/api/v1/health          -> 200 {"db_ok":true,"ok":true,...}
/api/v1/anchors         -> 503 {"error":"temporarily_unavailable","hint":"database busy, retry"}
/api/v1/anchors/recent  -> 503 {"error":"temporarily_unavailable","hint":"database busy, retry"}
RAW SQLITE ERROR: OperationalError no such column: commitment
```

Health is 200 and the anchor row is present — the DB is fine. Against the alternate `ergo_miner_anchor` schema the same query dies with `no such column: status` instead.

## Reachability

Live. `rustchain_v2_integrated_v2.2.1_rip200.py:1484` imports `register_api_v1` and calls it at 1486–1495; `/api/v1/anchors` and `/api/v1/anchors/recent` are bound unconditionally, and `/api/v1/anchors` is advertised in the module's own `ENDPOINTS` index. `ergo_anchors` is guaranteed to exist with the 9-column schema on a live node (`create_anchor_api_routes(app, AnchorService(DB_PATH))` at 1516, plus `_ensure_fallback_anchor_table` at 1544).

## Why the suite stayed green

`tests/test_api_v1.py` fixtured a **fabricated** `ergo_anchors` shape that exists nowhere in the repo (`id, commitment, miner_count, miner_data, rc_slot, ergo_height, tx_id, status, created_at`) — invented to match the query. `test_anchors_and_leaderboard_and_governance` then asserted `anchors[0]["tx_id"] == "txid1"` and passed. The test pinned the bug rather than the behaviour.

I re-fixtured it against the producer's real schema. With that change **both** anchor tests fail on main (503 → `KeyError`) and pass with the fix.

## The fix

Select the real columns, aliasing `commitment_hash -> commitment` and `ergo_tx_id -> tx_id` so the advertised field names are unchanged, and drop `miner_count` — no such data exists on this table. Since the endpoint has never returned a payload, no client can be depending on the current shape. I also surfaced `rustchain_height` and `confirmations`, which the producer records and an explorer would want.

## Deliberately left alone

`json_safe` mapping every `OperationalError` to a 503 "database busy" is what disguised this for so long — distinguishing "no such column/table" from genuine busy/locked would stop schema drift masquerading as transient load. That's a separate concern from this fix, so I kept it out rather than bundling it. Happy to send it as its own PR if you want it.

Tests: `tests/test_api_v1.py` 9 passed with the fix; 2 failed / 7 passed on main. Verified against `upstream/main` @ 96660f06.

RTC: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
