### PR TITLE
fix(attest): warthog_bonus never revoked -> permanent +15% epoch reward weight

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4838,17 +4838,22 @@ def _submit_attestation_impl():
     except Exception as _te:
         print(f"[TEMPORAL] Warning: {_te}")
 
-    # Update warthog_bonus in attestation record
-    if warthog_bonus > 1.0:
-        try:
-            with closing(sqlite3.connect(DB_PATH)) as wb_conn:
-                wb_conn.execute(
-                    "UPDATE miner_attest_recent SET warthog_bonus=? WHERE miner=?",
-                    (warthog_bonus, miner)
-                )
-                wb_conn.commit()
-        except Exception:
-            pass  # Column may not exist yet
+    # Update warthog_bonus in attestation record.
+    # Written unconditionally: warthog_bonus describes THIS attestation, and
+    # record_attestation_success() does not carry the column in its upsert. A
+    # `> 1.0` guard here would make the column a one-way ratchet — a miner that
+    # stops dual-mining, or that starts failing the fingerprint gate above,
+    # would keep the multiplier forever and dilute every honest miner's share
+    # of the fixed epoch pot in calculate_epoch_rewards_time_aged().
+    try:
+        with closing(sqlite3.connect(DB_PATH)) as wb_conn:
+            wb_conn.execute(
+                "UPDATE miner_attest_recent SET warthog_bonus=? WHERE miner=?",
+                (warthog_bonus, miner)
+            )
+            wb_conn.commit()
+    except Exception:
+        pass  # Column may not exist yet
 
     # Record MACs if provided
     if macs:

