### PR TITLE
fix(node-health): total_miners sums replica counts and inflates the figure Nx

### DIFF
--- a/tools/node_health_monitor.py
+++ b/tools/node_health_monitor.py
@@ -158,7 +158,14 @@ class NodeHealthMonitor:
 
         online = [s for s in statuses if s.status != "offline"]
         nodes_online = len(online)
-        total_miners = sum(s.miners or 0 for s in online)
+        # The attestation nodes are replicas of one shared ledger, so each online
+        # node reports the SAME network-wide miner count (the sibling tools
+        # ledger_verify / node_sync_validator flag any divergence as a mismatch).
+        # Summing per-node counts would multiply the true figure by the number of
+        # online nodes, so take the agreed value (max is robust to a node that is
+        # mid-sync and momentarily reporting fewer miners).
+        miner_counts = [s.miners for s in online if s.miners is not None]
+        total_miners = max(miner_counts) if miner_counts else 0
 
         epochs = {s.epoch for s in online if s.epoch is not None}
         consensus_ok = len(epochs) <= 1  # 0 or 1 distinct epoch → consensus holds

--- a/tools/test_node_health_total_miners.py
+++ b/tools/test_node_health_total_miners.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Regression test: NetworkHealth.total_miners must not multiply by node count.
+
+The attestation nodes are replicas of one shared ledger, so every online node
+reports the SAME network-wide miner count (ledger_verify / node_sync_validator
+flag any divergence as a mismatch). total_miners must therefore be the agreed
+value, not the sum across nodes.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools.node_health_monitor import NodeHealthMonitor, NodeStatus
+
+
+def _node(url, epoch, miners, status="online"):
+    return NodeStatus(
+        url=url, status=status, response_time_ms=10.0,
+        epoch=epoch, miners=miners, error=None,
+    )
+
+
+def test_replicas_are_not_summed():
+    m = NodeHealthMonitor()
+    statuses = [_node("n1", 42, 150), _node("n2", 42, 150), _node("n3", 42, 150)]
+    h = m.get_network_health(statuses)
+    # Buggy code returned 450 (3 * 150); correct network count is 150.
+    assert h.total_miners == 150, h.total_miners
+
+
+def test_lagging_node_does_not_lower_count():
+    m = NodeHealthMonitor()
+    statuses = [_node("n1", 42, 150), _node("n2", 42, 149), _node("n3", 42, 150)]
+    h = m.get_network_health(statuses)
+    assert h.total_miners == 150, h.total_miners
+
+
+def test_offline_and_missing_data():
+    m = NodeHealthMonitor()
+    statuses = [_node("n1", 42, 150), _node("n2", None, None, "offline"), _node("n3", 42, 150)]
+    h = m.get_network_health(statuses)
+    assert h.total_miners == 150 and h.nodes_online == 2
+
+    h = m.get_network_health([_node("n1", 42, None), _node("n2", 42, None)])
+    assert h.total_miners == 0
+
+
+if __name__ == "__main__":
+    test_replicas_are_not_summed()
+    test_lagging_node_does_not_lower_count()
+    test_offline_and_missing_data()
+    print("all node_health total_miners regression tests passed")


### PR DESCRIPTION
## The bug

`NodeHealthMonitor.get_network_health` reports the headline **Total miners** figure by summing each online node's count:

```python
online = [s for s in statuses if s.status != "offline"]
total_miners = sum(s.miners or 0 for s in online)   # <-- inflates Nx
```

But the monitored nodes (`DEFAULT_NODES`, three `:8088/:8099` hosts) are **replicas of one shared ledger**. Each `/status` returns the *network-wide* active-miner count (`miners` / `active_miners` / `miner_count`), not a disjoint per-node slice. The sibling tools in this repo prove the intent — they treat any divergence between nodes as an anomaly:

- `monitoring/ledger_verify.py` → `miner_count_match` / `MINER COUNT MISMATCH`
- `tools/node_sync_validator.py` → `miner_count_mismatch`

So in the healthy case every online node agrees, and summing multiplies the true count by the number of online nodes.

**Concrete input → wrong output:** 3 online nodes each reporting `miners = 150` (a network with 150 miners) → buggy `total_miners = 150 + 150 + 150 = 450`; correct = `150`. The operator's table (`print_table`) and `--json` output always show a fabricated 2-3x miner population.

## The fix

Take the value the replicas agree on instead of summing. `max` is used so a node that is mid-sync and momentarily reporting fewer miners doesn't drag the figure down:

```python
miner_counts = [s.miners for s in online if s.miners is not None]
total_miners = max(miner_counts) if miner_counts else 0
```

## Test

Added `tools/test_node_health_total_miners.py`: 3 replicas → 150 (not 450); one lagging node (149) → 150; one offline → 150 with `nodes_online=2`; no miner data → 0 (no crash). All pass.

Verified against `upstream/main` @ c6501de1.

RTC: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`