### PR TITLE
fix(beacon-x402): premium exports query tables no producer creates (200 + total:0 forever)

### DIFF
--- a/node/beacon_x402.py
+++ b/node/beacon_x402.py
@@ -337,7 +337,7 @@ def init_app(app, get_db_func):
         db = get_db_func()
         try:
             rows = db.execute(
-                "SELECT * FROM reputation ORDER BY score DESC"
+                "SELECT * FROM beacon_reputation ORDER BY score DESC"
             ).fetchall()
             reputation = [dict(r) for r in rows]
         except sqlite3.OperationalError:
@@ -363,9 +363,12 @@ def init_app(app, get_db_func):
             return err_resp
 
         db = get_db_func()
+        # The wallet join below is unguarded, and _run_migrations creates
+        # beacon_wallets next to this module rather than in the runtime database.
+        _ensure_x402_tables(db)
         try:
             rows = db.execute(
-                "SELECT * FROM contracts ORDER BY created_at DESC"
+                "SELECT * FROM beacon_contracts ORDER BY created_at DESC"
             ).fetchall()
         except sqlite3.OperationalError:
             rows = []

--- a/tests/test_beacon_x402_premium_export_real_schema.py
+++ b/tests/test_beacon_x402_premium_export_real_schema.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: MIT
+"""Premium x402 exports must query the tables the Beacon producer actually creates.
+
+The existing gate suite (test_beacon_x402_payment_gate.py) fixtures its database with
+hand-written ``CREATE TABLE reputation`` / ``CREATE TABLE contracts`` statements. No
+producer in the tree ever creates those names: ``beacon_api.init_beacon_tables`` -- the
+only writer, and the one the node calls -- creates ``beacon_reputation`` and
+``beacon_contracts``. So the suite is green while production exports nothing.
+
+These tests build the database with the *real* producer so the schema cannot drift from
+what the node actually deploys.
+"""
+
+import sqlite3
+
+import pytest
+from flask import Flask
+
+import beacon_api
+import beacon_x402
+
+
+@pytest.fixture
+def real_schema_db(tmp_path):
+    """A database created by the real producer, seeded via its real table names."""
+    db_path = tmp_path / "rustchain_v2.db"
+    beacon_api.init_beacon_tables(str(db_path))
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO beacon_reputation (agent_id, score, bounties_completed) "
+            "VALUES (?, ?, ?)",
+            ("agent-alpha", 99, 3),
+        )
+        conn.execute(
+            "INSERT INTO beacon_contracts (id, from_agent, to_agent, type, amount, "
+            "term, state, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("contract-1", "agent-alpha", "agent-beta", "work", 100.0, "net30",
+             "offered", 1000),
+        )
+    return db_path
+
+
+def _client(db_path, monkeypatch):
+    monkeypatch.setattr(beacon_x402, "X402_CONFIG_OK", True)
+    monkeypatch.setattr(beacon_x402, "PRICE_REPUTATION_EXPORT", "0", raising=False)
+    monkeypatch.setattr(beacon_x402, "PRICE_BEACON_CONTRACT", "0", raising=False)
+    monkeypatch.setattr(
+        beacon_x402,
+        "is_free",
+        lambda price: str(price) in ("0", "0.0", "0.00", ""),
+        raising=False,
+    )
+    # The module migrates a path of its own choosing; these tests exercise the runtime
+    # connection the node hands in, which is what every route actually reads.
+    monkeypatch.setattr(beacon_x402, "_run_migrations", lambda _db_path: None)
+
+    def get_db():
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    beacon_x402.init_app(app, get_db)
+    return app.test_client()
+
+
+def test_reputation_export_returns_producer_rows(real_schema_db, monkeypatch):
+    """/api/premium/reputation must export the rows beacon_api wrote."""
+    client = _client(real_schema_db, monkeypatch)
+
+    resp = client.get("/api/premium/reputation")
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # On main this is 0: the query reads `reputation`, the producer wrote
+    # `beacon_reputation`, and the OperationalError is swallowed into an empty list.
+    assert body["total"] == 1
+    assert body["reputation"][0]["agent_id"] == "agent-alpha"
+    assert body["reputation"][0]["score"] == 99
+
+
+def test_contracts_export_returns_producer_rows(real_schema_db, monkeypatch):
+    """/api/premium/contracts/export must export the rows beacon_api wrote."""
+    client = _client(real_schema_db, monkeypatch)
+
+    resp = client.get("/api/premium/contracts/export")
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["total"] == 1
+    assert body["contracts"][0]["id"] == "contract-1"
+
+
+def test_contracts_export_survives_a_runtime_db_without_beacon_wallets(
+    real_schema_db, monkeypatch
+):
+    """The wallet join must not 500 on a database the module never migrated.
+
+    ``_run_migrations`` creates beacon_wallets in a beacon_atlas.db beside this module,
+    but the node hands the routes a connection to RUSTCHAIN_DB_PATH/rustchain_v2.db.
+    Only the two wallet routes call _ensure_x402_tables, so on a node where no wallet
+    was ever registered the table is absent from the runtime database and the unguarded
+    join at the bottom of the export raises.
+
+    This never fired on main only because the export selected a non-existent table,
+    returned zero rows, and skipped the loop -- the two defects masked each other.
+    """
+    with sqlite3.connect(real_schema_db) as conn:
+        conn.execute("DROP TABLE IF EXISTS beacon_wallets")
+
+    client = _client(real_schema_db, monkeypatch)
+
+    resp = client.get("/api/premium/contracts/export")
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["total"] == 1
+    # No wallet registered for either party -> reported as null, not a crash.
+    assert body["contracts"][0]["from_agent_wallet"] is None
+    assert body["contracts"][0]["to_agent_wallet"] is None
+
+
+def test_export_does_not_mask_a_missing_table_as_an_empty_export(
+    real_schema_db, monkeypatch
+):
+    """A real empty table and a missing table must not look identical to a payer.
+
+    This is what let the bug survive: `except sqlite3.OperationalError: -> []` turns
+    "your query names a table that does not exist" into a 200 with total: 0, which is
+    indistinguishable from "there is genuinely no reputation data yet".
+    """
+    with sqlite3.connect(real_schema_db) as conn:
+        conn.execute("DELETE FROM beacon_reputation")
+
+    client = _client(real_schema_db, monkeypatch)
+    empty = client.get("/api/premium/reputation").get_json()
+
+    # Genuinely-empty table: 200 + total 0 is correct here.
+    assert empty["total"] == 0
+
+    # And the queried table must be one that actually exists, so that the swallow
+    # cannot hide a schema drift again.
+    with sqlite3.connect(real_schema_db) as conn:
+        names = {
+            r[0]
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+    assert "beacon_reputation" in names
+    assert "reputation" not in names, (
+        "No producer creates a bare `reputation` table; if a test creates one it is "
+        "fixturing the consumer's bug rather than the deployed schema."
+    )


### PR DESCRIPTION
## The bug

`/api/premium/reputation` and `/api/premium/contracts/export` — the two endpoints `/api/x402/status` advertises as the premium offering — query tables that no producer in this tree creates.

| consumer (`node/beacon_x402.py`) | real producer (`node/beacon_api.py:95`) |
|---|---|
| `SELECT * FROM reputation` (:340) | `CREATE TABLE beacon_reputation` (:137) |
| `SELECT * FROM contracts` (:368) | `CREATE TABLE beacon_contracts` (:100) |

`beacon_api.init_beacon_tables` is the only writer of this data and the one the node calls; it uses `DB_PATH = 'rustchain_v2.db'`, the same database the monolith hands to `beacon_x402` (`_beacon_x402_get_db`, `rustchain_v2_integrated_v2.2.1_rip200.py:761-773` → `RUSTCHAIN_DB_PATH` / `./rustchain_v2.db`). So the connection is right; only the table names are wrong.

The `except sqlite3.OperationalError: rows = []` then converts *"you named a table that does not exist"* into **HTTP 200 with `total: 0`** — indistinguishable from "there is genuinely no data yet". Both exports have therefore returned nothing, silently, for every caller.

## A second defect the first one was masking

Correcting the table names makes the contracts export get further — and it then **500s**:

```
sqlite3.OperationalError: no such table: beacon_wallets   # beacon_x402.py:379
```

`_run_migrations` (:216) creates `beacon_wallets` in a `beacon_atlas.db` **beside the module file** (:210), not in the runtime database `get_db_func` returns. Only the two wallet routes (:250, :280) call `_ensure_x402_tables`, so on a node where no wallet was ever registered the table is absent from the runtime DB and the unguarded join at :379-382 raises. On `main` the loop never ran, because the export always returned zero rows — the two bugs hid each other.

Guarded with the module's own `_ensure_x402_tables`, matching what both wallet routes already do (idempotent `CREATE TABLE IF NOT EXISTS`).

## Severity, honestly

Both prices are `"0"` in `x402_config.py:33,38` today, so **nobody is currently paying for an empty response** — the endpoints are free and inert. I am not claiming lost funds. What I'd flag is the failure mode: the comments there read `# Future: "50000" = $0.05`, and the day those flip on, a caller pays USDC and receives `total: 0` with a 200 — no error, no refund path, nothing in the logs. The contracts export would also 500 for the first payer whose node never registered a wallet. Worth fixing before the price is switched on rather than after. You know your deployment; the weight is yours to set.

## Why the tests never caught it

`tests/test_beacon_x402_payment_gate.py:14,84` fixtures the database with hand-written `CREATE TABLE reputation` / `CREATE TABLE contracts` — the consumer's imagined names, which no producer creates. The suite validated the bug rather than the deployed schema. Same pattern as the anchors (#7987) and fleet (#7988) skews.

## Verification

New `tests/test_beacon_x402_premium_export_real_schema.py` builds the DB by calling the **real producer** (`beacon_api.init_beacon_tables`), so the fixture cannot drift from what the node deploys.

- **3 fail on pristine `main`, 4 pass with this fix** (verified in a clean worktree at `upstream/main`).
- The 4th test is a control — a genuinely-empty `beacon_reputation` still correctly returns `total: 0`, and it passes both on `main` and with the fix, proving the tests distinguish the bug from real empty state.
- Neighbours green: **186 passed, 10 skipped** (`-k beacon`), plus the 7 existing gate tests still pass unchanged.
- `tests/test_relic_market_signing_keys.py` fails collection on `main` too (`ModuleNotFoundError: No module named 'nacl'`) — pre-existing, unrelated.

## Not bundled

`x402_beacon_payments` is created and read (:409) but **never inserted into** anywhere in the module — the payment history endpoint is empty by construction. That looks like an unfinished feature rather than a typo, so I left it alone rather than guess at the intended write path. Happy to take it as a follow-up if you want it.

RTC: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7
