### PR TITLE
fix(fleet): thermal_signature always NULL — consumer reads keys no producer emits

### DIFF
--- a/rips/python/rustchain/fleet_immune_system.py
+++ b/rips/python/rustchain/fleet_immune_system.py
@@ -331,9 +331,16 @@ def record_fleet_signals_from_request(
             cache_str = str(sorted(cache.items()))
             cache_hash = hashlib.sha256(cache_str.encode()).hexdigest()[:16]
 
-        # Thermal drift entropy
+        # Thermal drift entropy. check_thermal_drift emits 'drift_ratio' (and has
+        # in every miner build); 'entropy'/'drift_magnitude' are read first only
+        # for legacy payloads. Without drift_ratio this was None for every real
+        # attestation, so thermal_signature stored NULL fleet-wide and the
+        # thermal comparison in _detect_fingerprint_similarity could never run.
+        # Mirrors the tolerance already used by hardware_binding_v2.
         thermal = checks.get("thermal_drift", {}).get("data", {})
-        thermal_sig = thermal.get("entropy", thermal.get("drift_magnitude"))
+        thermal_sig = thermal.get(
+            "entropy", thermal.get("drift_magnitude", thermal.get("drift_ratio"))
+        )
 
         # SIMD bias profile hash
         simd = checks.get("simd_identity", {}).get("data", {})

--- a/tests/test_fleet_thermal_signature_real_payload.py
+++ b/tests/test_fleet_thermal_signature_real_payload.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: MIT
+"""Regression: fleet thermal_signature must be populated from the real payload.
+
+`record_fleet_signals_from_request` read `thermal_drift.data.entropy` /
+`drift_magnitude`. No producer in the repo emits either key: `check_thermal_drift`
+(node/fingerprint_checks.py, and identically in every miner build) emits
+`cold_avg_ns / hot_avg_ns / cold_stdev / hot_stdev / drift_ratio`.
+
+So `thermal_signature` was written NULL for every real attestation, and the thermal
+branch of `_detect_fingerprint_similarity` (`if sig_a.get("thermal_signature") and
+sig_b.get("thermal_signature")`) could never be true — the detector silently ran on
+3 of its 4 signals while still requiring `shared_hashes >= 2`.
+
+Every existing fleet test fabricates the consumer's imaginary `{"entropy": ...}`
+schema, so the green suite proved nothing here. These tests build the payload from
+`check_thermal_drift`'s actual output shape instead.
+"""
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(REPO, "rips", "python", "rustchain"))
+sys.path.insert(0, os.path.join(REPO, "node"))
+
+import fleet_immune_system as fis
+
+
+def _real_thermal_payload(drift_ratio):
+    """The shape check_thermal_drift actually returns (node/fingerprint_checks.py)."""
+    return {
+        "checks": {
+            "thermal_drift": {
+                "data": {
+                    "cold_avg_ns": 1_000_000,
+                    "hot_avg_ns": int(1_000_000 * drift_ratio),
+                    "cold_stdev": 5000,
+                    "hot_stdev": 4800,
+                    "drift_ratio": round(drift_ratio, 4),
+                }
+            }
+        }
+    }
+
+
+class ThermalSignatureFromRealPayloadTest(unittest.TestCase):
+    def setUp(self):
+        fd, self.path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.db = sqlite3.connect(self.path)
+        self.addCleanup(lambda: os.path.exists(self.path) and os.unlink(self.path))
+        self.addCleanup(self.db.close)
+
+    def _record(self, miner, drift_ratio, ip="10.0.0.1"):
+        fis.record_fleet_signals_from_request(
+            self.db, miner=miner, epoch=1,
+            fingerprint=_real_thermal_payload(drift_ratio),
+            attest_ts=1_700_000_000, ip_address=ip,
+        )
+
+    def _thermal(self, miner):
+        row = self.db.execute(
+            "SELECT thermal_signature FROM fleet_signals WHERE miner = ?", (miner,)
+        ).fetchone()
+        return row[0] if row else None
+
+    def test_real_producer_payload_populates_thermal_signature(self):
+        self._record("MINER_A", 1.0523)
+        self.assertIsNotNone(
+            self._thermal("MINER_A"),
+            "thermal_signature is NULL for a real check_thermal_drift payload — "
+            "the consumer reads keys no producer emits",
+        )
+        self.assertAlmostEqual(self._thermal("MINER_A"), 1.0523, places=4)
+
+    def test_legacy_entropy_key_still_wins(self):
+        """Legacy payloads must keep working (same tolerance as hardware_binding_v2)."""
+        fis.record_fleet_signals_from_request(
+            self.db, miner="LEGACY", epoch=1,
+            fingerprint={"checks": {"thermal_drift": {"data": {"entropy": 0.42,
+                                                              "drift_ratio": 1.05}}}},
+            attest_ts=1_700_000_000, ip_address="10.0.0.2",
+        )
+        self.assertAlmostEqual(self._thermal("LEGACY"), 0.42, places=4)
+
+    def test_absent_thermal_check_stays_null(self):
+        fis.record_fleet_signals_from_request(
+            self.db, miner="NO_THERMAL", epoch=1, fingerprint={"checks": {}},
+            attest_ts=1_700_000_000, ip_address="10.0.0.3",
+        )
+        self.assertIsNone(self._thermal("NO_THERMAL"))
+
+    def test_thermal_branch_of_similarity_detector_can_fire(self):
+        """End-to-end: a cloned fleet's near-identical thermal profiles must count.
+
+        Six machines on one /24 with thermal ratios inside the detector's 10%
+        band. On main every thermal_signature is NULL, so this signal contributes
+        nothing to `shared_hashes` and the fleet scores lower than it should.
+        """
+        for i in range(6):
+            self._record(f"CLONE_{i}", 1.0500 + i * 0.0002, ip=f"10.0.0.{10 + i}")
+
+        stored = self.db.execute(
+            "SELECT COUNT(*) FROM fleet_signals WHERE epoch = 1 "
+            "AND thermal_signature IS NOT NULL"
+        ).fetchone()[0]
+        self.assertEqual(
+            stored, 6,
+            "thermal_signature NULL for real payloads -> the detector's thermal "
+            "branch is unreachable and fleet detection runs on 3 of 4 signals",
+        )
+
+        scores = fis.compute_fleet_scores(self.db, epoch=1)
+        self.assertEqual(len(scores), 6)
+        for miner, score in scores.items():
+            self.assertGreater(
+                score, 0.0,
+                f"{miner} scored {score} — a 6-machine clone fleet on one subnet "
+                "should not read as solo",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

`record_fleet_signals_from_request` reads two keys that **no producer in this repo emits**:

```python
thermal = checks.get("thermal_drift", {}).get("data", {})
thermal_sig = thermal.get("entropy", thermal.get("drift_magnitude"))
```

`check_thermal_drift` — `node/fingerprint_checks.py:202-208`, and identically in `miners/linux/`, `miners/macos/`, `miners/windows/` and `miners/power8/` — emits exactly:

```python
{"cold_avg_ns", "hot_avg_ns", "cold_stdev", "hot_stdev", "drift_ratio"}
```

So `thermal_sig` is `None` for every real attestation, `fleet_signals.thermal_signature` is written **NULL fleet-wide**, and the thermal branch of `_detect_fingerprint_similarity`:

```python
if sig_a.get("thermal_signature") and sig_b.get("thermal_signature"):
```

can never be true. The detector silently runs on 3 of its 4 signals while still requiring `shared_hashes >= 2`.

`grep -rn drift_magnitude` shows that key exists only as `clock_drift_magnitude` in `node/arch_cross_validation.py` — an unrelated string enum it was likely copy-pasted from.

## Precedent: this exact skew was already fixed next door

`node/hardware_binding_v2.py:88-89`:

```python
# Accept legacy 'ratio' OR v3 'drift_ratio'.
'thermal_ratio': thermal_data.get('ratio') or thermal_data.get('drift_ratio') or 0,
```

`fleet_immune_system` was never updated with it. This PR mirrors that tolerance — legacy keys still win, `drift_ratio` is accepted.

`drift_ratio` (hot/cold, 4dp) is exactly the stable per-model signal the ±10% comparison wants. The surviving signals don't compensate: `cache_latency_hash` is a SHA over raw float latencies, so it never collides across machines either; `simd_bias_hash` matches, but that's 1 of the required 2, leaving detection to hinge entirely on `clock_drift_cv` landing within 5% — which `hardware_binding_v2.py:116-118` itself documents as "varies 100%+ between runs".

(Checked the neighbours: `clock_drift` really does emit `cv`, and the SIMD/cache hashes are computed over whatever the check returns. Thermal is the only signal broken this way.)

## Repro

6 identical machines on one /24, payload built from the real `check_thermal_drift` output shape:

| | thermal_signature stored | fleet detection |
|---|---|---|
| main | `NULL` × 6 | thermal branch unreachable, 3 of 4 signals |
| with fix | `1.0500 … 1.0510` | thermal branch compares as designed |

## Scope — honestly

I want to be precise about the blast radius rather than oversell this:

- **The write side is live.** `submit_attestation` → `record_attestation_success` → `record_fleet_signals` → `record_fleet_signals_from_request`. Every real attestation persists a NULL thermal column today. That's a poisoned audit column, right now.
- **The read side is not wired into rewards.** `_detect_fingerprint_similarity` is reached only via `compute_fleet_scores` ← `calculate_immune_weights` / `calculate_immune_rewards_equal_split`. The node imports `calculate_immune_weights` but I found **no call site for it** in the monolith; `register_fleet_endpoints` only exposes `/admin/fleet/*` readers over `fleet_scores`. So this is **not** an active reward exploit — it's a correctness bug in a detector that is degraded before it is ever switched on.
- Secondary note: the flat-name `from fleet_immune_system import ...` resolves only if the module is deployed alongside the node (it lives in `rips/python/rustchain/`, and the `sys.path` insert in the monolith is inside a function, i.e. too late), so on a plain checkout `HAVE_FLEET_IMMUNE` is False. If that's intentional, this fix still matters for whenever the module is deployed; if it isn't, that's a separate packaging issue and I'm happy to look at it.

## Why the suite never caught it

Every fleet test fabricates the consumer's imaginary schema instead of the producer's:

- `tests/test_false_positive_scenarios.py:45` — `"thermal_drift": {"data": {"entropy": entropy}}`
- `tests/test_fleet_score_manipulation.py:63`, `tests/test_rip201_fleet_bypass.py:180` — same `entropy` key
- `tools/rip201_false_positive_report.py:46`, `tools/rip_poa_fingerprint_replay_poc.py:116` — same

No test feeds real `check_thermal_drift` output through `record_fleet_signals_from_request`, so the green suite proved nothing here. The new tests build the payload from the producer's actual shape.

## Tests

`tests/test_fleet_thermal_signature_real_payload.py` — 4 tests, **2 fail on main**, all pass with the fix:
- real producer payload populates `thermal_signature` (NULL on main)
- a 6-machine clone fleet gets its thermal branch counted (unreachable on main)
- legacy `entropy` key still wins (tolerance preserved)
- absent thermal check still stores NULL

Existing fleet suites green: `test_false_positive_scenarios.py`, `test_fleet_score_manipulation.py`, `test_rip201_fleet_bypass.py` (16 passed).

## Related, not bundled

`node/hardware_fingerprint_replay.py:202-213` (`compute_entropy_profile_hash`) has the *same* skew — it reads `cache_data.get('L1')`, `thermal_data.get('ratio')`, `jitter_data.get('cv')`, none of which v3 emits. I left it out of this PR because the exact-hash design still catches verbatim profile copying, so the impact there is "hash is narrower than intended" rather than a dead check. Say the word and I'll send it separately.

Verified against `upstream/main` @ 96660f06.

RTC: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
