### PR TITLE
fix(replay): entropy profile hash reads keys the producer never emits

### DIFF
--- a/node/hardware_fingerprint_replay.py
+++ b/node/hardware_fingerprint_replay.py
@@ -188,35 +188,40 @@ def compute_entropy_profile_hash(fingerprint: Dict) -> str:
     checks = fingerprint.get('checks', {}) if isinstance(fingerprint, dict) else {}
     
     entropy_values = {}
-    
+
+    # The producer (node/fingerprint_checks.py) emits load-normalized *ratios*
+    # and coefficients of variation as the stable per-machine characteristics;
+    # the raw *_ns latencies vary run-to-run and are intentionally excluded so
+    # the same box yields a stable profile across attestations.
+
     # Extract clock drift entropy
     clock_data = checks.get('clock_drift', {}).get('data', {})
     if isinstance(clock_data, dict):
         entropy_values['clock_cv'] = clock_data.get('cv', 0)
-        entropy_values['clock_drift_hash'] = clock_data.get('drift_hash', '')
-    
-    # Extract cache timing entropy
+
+    # Extract cache timing entropy (hierarchy ratios are the stable signal)
     cache_data = checks.get('cache_timing', {}).get('data', {})
     if isinstance(cache_data, dict):
-        entropy_values['cache_hash'] = cache_data.get('cache_hash', '')
-        entropy_values['cache_l1'] = cache_data.get('L1', 0)
-        entropy_values['cache_l2'] = cache_data.get('L2', 0)
-    
+        entropy_values['cache_l2_l1_ratio'] = cache_data.get('l2_l1_ratio', 0)
+        entropy_values['cache_l3_l2_ratio'] = cache_data.get('l3_l2_ratio', 0)
+
     # Extract thermal drift entropy
     thermal_data = checks.get('thermal_drift', {}).get('data', {})
     if isinstance(thermal_data, dict):
-        entropy_values['thermal_ratio'] = thermal_data.get('ratio', 0)
-    
-    # Extract jitter entropy
+        entropy_values['thermal_ratio'] = thermal_data.get('drift_ratio', 0)
+
+    # Extract jitter entropy as load-robust relative timings (fp/int, branch/int);
+    # the producer emits only per-op *_avg_ns, so derive dimensionless ratios.
     jitter_data = checks.get('instruction_jitter', {}).get('data', {})
     if isinstance(jitter_data, dict):
-        entropy_values['jitter_cv'] = jitter_data.get('cv', 0)
-        jitter_map = jitter_data.get('jitter_map', {})
-        if isinstance(jitter_map, dict):
-            # Hash the jitter map for compact representation
-            entropy_values['jitter_map_hash'] = hashlib.sha256(
-                json.dumps(jitter_map, sort_keys=True).encode()
-            ).hexdigest()[:16]
+        int_avg = jitter_data.get('int_avg_ns', 0) or 0
+        if int_avg:
+            entropy_values['jitter_fp_int_ratio'] = round(
+                jitter_data.get('fp_avg_ns', 0) / int_avg, 3
+            )
+            entropy_values['jitter_branch_int_ratio'] = round(
+                jitter_data.get('branch_avg_ns', 0) / int_avg, 3
+            )
     
     # Extract SIMD profile entropy
     simd_data = checks.get('simd_identity', {}).get('data', {})