--- a/node/tests/test_warthog_bonus_not_ratcheted.py
+++ b/node/tests/test_warthog_bonus_not_ratcheted.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression tests: miner_attest_recent.warthog_bonus must track the CURRENT
+attestation, not ratchet up permanently.
+
+The submit handler only writes the column when the freshly computed bonus is
+> 1.0, and record_attestation_success() does not carry warthog_bonus in its
+ON CONFLICT DO UPDATE list. So once a miner earns the dual-mining bonus, no
+code path ever writes 1.0 back: the miner can stop dual-mining, or start
+failing the hardware fingerprint (which the handler explicitly intends to deny
+the bonus), and keep the multiplier on every future epoch.
+
+rip_200_round_robin_1cpu1vote.calculate_epoch_rewards_time_aged reads
+COALESCE(warthog_bonus, 1.0) straight into the miner's epoch reward weight, so
+the stale value dilutes every honest miner's share of the fixed epoch pot.
+"""
+
+import importlib.util
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+NODE_DIR = PROJECT_ROOT / "node"
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+EPOCH = 85
+NONCE = "nonce-warthog"
+MINER = "warthog-miner"
+
+
+def _load_integrated_node(db_path: Path, warthog_verified: bool):
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    if str(NODE_DIR) not in sys.path:
+        sys.path.insert(0, str(NODE_DIR))
+
+    from tests import mock_crypto
+
+    sys.modules["rustchain_crypto"] = mock_crypto
+    os.environ["DB_PATH"] = str(db_path)
+    os.environ["RUSTCHAIN_DB_PATH"] = str(db_path)
+    os.environ.setdefault("RC_ADMIN_KEY", "0" * 32)
+
+    spec = importlib.util.spec_from_file_location(
+        f"integrated_node_warthog_test_{warthog_verified}_{db_path.name}",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    module.DB_PATH = str(db_path)
+    module.app.config["TESTING"] = True
+    module.UTXO_DUAL_WRITE = False
+    module.HW_BINDING_V2 = False
+    module.HW_PROOF_AVAILABLE = False
+    module.HAVE_REPLAY_DEFENSE = False
+    module.HAVE_FLEET_IMMUNE = False
+    module.HAVE_WARTHOG = True
+    module.check_ip_rate_limit = lambda client_ip, miner_id: (True, "ok")
+    module._check_hardware_binding = lambda *args, **kwargs: (True, "ok", "")
+    module._check_oui_gate = lambda macs: (True, {"ok": True})
+    module.wallet_review_gate_response = lambda miner: None
+    module.record_macs = lambda *args, **kwargs: None
+    module._check_welcome_bonus = lambda miner: None
+    module.current_slot = lambda: 12345
+    module.slot_to_epoch = lambda slot: EPOCH
+    module.validate_fingerprint_data = lambda fingerprint, claimed_device=None: (True, "ok")
+    module.verify_warthog_proof = lambda proof, miner: (warthog_verified, 1.15, "own_node")
+    module.record_warthog_proof = lambda *args, **kwargs: None
+    return module
+
+
+def _prepare_db(node, db_path: Path, seeded_bonus: float):
+    now = int(time.time())
+    with sqlite3.connect(db_path) as conn:
+        node.attest_ensure_tables(conn)
+        conn.execute("INSERT INTO nonces (nonce, expires_at) VALUES (?, ?)", (NONCE, now + 3600))
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS tickets (ticket_id TEXT PRIMARY KEY, expires_at INTEGER, commitment TEXT);
+            CREATE TABLE IF NOT EXISTS epoch_state (epoch INTEGER PRIMARY KEY, settled INTEGER DEFAULT 0, settled_ts INTEGER);
+            CREATE TABLE IF NOT EXISTS balances (
+                miner_id TEXT PRIMARY KEY, miner_pk TEXT,
+                amount_i64 INTEGER DEFAULT 0, balance_rtc REAL DEFAULT 0
+            );
+            CREATE TABLE IF NOT EXISTS miner_attest_recent (
+                miner TEXT PRIMARY KEY,
+                ts_ok INTEGER,
+                device_family TEXT,
+                device_arch TEXT,
+                entropy_score REAL DEFAULT 0.0,
+                fingerprint_passed INTEGER DEFAULT 0,
+                source_ip TEXT,
+                signing_pubkey TEXT,
+                fingerprint_checks_json TEXT,
+                warthog_bonus REAL DEFAULT 1.0
+            );
+            CREATE TABLE IF NOT EXISTS miner_attest_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                miner TEXT NOT NULL,
+                ts_ok INTEGER NOT NULL,
+                device_family TEXT,
+                device_arch TEXT,
+                entropy_score REAL DEFAULT 0.0,
+                fingerprint_passed INTEGER DEFAULT 0,
+                fingerprint_checks_json TEXT
+            );
+            """
+        )
+        conn.execute("INSERT OR IGNORE INTO epoch_state(epoch, settled) VALUES (?, 0)", (EPOCH,))
+        conn.execute(
+            "INSERT OR IGNORE INTO balances(miner_id, miner_pk, amount_i64, balance_rtc)"
+            " VALUES (?, ?, 0, 0)",
+            (MINER, MINER),
+        )
+        # The miner previously verified a Warthog proof and earned the 1.15x tier.
+        conn.execute(
+            "INSERT INTO miner_attest_recent"
+            " (miner, ts_ok, device_arch, fingerprint_passed, warthog_bonus)"
+            " VALUES (?, ?, 'x86_64', 1, ?)",
+            (MINER, now - 3600, seeded_bonus),
+        )
+        conn.commit()
+
+
+def _payload(with_warthog: bool):
+    payload = {
+        "miner": MINER,
+        "miner_id": MINER,
+        "nonce": NONCE,
+        "device": {"model": "Generic CPU", "arch": "x86_64", "family": "x86_64", "cores": 4},
+        "signals": {"hostname": "baremetal-host"},
+        "report": {"nonce": NONCE, "commitment": "commitment"},
+        "fingerprint": {
+            "checks": {
+                "clock_drift": {"passed": True, "data": {"cv": 0.03}},
+                "anti_emulation": {"passed": True, "data": {}},
+            }
+        },
+    }
+    if with_warthog:
+        payload["warthog"] = {
+            "enabled": True,
+            "proof_type": "own_node",
+            "node": {"synced": True, "height": 500000},
+            "balance": "42.5",
+            "collected_at": int(time.time()),
+        }
+    return payload
+
+
+def _stored_bonus(db_path: Path):
+    with sqlite3.connect(db_path) as conn:
+        return conn.execute(
+            "SELECT warthog_bonus FROM miner_attest_recent WHERE miner = ?", (MINER,)
+        ).fetchone()[0]
+
+
+def test_attestation_without_warthog_proof_clears_stale_bonus(tmp_path):
+    """Miner stops dual-mining: the bonus must not survive the next attestation."""
+    db_path = tmp_path / "warthog_stop.sqlite3"
+    node = _load_integrated_node(db_path, warthog_verified=True)
+    _prepare_db(node, db_path, seeded_bonus=1.15)
+
+    with node.app.test_client() as client:
+        response = client.post("/attest/submit", json=_payload(with_warthog=False))
+
+    assert response.status_code == 200, response.get_data(as_text=True)
+    assert _stored_bonus(db_path) == 1.0, "bonus must reflect the current attestation"
+
+
+def test_failed_warthog_verification_clears_stale_bonus(tmp_path):
+    """Proof sent but rejected: the previously earned bonus must be revoked."""
+    db_path = tmp_path / "warthog_fail.sqlite3"
+    node = _load_integrated_node(db_path, warthog_verified=False)
+    _prepare_db(node, db_path, seeded_bonus=1.15)
+
+    with node.app.test_client() as client:
+        response = client.post("/attest/submit", json=_payload(with_warthog=True))
+
+    assert response.status_code == 200, response.get_data(as_text=True)
+    assert _stored_bonus(db_path) == 1.0, "a rejected proof must not keep the bonus"
+
+
+def test_verified_warthog_proof_still_records_bonus(tmp_path):
+    """Guard against over-reach: a genuine proof must still earn the bonus."""
+    db_path = tmp_path / "warthog_ok.sqlite3"
+    node = _load_integrated_node(db_path, warthog_verified=True)
+    _prepare_db(node, db_path, seeded_bonus=1.0)
+
+    with node.app.test_client() as client:
+        response = client.post("/attest/submit", json=_payload(with_warthog=True))
+
+    assert response.status_code == 200, response.get_data(as_text=True)
+    assert _stored_bonus(db_path) == 1.15, "verified dual-mining still earns 1.15x"


