### PR TITLE
fix(gpu-attest): tensor-core gate string-compares CC, dropping channel for CC>=10

### DIFF
--- a/node/gpu_attestation.py
+++ b/node/gpu_attestation.py
@@ -4,6 +4,21 @@ import os
 import subprocess
 from typing import Dict, Tuple
 
+def _supports_tensor_cores(compute_capability) -> bool:
+    """Tensor cores exist on CUDA compute capability >= 7.0 (Volta and newer).
+
+    compute_capability is a string like "7.0", "8.0", "9.0", "10.0", "12.0"
+    (built as f"{major}.{minor}"). It must be compared numerically: a raw
+    string comparison mis-ranks multi-digit majors — "10.0" >= "7.0" is False
+    because '1' < '7' lexically — which silently dropped the tensor-core channel
+    for exactly the newest tensor-core GPUs (Blackwell CC 10.0 / 12.0).
+    """
+    try:
+        return float(compute_capability) >= 7.0
+    except (TypeError, ValueError):
+        return False
+
+
 def validate_gpu_fingerprint(fingerprint_data: Dict) -> Tuple[bool, str]:
     """
     Server-side validation of GPU fingerprint data (RIP-0308).
@@ -70,7 +85,7 @@ def get_gpu_attestation_payload(device_index=0) -> Dict:
     
     # Add Channel 8f (Tensor Core LSB Signature) for deep silicon identity
     try:
-        if fp.compute_capability >= "7.0":
+        if _supports_tensor_cores(fp.compute_capability):
             tc_fp = run_tensor_core_fingerprint(device_index=device_index)
             payload["channels"].append({
                 "name": "8f: Tensor Core Precision Drift",

--- a/node/tests/test_gpu_tensor_core_cc_compare.py
+++ b/node/tests/test_gpu_tensor_core_cc_compare.py
@@ -1,0 +1,46 @@
+"""
+Regression test for the tensor-core compute-capability gate in gpu_attestation.
+
+`GPUFingerprint.compute_capability` is a string built as f"{major}.{minor}"
+("7.0", "8.0", "9.0", "10.0", "12.0", ...). get_gpu_attestation_payload gates
+the Channel 8f (Tensor Core) fingerprint on that value being >= 7.0.
+
+The gate used a raw string comparison (`fp.compute_capability >= "7.0"`), which
+compares lexically: "10.0" >= "7.0" is False because '1' < '7'. That silently
+dropped the tensor-core channel for exactly the newest tensor-core GPUs —
+Blackwell data-center (CC 10.0) and consumer Blackwell / RTX-50 (CC 12.0) —
+while Volta..Hopper (7.0-9.x) worked. The fix parses the value numerically.
+
+This test does not require torch/CUDA: `import torch` in gpu_attestation is
+function-local, so the module and the helper import cleanly on any host.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from gpu_attestation import _supports_tensor_cores
+
+
+def test_volta_through_hopper_supported():
+    for cc in ["7.0", "7.5", "8.0", "8.6", "9.0"]:
+        assert _supports_tensor_cores(cc) is True, cc
+
+
+def test_blackwell_multidigit_major_supported():
+    # These are exactly the values the old string comparison wrongly rejected.
+    for cc in ["10.0", "12.0"]:
+        assert _supports_tensor_cores(cc) is True, cc
+        # Guard against a regression back to lexical comparison.
+        assert (cc >= "7.0") is False, cc
+
+
+def test_pre_volta_not_supported():
+    for cc in ["5.0", "6.0", "6.1"]:
+        assert _supports_tensor_cores(cc) is False, cc
+
+
+def test_malformed_values_do_not_crash():
+    for cc in [None, "", "abc"]:
+        assert _supports_tensor_cores(cc) is False, cc


### PR DESCRIPTION
## The bug

`get_gpu_attestation_payload` (node/gpu_attestation.py) gates the Channel 8f **Tensor Core** fingerprint on the GPU's compute capability:

```python
if fp.compute_capability >= "7.0":
    tc_fp = run_tensor_core_fingerprint(...)
```

`compute_capability` is a **string** (`GPUFingerprint.compute_capability: str`, built as `f"{major}.{minor}"` — "7.0", "8.0", "9.0", "10.0", "12.0"). `>=` on strings compares **lexically**, so:

```
"10.0" >= "7.0"  ->  False   ('1' < '7')
"12.0" >= "7.0"  ->  False
```

The check is meant to include Volta and newer (all of which have tensor cores). It instead **silently drops the tensor-core channel for exactly the newest tensor-core GPUs** — Blackwell data-center (CC 10.0) and consumer Blackwell / RTX-50 (CC 12.0) — while Volta..Hopper (7.0-9.x) pass. Those miners' attestation payloads are missing Channel 8f entirely.

## The fix

Parse the value numerically via a small helper (so it's unit-testable without a GPU):

```python
def _supports_tensor_cores(compute_capability) -> bool:
    try:
        return float(compute_capability) >= 7.0
    except (TypeError, ValueError):
        return False
...
if _supports_tensor_cores(fp.compute_capability):
```

## Test

Added `node/tests/test_gpu_tensor_core_cc_compare.py` (torch-free — `import torch` in gpu_attestation is function-local): Volta..Hopper supported; CC 10.0 / 12.0 now supported (and asserts the old lexical compare returned False for them); pre-Volta and malformed values rejected without crashing. 4 pass.

Verified against `upstream/main` @ c6501de1.

RTC: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`