--- a/tests/test_entropy_profile_real_producer_schema.py
+++ b/tests/test_entropy_profile_real_producer_schema.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Regression test: compute_entropy_profile_hash must read the SAME keys that the
+real fingerprint producer (node/fingerprint_checks.py) actually emits.
+
+Issue: the entropy profile hash feeds the live anti-Sybil gate
+(check_entropy_collision, called from the attestation path in
+rustchain_v2_integrated_v2.2.1_rip200.py). On main the consumer reads key names
+that the producer never emits:
+
+    consumer key        producer (fingerprint_checks.py) actually emits
+    ------------        -----------------------------------------------
+    thermal 'ratio'  -> 'drift_ratio'
+    cache   'L1'     -> 'l1_ns' / hierarchy ratios 'l2_l1_ratio','l3_l2_ratio'
+    cache   'L2'     -> 'l2_ns'
+    cache   'cache_hash' -> (no such field)
+    jitter  'cv'     -> (no such field; emits int/fp/branch avg_ns + stdevs)
+    jitter  'jitter_map' -> (no such field)
+    clock   'drift_hash' -> (no such field; emits cv/stdev_ns/drift_stdev)
+
+Effect on REAL hardware: thermal, cache and jitter collapse to constants, so the
+entropy_profile_hash is derived almost entirely from clock_cv + simd. Two
+fingerprints that differ ONLY in their thermal/cache/jitter entropy (i.e.
+genuinely different hardware timing profiles) hash IDENTICALLY -> the anti-Sybil
+collision check fires against honest, distinct miners while ignoring 3 of its 5
+advertised entropy dimensions.
+
+These tests build fingerprints in the REAL producer shape and fail on main.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+NODE_PATH = PROJECT_ROOT / "node"
+sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, str(NODE_PATH))
+
+TEST_DB_PATH = str(PROJECT_ROOT / "tests" / ".test_entropy_profile_schema.db")
+os.environ["DB_PATH"] = TEST_DB_PATH
+os.environ["RUSTCHAIN_DB_PATH"] = TEST_DB_PATH
+
+from hardware_fingerprint_replay import compute_entropy_profile_hash
+
+
+def _real_producer_fingerprint(
+    *, drift_ratio, l2_l1_ratio, l3_l2_ratio, int_avg_ns, fp_mult=1.7, branch_mult=2.3,
+    cv=0.031, simd_tag="avx2"
+):
+    """Fingerprint shaped exactly like node/fingerprint_checks.py emits."""
+    return {
+        "checks": {
+            "clock_drift": {
+                "passed": True,
+                "data": {
+                    "mean_ns": 12000,
+                    "stdev_ns": 372,
+                    "cv": cv,
+                    "drift_stdev": 41,
+                },
+            },
+            "cache_timing": {
+                "passed": True,
+                "data": {
+                    "l1_ns": 5.1,
+                    "l2_ns": 14.2,
+                    "l3_ns": 44.7,
+                    "l2_l1_ratio": l2_l1_ratio,
+                    "l3_l2_ratio": l3_l2_ratio,
+                },
+            },
+            "thermal_drift": {
+                "passed": True,
+                "data": {
+                    "cold_avg_ns": 8100,
+                    "hot_avg_ns": 8900,
+                    "cold_stdev": 55,
+                    "hot_stdev": 61,
+                    "drift_ratio": drift_ratio,
+                },
+            },
+            "instruction_jitter": {
+                "passed": True,
+                "data": {
+                    "int_avg_ns": int_avg_ns,
+                    "fp_avg_ns": int(int_avg_ns * fp_mult),
+                    "branch_avg_ns": int(int_avg_ns * branch_mult),
+                    "int_stdev": 40,
+                    "fp_stdev": 70,
+                    "branch_stdev": 90,
+                },
+            },
+            "simd_identity": {
+                "passed": True,
+                "data": {"isa": simd_tag, "vector_width": 256},
+            },
+        }
+    }
+
+
+def test_thermal_entropy_is_read_from_real_producer_key():
+    """Two rigs identical except for thermal drift_ratio must hash differently."""
+    a = _real_producer_fingerprint(
+        drift_ratio=1.05, l2_l1_ratio=2.78, l3_l2_ratio=3.15, int_avg_ns=9100
+    )
+    b = _real_producer_fingerprint(
+        drift_ratio=1.42, l2_l1_ratio=2.78, l3_l2_ratio=3.15, int_avg_ns=9100
+    )
+    assert compute_entropy_profile_hash(a) != compute_entropy_profile_hash(b), (
+        "thermal drift_ratio does not influence the entropy profile hash "
+        "(consumer reads 'ratio', producer emits 'drift_ratio')"
+    )
+
+
+def test_cache_entropy_is_read_from_real_producer_key():
+    """Two rigs identical except for cache hierarchy ratios must hash differently."""
+    a = _real_producer_fingerprint(
+        drift_ratio=1.2, l2_l1_ratio=2.40, l3_l2_ratio=3.05, int_avg_ns=9100
+    )
+    b = _real_producer_fingerprint(
+        drift_ratio=1.2, l2_l1_ratio=3.90, l3_l2_ratio=4.80, int_avg_ns=9100
+    )
+    assert compute_entropy_profile_hash(a) != compute_entropy_profile_hash(b), (
+        "cache hierarchy ratios do not influence the entropy profile hash "
+        "(consumer reads 'L1'/'L2'/'cache_hash', producer emits 'l*_ns'/'l2_l1_ratio')"
+    )
+
+
+def test_jitter_entropy_is_read_from_real_producer_key():
+    """Two rigs with different micro-arch jitter ratios must hash differently."""
+    a = _real_producer_fingerprint(
+        drift_ratio=1.2, l2_l1_ratio=2.78, l3_l2_ratio=3.15,
+        int_avg_ns=9100, fp_mult=1.7, branch_mult=2.3,
+    )
+    b = _real_producer_fingerprint(
+        drift_ratio=1.2, l2_l1_ratio=2.78, l3_l2_ratio=3.15,
+        int_avg_ns=9100, fp_mult=2.4, branch_mult=3.6,
+    )
+    assert compute_entropy_profile_hash(a) != compute_entropy_profile_hash(b), (
+        "instruction jitter does not influence the entropy profile hash "
+        "(consumer reads 'cv'/'jitter_map', producer emits '*_avg_ns'/'*_stdev')"
+    )
+
+
+def test_jitter_uses_load_robust_ratio_not_absolute_ns():
+    """Same relative jitter but different absolute load must NOT change the hash.
+
+    Raw per-op ns scale with machine load; only the relative timing between op
+    classes is a stable hardware characteristic, so it alone must drive the hash.
+    """
+    light = _real_producer_fingerprint(
+        drift_ratio=1.2, l2_l1_ratio=2.78, l3_l2_ratio=3.15,
+        int_avg_ns=8200, fp_mult=1.7, branch_mult=2.3,
+    )
+    loaded = _real_producer_fingerprint(
+        drift_ratio=1.2, l2_l1_ratio=2.78, l3_l2_ratio=3.15,
+        int_avg_ns=15900, fp_mult=1.7, branch_mult=2.3,
+    )
+    assert compute_entropy_profile_hash(light) == compute_entropy_profile_hash(loaded)
+
+
+def test_distinct_hardware_not_a_false_collision():
+    """Full sanity: two clearly different rigs must not share an entropy hash."""
+    rig1 = _real_producer_fingerprint(
+        drift_ratio=1.05, l2_l1_ratio=2.40, l3_l2_ratio=3.05,
+        int_avg_ns=8200, cv=0.031, simd_tag="avx2",
+    )
+    rig2 = _real_producer_fingerprint(
+        drift_ratio=1.42, l2_l1_ratio=3.90, l3_l2_ratio=4.80,
+        int_avg_ns=15900, cv=0.031, simd_tag="avx2",
+    )
+    assert compute_entropy_profile_hash(rig1) != compute_entropy_profile_hash(rig2), (
+        "distinct hardware collapses to the same entropy_profile_hash -> honest "
+        "miner falsely blocked as an entropy-sharing Sybil"
+    )
+
+
+def test_same_hardware_still_stable():
+    """Same stable characteristics -> same hash (Sybil-on-one-box still caught)."""
+    a = _real_producer_fingerprint(
+        drift_ratio=1.2, l2_l1_ratio=2.78, l3_l2_ratio=3.15, int_avg_ns=9100
+    )
+    b = _real_producer_fingerprint(
+        drift_ratio=1.2, l2_l1_ratio=2.78, l3_l2_ratio=3.15, int_avg_ns=9100
+    )
+    assert compute_entropy_profile_hash(a) == compute_entropy_profile_hash(b)