### PR DESCRIPTION
## Bug

`miner_attest_recent.warthog_bonus` only ever ratchets **up**. Once a miner earns the dual-mining tier, nothing ever revokes it.

Two things combine:

- `_submit_attestation_impl` writes the column only when the freshly computed bonus is `> 1.0` (`node/rustchain_v2_integrated_v2.2.1_rip200.py:4842`). That `UPDATE` is the **only writer of the column in the repo** (`grep "SET warthog_bonus"` → a single hit).
- `record_attestation_success()` (`:3203`) upserts `miner_attest_recent`, but `warthog_bonus` is **not** in its column list or its `ON CONFLICT DO UPDATE SET` list, so the existing value survives untouched.

So `warthog_bonus = 1.0` is never written back. A miner who verifies a proof once and then:

- stops dual-mining entirely (sends no `warthog` key at all), or
- starts failing the hardware fingerprint

keeps the 1.15x multiplier forever. The second case directly defeats the stated invariant in the code right above the bug (`:4801-4803`):

> `SECURITY: Warthog bonus requires passing hardware fingerprint. Without this gate, VMs could fake/run Warthog and farm the bonus.`

The gate correctly computes `warthog_bonus = 1.0` for these miners — the write is just skipped, so the DB keeps the old 1.15.

## Impact — this is live money

The stale column feeds epoch rewards directly:

`POST /attest/submit` → `:4842` (skipped write) → `rip_200_round_robin_1cpu1vote.calculate_epoch_rewards_time_aged` `:652` `wart_sql = ", COALESCE(warthog_bonus, 1.0) "` → `:683` → `_apply_warthog_bonus(weight_units, warthog_bonus)` (`:96`) → `rewards_implementation_rip200.settle_epoch_rip200` → credits `balances`.

Two enrolled miners, weight 1.0 each, epoch pot 2,150,000 uRTC:

| miner | correct | on main |
|---|---|---|
| A (stale 1.15, no longer dual-mining) | 1,075,000 | **1,150,000** |
| B (honest) | 1,075,000 | **1,000,000** |

B is short **75,000 uRTC every epoch, indefinitely**, out of the fixed `PER_EPOCH_URTC` pot. It compounds: every miner that *ever* dual-mined keeps +15% weight permanently, diluting everyone else.

Note `warthog_verification.py` itself is correct here — it returns `(False, 1.0, reason)` as it should; the caller discards that result. `get_warthog_bonus()` (`warthog_verification.py:201`), which would read the column, has zero live callers and so does not mitigate.

## Fix

Write the column unconditionally, so it describes the current attestation. One-line change (plus a comment recording why the guard must not come back).

## Verification

`node/tests/test_warthog_bonus_not_ratcheted.py` drives the real `/attest/submit` route (reusing the harness from `node/tests/test_attest_missing_fingerprint_reward_bypass.py`). **2 of 3 fail on main:**

```
FAILED test_attestation_without_warthog_proof_clears_stale_bonus
        AssertionError: bonus must reflect the current attestation
        assert 1.15 == 1.0
FAILED test_failed_warthog_verification_clears_stale_bonus
        AssertionError: a rejected proof must not keep the bonus
2 failed, 1 passed   ->   3 passed with the fix
```

The third (`test_verified_warthog_proof_still_records_bonus`) passes on **both** — it guards against over-reach by pinning that a genuine verified proof still earns 1.15x.

Existing `node/tests/test_rip200_warthog_bonus.py` stays green (2 passed). It's a good test, but it covers the **read** path only — it seeds `warthog_bonus` directly and never re-attests, which is exactly why the missing write went unnoticed.

Wider run (`node/tests/ -k "attest or warthog or rip200 or reward"`): **164 passed, 2 failed**. Honest note on those 2 — `test_attest_challenge_rate_limit.py` is **order-dependent and fails identically on pristine main** in the same batch (shared in-process rate-limit state); both pass in isolation with and without this change. On main the same batch fails 4 (those 2 + my 2 new tests); with this fix it's 2.

---
RTC: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7
