### PR TITLE
Sign the pre-image the P2P auth middleware verifies (secure block sync 401s itself)

### DIFF
--- a/node/rustchain_p2p_sync_secure.py
+++ b/node/rustchain_p2p_sync_secure.py
@@ -491,9 +491,12 @@ class SecureBlockSync:
                 if not self.peer_manager.rate_limiter.check_rate_limit(peer_url, '/p2p/blocks'):
                     continue
 
-                # Generate auth signature
-                message = f"get_blocks:{peer_url}"
-                signature, timestamp = self.peer_manager.auth_manager.generate_signature(message)
+                # Sign the request body: that is the pre-image the peer's auth
+                # middleware verifies (create_p2p_auth_middleware -> request.get_data()).
+                # This GET carries no body, so the signed pre-image is the empty
+                # string, matching tests/test_p2p_peer_auth_no_ip_bypass.py.
+                body = ""
+                signature, timestamp = self.peer_manager.auth_manager.generate_signature(body)
 
                 # Request blocks with authentication
                 response = requests.get(

--- a/tests/test_p2p_sync_signs_what_verifier_checks.py
+++ b/tests/test_p2p_sync_signs_what_verifier_checks.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: MIT
+"""sync_from_peers must sign the pre-image the auth middleware actually verifies.
+
+The signer built its own message (`get_blocks:{peer_url}`) while
+create_p2p_auth_middleware verifies over `request.get_data()`, so the two HMACs
+were computed over different pre-images and every sync request 401'd -- with no
+else-branch and no reputation penalty, so silently.
+
+This drives the REAL sync_from_peers against the REAL middleware over a shared
+key; only requests.get is redirected into a Flask test client.
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+from flask import Flask, jsonify
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "node" / "rustchain_p2p_sync_secure.py"
+
+os.environ["RC_P2P_KEY"] = "shared-network-key"
+spec = importlib.util.spec_from_file_location("rustchain_p2p_sync_secure", MODULE_PATH)
+p2p = importlib.util.module_from_spec(spec)
+sys.modules["rustchain_p2p_sync_secure"] = p2p
+spec.loader.exec_module(p2p)
+
+PEER_URL = "http://peer.example:8099"
+
+
+class _Resp:
+    """The bit of requests.Response that sync_from_peers touches."""
+
+    def __init__(self, flask_response):
+        self.status_code = flask_response.status_code
+        self.ok = flask_response.status_code < 400
+        self._json = flask_response.get_json()
+
+    def json(self):
+        return self._json
+
+
+@pytest.fixture
+def rig(monkeypatch):
+    """Real peer manager + real auth middleware, wired peer-to-peer over HTTP."""
+    db_path = os.path.join(tempfile.mkdtemp(), "peers.db")
+    manager = p2p.SecurePeerManager(db_path=db_path, local_host="127.0.0.1", local_port=8099)
+    sync = p2p.SecureBlockSync(manager, db_path=db_path)
+
+    with __import__("sqlite3").connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO peers (peer_url, is_active, is_banned) VALUES (?, 1, 0)", (PEER_URL,)
+        )
+
+    # The remote node: same module, same shared key, the middleware as the monolith wires it
+    # (node/rustchain_v2_integrated_v2.2.1_rip200.py:10693-10694).
+    remote_auth = p2p.P2PAuthManager()
+    require_peer_auth = p2p.create_p2p_auth_middleware(remote_auth)
+    app = Flask(__name__)
+    served = [{"block_index": 1, "previous_hash": "0" * 64, "timestamp": 0,
+               "miner": "node1", "transactions": [], "hash": "a" * 64}]
+
+    @app.route("/p2p/blocks", methods=["GET"])
+    @require_peer_auth
+    def p2p_blocks():
+        return jsonify({"blocks": served})
+
+    client = app.test_client()
+    seen = []
+
+    def fake_get(url, headers=None, timeout=None):
+        resp = client.get("/p2p/blocks", headers=headers or {})
+        seen.append(resp.status_code)
+        return _Resp(resp)
+
+    monkeypatch.setattr(p2p.requests, "get", fake_get)
+
+    applied = []
+    monkeypatch.setattr(p2p.SecureBlockSync, "_apply_block",
+                        lambda self, block: applied.append(block))
+    monkeypatch.setattr(p2p.BlockValidator, "validate_block", lambda self, block: (True, None))
+    return sync, seen, applied
+
+
+def test_peer_accepts_our_sync_request(rig):
+    """A correctly-keyed peer must authenticate us, not 401 us."""
+    sync, seen, _ = rig
+
+    sync.sync_from_peers()
+
+    assert seen == [200], f"peer rejected our own signature: HTTP {seen}"
+
+
+def test_blocks_from_peer_are_actually_ingested(rig):
+    """The 401 fails closed and silent -- `if response.ok` just never runs."""
+    sync, _, applied = rig
+
+    sync.sync_from_peers()
+
+    assert len(applied) == 1, "no block ingested; the secure sync path is inert"
+    assert applied[0]["block_index"] == 1


### PR DESCRIPTION
## The bug

`SecureBlockSync.sync_from_peers` and the auth middleware sign **different pre-images**, so they can never agree.

Signer (`node/rustchain_p2p_sync_secure.py:493-495`):
```python
message = f"get_blocks:{peer_url}"
signature, timestamp = self.peer_manager.auth_manager.generate_signature(message)
response = requests.get(f"{peer_url}/p2p/blocks", headers={'X-Peer-Signature': signature, ...})
```

Verifier (`create_p2p_auth_middleware.decorated`, `:595-598`):
```python
body = request.get_data().decode()
if not auth_manager.verify_peer_signature(signature, body, timestamp):
    return jsonify({'error': 'Invalid signature'}), 401
```

`verify_peer_signature` recomputes `HMAC(key, f"{message}{timestamp}")`. The request is a **GET**, so `request.get_data()` is `b""`: the verifier computes `HMAC(key, "" + ts)` while the signer produced `HMAC(key, "get_blocks:http://peer:8099" + ts)`. This is not a key-distribution problem — with a perfectly shared `RC_P2P_KEY` it still fails, because the pre-images differ.

## Why it goes unnoticed

It fails **closed and silent**. There is no `else` on `if response.ok:` (`:508`), and the `-5` reputation penalty (`:526`) only fires on exceptions — a 401 is a clean response, so it is neither logged nor scored. `SecureBlockSync` prints `[P2P] [OK] Block sync started` and then ingests exactly nothing, every 30s, forever.

Existing tests miss it because `tests/test_p2p_peer_auth_no_ip_bypass.py` only exercises the middleware from a hand-built client that **signs the body correctly** (`:49-50`, `auth_manager.generate_signature(body)`) — it never drives `sync_from_peers`, the one caller that doesn't.

## Live path

- `node/rustchain_v2_integrated_v2.2.1_rip200.py:10672` — `from rustchain_p2p_sync_secure import initialize_secure_p2p`
- `:10675-10678` — `peer_manager, block_sync, require_peer_auth = initialize_secure_p2p(...)`
- `:10693-10694` — `@app.route('/p2p/blocks', methods=['GET'])` + `@require_peer_auth`
- `:10743-10744` — `block_sync.start()` unless `RUSTCHAIN_DISABLE_P2P_AUTO_START=1`

## Severity, honestly

This is *good peers rejected*, not an auth bypass — nothing unauthorized gets in. And the separate gossip path (`rustchain_p2p_init.init_p2p` → `rustchain_p2p_gossip`, wired at `:11749-11750`) is also live, so the chain still syncs by that route. The accurate framing is: **the "secure" block-sync module has never done anything**, and its failure mode hides that from the operator. I'm not claiming lost funds.

## The fix

Sign the body — the contract the middleware defines, and the one the existing test already encodes. For this bodyless GET that is the empty string.

Deliberately **not** bundled: the fact that an empty-body GET signature covers only the timestamp (so it is replayable across bodyless endpoints within the 300s window) is a real design question, but tightening it means changing the middleware's pre-image contract and every caller — a separate PR, and your call on the shape. Happy to open it if you want the pre-image to include method+path.

## Verification

`tests/test_p2p_sync_signs_what_verifier_checks.py` drives the **real** `sync_from_peers` against the **real** middleware over a shared key; only `requests.get` is redirected into a Flask test client.

```
main:  2 failed  -> peer rejected our own signature: HTTP [401] / "no block ingested; the secure sync path is inert"
here:  2 passed
```

Neighbouring suites green: `test_p2p_peer_auth_no_ip_bypass` 3 passed; `test_p2p_blocks`, `test_p2p_blocks_and_add_peer_6131_6129`, `test_p2p_demo_peer_config`, `test_p2p_mtls_gate`, `test_p2p_nonce_security` 29 passed.

RTC: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7