### PR DESCRIPTION
## Problem

`compute_entropy_profile_hash()` (node/hardware_fingerprint_replay.py) feeds the **live anti-Sybil gate**: the attestation submit path in `rustchain_v2_integrated_v2.2.1_rip200.py` (line ~4687) computes the entropy hash and passes it to `check_entropy_collision()` (line ~4708) to block wallets that share a hardware entropy profile.

But the function reads key names that the **real producer** (`node/fingerprint_checks.py`) never emits:

| consumer reads | producer actually emits |
|---|---|
| thermal `ratio` | `drift_ratio` |
| cache `L1` / `L2` | `l1_ns` / `l2_ns` (+ `l2_l1_ratio`, `l3_l2_ratio`) |
| cache `cache_hash` | — (no such field) |
| jitter `cv` | — (only `int/fp/branch_avg_ns` + `*_stdev`) |
| jitter `jitter_map` | — (no such field) |
| clock `drift_hash` | — (emits `cv`, `stdev_ns`, `drift_stdev`) |

Only `clock_drift.cv` and the whole `simd_identity.data` are read correctly. So on real hardware **thermal, cache and jitter collapse to constants**, and the entropy profile hash is derived almost entirely from `clock_cv + simd`.

**Effect:** two rigs that differ *only* in their thermal/cache/jitter entropy produce the **identical** `entropy_profile_hash`, so `check_entropy_collision` (a) can false-block honest, physically-distinct miners as `entropy_profile_collision`, and (b) ignores 3 of the 5 entropy dimensions it advertises for Sybil detection.

The existing `tests/test_replay_defense.py` fixture masked this — it fabricates a fingerprint with the *consumer's* invented keys (`ratio`, `L1`, `cache_hash`, `jitter_map`), not the producer's real ones, and `test_entropy_hash_different_profiles` only mutates `clock_drift.cv` (the one field read correctly).

## Fix

Read the producer's stable, load-normalized characteristics: `cv`, cache hierarchy ratios (`l2_l1_ratio`, `l3_l2_ratio`), thermal `drift_ratio`, and dimensionless jitter ratios (`fp/int`, `branch/int`). Raw `*_ns` stay excluded on purpose so the same machine yields a stable profile across attestations. This is the same producer-key alignment `hardware_binding_v2` already applies for thermal.

## Verification

New `tests/test_entropy_profile_real_producer_schema.py`, built on the **real producer shape**: 4 tests fail on clean `main` (distinct hardware collapses to one hash), all pass with the fix. Existing replay/binding suites stay green (78 passed replay + new; 69 passed / 1 skipped hardware-binding).

## Severity — honest scope

This is a correctness/security bug in a **live** attestation gate (write + read path both active). I'm not attaching a specific RTC-loss figure: it both false-blocks honest miners and under-detects real hardware sharing; the maintainer is better placed to weight those. The `*_ns`-volatility concern (why raw latencies must stay out of the hash) is covered by an added stability test.

RTC: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
