### PR TITLE
fix(lock_ledger): bridge-owned lock release double-credits the source (mints RTC)

### DIFF
--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -242,7 +242,8 @@ def release_lock(
 
     # Find the lock
     row = cursor.execute("""
-        SELECT id, miner_id, amount_i64, lock_type, status, unlock_at
+        SELECT id, miner_id, amount_i64, lock_type, status, unlock_at,
+               bridge_transfer_id
         FROM lock_ledger
         WHERE id = ?
     """, (lock_id,)).fetchone()
@@ -250,12 +251,30 @@ def release_lock(
     if not row:
         return False, {"error": "Lock not found"}
 
-    lid, miner_id, amount_i64, lock_type, status, unlock_at = row
+    lid, miner_id, amount_i64, lock_type, status, unlock_at, bridge_transfer_id = row
 
     if status != "locked":
         return False, {
             "error": f"Lock already {status}",
             "hint": "Only locked entries can be released"
+        }
+
+    # Bridge-owned locks settle through bridge_api, not here. This function
+    # credits `balances` because it is the counterpart of create_lock(), which
+    # debits. bridge_api.create_bridge_transfer() does its own hard debit and
+    # writes the lock row directly, tracking the refund on
+    # bridge_transfers.source_debited — a flag this function neither reads nor
+    # clears. Crediting such a lock therefore reverses a debit the bridge still
+    # considers outstanding, and the bridge's own void path refunds it again.
+    if bridge_transfer_id is not None:
+        return False, {
+            "error": "Lock is owned by a bridge transfer",
+            "lock_id": lock_id,
+            "bridge_transfer_id": bridge_transfer_id,
+            "hint": (
+                "Settle via the bridge: complete the transfer, or void it to "
+                "refund the source. Releasing here would double-credit."
+            )
         }
 
     # Check if unlock time has passed (unless admin override)
@@ -641,9 +660,18 @@ def auto_release_expired_locks(
 
     released_count = 0
     total_amount = 0
+    skipped_bridge_owned = 0
     errors = []
 
     for lock in expired:
+        # Bridge-owned locks are settled by bridge_api (complete or void); this
+        # worker must not touch their balances. Skip rather than call through to
+        # release_lock() and log an error per lock on every run — an expired
+        # bridge deposit is a normal state that an operator resolves by voiding.
+        if lock.bridge_transfer_id is not None:
+            skipped_bridge_owned += 1
+            continue
+
         success, result = release_lock(
             db_conn,
             lock.id,
@@ -663,6 +691,7 @@ def auto_release_expired_locks(
     return {
         "released_count": released_count,
         "total_amount_rtc": total_amount / LOCK_UNIT,
+        "skipped_bridge_owned": skipped_bridge_owned,
         "errors": errors,
         "processed_at": now
     }

--- a/tests/test_lock_ledger_bridge_owned_no_credit.py
+++ b/tests/test_lock_ledger_bridge_owned_no_credit.py
@@ -1,0 +1,152 @@
+"""
+Regression tests: lock_ledger must not credit balances for bridge-owned locks.
+
+bridge_api.create_bridge_transfer() hard-debits the source, writes the
+lock_ledger row directly (it never calls lock_ledger.create_lock()), and tracks
+the refund itself on bridge_transfers.source_debited. lock_ledger.release_lock()
+credits unconditionally because it is the counterpart of create_lock(), which
+debits — but that pairing does not hold for bridge-produced rows, so releasing
+one reverses a debit the bridge still considers outstanding.
+
+Every test here fails on main:
+  - admin release of a pending deposit un-does the hard debit
+  - the routine auto-release worker does the same once the lock expires
+  - release followed by the bridge's own void refunds twice (100 -> 200 RTC)
+"""
+
+import os
+import sqlite3
+import sys
+import time
+
+import pytest
+
+NODE_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "node")
+if NODE_DIR not in sys.path:
+    sys.path.insert(0, NODE_DIR)
+
+import bridge_api  # noqa: E402
+import lock_ledger  # noqa: E402
+
+UNIT = bridge_api.BRIDGE_UNIT
+
+
+@pytest.fixture
+def conn(tmp_path):
+    db = sqlite3.connect(str(tmp_path / "bridge.db"))
+    cur = db.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS balances ("
+        "  miner_id TEXT PRIMARY KEY,"
+        "  amount_i64 INTEGER NOT NULL DEFAULT 0"
+        ")"
+    )
+    bridge_api.init_bridge_schema(cur)
+    lock_ledger.init_lock_ledger_schema(cur)
+    cur.execute("INSERT INTO balances VALUES (?, ?)", ("alice", 100 * UNIT))
+    db.commit()
+    yield db
+    db.close()
+
+
+def _balance(db, miner_id="alice"):
+    row = db.execute(
+        "SELECT amount_i64 FROM balances WHERE miner_id = ?", (miner_id,)
+    ).fetchone()
+    return row[0] if row else 0
+
+
+def _open_deposit(db, amount_rtc=100.0):
+    """Open a real deposit: hard-debits alice and writes the bridge-owned lock."""
+    request = bridge_api.BridgeTransferRequest(
+        direction="deposit",
+        source_chain="rustchain",
+        dest_chain="solana",
+        source_address="alice",
+        dest_address="SoLaNaAddr",
+        amount_rtc=amount_rtc,
+        bridge_type="lock_mint",
+        memo=None,
+    )
+    ok, _ = bridge_api.create_bridge_transfer(db, request)
+    assert ok, "fixture: deposit should open"
+    tx_hash, lock_id = db.execute(
+        "SELECT t.tx_hash, l.id FROM bridge_transfers t"
+        " JOIN lock_ledger l ON l.bridge_transfer_id = t.id"
+    ).fetchone()
+    assert _balance(db) == 0, "fixture: deposit hard-debits the source"
+    return tx_hash, lock_id
+
+
+def test_admin_release_does_not_credit_bridge_deposit(conn):
+    """Admin release of a bridge lock must not undo the bridge's hard debit."""
+    _tx_hash, lock_id = _open_deposit(conn)
+
+    # released_by="admin" bypasses the unlock timer by design.
+    ok, result = lock_ledger.release_lock(conn, lock_id, released_by="admin")
+
+    assert not ok, "bridge-owned locks must not be released via lock_ledger"
+    assert "bridge" in result["error"].lower()
+    assert _balance(conn) == 0, "hard debit must stand while the deposit is pending"
+
+
+def test_release_then_complete_does_not_mint(conn):
+    """The deposit completes on Solana; alice must not also keep her RTC here."""
+    tx_hash, lock_id = _open_deposit(conn)
+
+    lock_ledger.release_lock(conn, lock_id, released_by="admin")
+    ok, result = bridge_api.update_external_confirmation(conn, tx_hash, "solana_tx_abc", 12)
+    assert ok and result["status"] == "completed"
+
+    # She holds 100 RTC on Solana. Any RustChain balance here is minted supply.
+    assert _balance(conn) == 0, "completed deposit must not leave a RustChain balance"
+
+
+def test_release_then_void_refunds_once(conn):
+    """Void refunds the source exactly once, not on top of a lock release."""
+    tx_hash, lock_id = _open_deposit(conn)
+
+    lock_ledger.release_lock(conn, lock_id, released_by="admin")
+    ok, _ = bridge_api.void_bridge_transfer(conn, tx_hash, reason="stuck", voided_by="admin")
+    assert ok
+
+    assert _balance(conn) == 100 * UNIT, "void must refund exactly once (not 200 RTC)"
+
+
+def test_auto_release_worker_skips_bridge_owned_locks(conn):
+    """The routine worker must not credit an expired-but-pending deposit."""
+    _tx_hash, _lock_id = _open_deposit(conn)
+
+    # The 7-day lock expires while the deposit is still pending.
+    conn.execute("UPDATE lock_ledger SET unlock_at = ?", (int(time.time()) - 1,))
+    conn.commit()
+
+    result = lock_ledger.auto_release_expired_locks(conn)
+
+    assert result["released_count"] == 0
+    assert result["skipped_bridge_owned"] == 1
+    assert result["errors"] == [], "skipping is a normal state, not a per-run error"
+    assert _balance(conn) == 0, "worker must not undo the bridge's hard debit"
+    status, source_debited = conn.execute(
+        "SELECT status, source_debited FROM bridge_transfers"
+    ).fetchone()
+    assert (status, source_debited) == ("pending", 1)
+
+
+def test_standalone_lock_release_still_credits(conn):
+    """Guard against over-reach: non-bridge locks keep debit/credit symmetry."""
+    unlock_at = int(time.time()) + 3600
+    ok, created = lock_ledger.create_lock(
+        conn,
+        miner_id="alice",
+        amount_i64=40 * UNIT,
+        lock_type="bridge_deposit",
+        unlock_at=unlock_at,
+    )
+    assert ok, created
+    assert _balance(conn) == 60 * UNIT, "create_lock debits"
+
+    ok, _ = lock_ledger.release_lock(conn, created["lock_id"], released_by="admin")
+
+    assert ok, "locks created here are still ours to release"
+    assert _balance(conn) == 100 * UNIT, "release_lock credits its own locks back"


### PR DESCRIPTION
## Bug

`lock_ledger.release_lock()` credits `balances` for locks the **bridge** owns and already settles itself, reversing a debit that is still outstanding.

`release_lock()` credits unconditionally because it is the counterpart of `create_lock()`, which debits. That pairing does not hold in production:

- `create_lock()` has **no live callers** (`grep` → only its own definition/docstring).
- Every real `lock_ledger` row is written by `bridge_api.create_bridge_transfer()` with a **raw INSERT** (`node/bridge_api.py:463`), after it hard-debits the source at `:406` and records `bridge_transfers.source_debited = 1` at `:454`.
- `release_lock()` never reads or clears `source_debited`.

Both modules register under the same `HAVE_BRIDGE` flag (`node/rustchain_v2_integrated_v2.2.1_rip200.py:1462-1465`), so the lock producer and these release routes are always live together.

## Impact — reproduced against the real schema

| path | scenario | correct | on main |
|---|---|---|---|
| `POST /api/lock/release` | deposit opened (alice 100 → 0, `source_debited=1`), admin releases, deposit then completes on Solana | `0` | **`100 RTC`** — alice keeps her RTC on *both* chains |
| `POST /api/lock/release` → bridge void | release, then the bridge's own void refunds again | `100 RTC` | **`200 RTC`** — double refund |
| `POST /api/lock/auto-release` | **no operator action**: the 7-day lock expires while the deposit is still `pending` | `0` | **`100 RTC`**, `bridge_transfers` still `('pending', 1)` |

`released_by="admin"` bypasses the unlock timer by design (`:262`), so the first two are immediate. The third needs nobody: `get_pending_unlocks()` (`:520`) filters on `status='locked' AND unlock_at <= now` with **no `lock_type` filter**, so the documented auto-release worker picks up bridge deposits and silently un-does the hard debit under a live deposit.

The restored balance is also immediately spendable: `available_balance.encumbered_i64()` only counts deposits with `source_debited = 0 OR IS NULL` (`node/available_balance.py:69`), and `release_lock()` leaves `source_debited = 1` — so the un-debited funds are invisible to every encumbrance check.

The bridge's own settlement never expects that credit: void (`bridge_api.py:696`) refunds guarded on `source_debited`, and completion (`:836`) deliberately does *not* refund — it only flips the lock row to `released`.

## Fix

- `release_lock()` fails closed for any lock carrying a `bridge_transfer_id`, pointing the caller at the bridge (complete or void).
- The auto-release worker **skips** bridge-owned locks and reports `skipped_bridge_owned`, rather than calling through and logging an error per lock on every run — an expired bridge deposit is a normal state an operator resolves by voiding.
- Locks created via `create_lock()` are untouched and keep their debit/credit symmetry.

## Verification

`tests/test_lock_ledger_bridge_owned_no_credit.py` — **4 of 5 fail on main**, all pass with the fix:

```
# clean main
FAILED test_admin_release_does_not_credit_bridge_deposit
FAILED test_release_then_complete_does_not_mint
FAILED test_release_then_void_refunds_once      (assert 200 RTC == 100 RTC)
FAILED test_auto_release_worker_skips_bridge_owned_locks
4 failed, 1 passed
# with fix
5 passed
```

The 5th (`test_standalone_lock_release_still_credits`) passes on **both** — it guards against over-reach by pinning that `create_lock()`/`release_lock()` still balance.

Existing `tests/test_bridge_lock_ledger.py` stays green (**71 passed**). It didn't catch this because `test_release_lock` (`:669`) only exercises the symmetric `create_lock()` → `release_lock()` pair, and `create_lock()` debits, so the credit balances out — but that producer is never used in production. No test ever fed a `bridge_api`-produced lock into `release_lock()`.

I also ran the wider money-path selection (`-k "bridge or lock or balance or encumb or payout"`): the failures there are **identical on pristine main** and unrelated to this change (the only diff between main and this branch is my 4 tests flipping to pass).

---
RTC: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7
