### PR TITLE
fix(airdrop): canonicalize Base wallet case so one wallet cannot double-claim

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -319,6 +319,24 @@ class AirdropV2:
         return (github_username or "").strip().casefold()
 
     @staticmethod
+    def _normalize_wallet(wallet_address: str, chain: str) -> str:
+        """Canonicalize a wallet address for de-duplication.
+
+        Base (EVM) addresses are case-insensitive on-chain: the same account
+        can be written checksummed (EIP-55), all-lower, or all-upper, and
+        eth_getBalance returns the identical balance for every casing. The
+        one-airdrop-per-wallet invariant must therefore compare a canonical
+        (lowercase) form, otherwise the same physical Base wallet slips past
+        _has_claimed / UNIQUE(github_username, wallet_address, chain) simply by
+        varying hex case. Solana uses base58, which IS case-sensitive, so it is
+        left untouched.
+        """
+        wallet_address = (wallet_address or "").strip()
+        if chain and chain.lower() == "base":
+            return wallet_address.lower()
+        return wallet_address
+
+    @staticmethod
     def _is_valid_github_username(github_username: str) -> bool:
         return bool(GITHUB_USERNAME_RE.fullmatch(github_username))
 
@@ -355,6 +373,7 @@ class AirdropV2:
                 eligible=False,
                 reason=f"Unsupported chain: {chain}. Must be 'solana' or 'base'",
             )
+        wallet_address = self._normalize_wallet(wallet_address, chain_lower)
 
         checks = {}
 
@@ -794,6 +813,7 @@ class AirdropV2:
         if not self._is_valid_github_username(github_username):
             return False, "Invalid GitHub username", None
         chain_lower = chain.lower()
+        wallet_address = self._normalize_wallet(wallet_address, chain_lower)
 
         if self._has_claimed(github_username, wallet_address, chain_lower):
             return False, "Claim already exists for this GitHub account or wallet", None

--- a/node/test_airdrop_wallet_case_dedup.py
+++ b/node/test_airdrop_wallet_case_dedup.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Regression tests for the airdrop wallet-address de-duplication invariant.
+
+Base (EVM) addresses are case-insensitive on-chain: 0xAbCd..., 0xabcd... and
+0xABCD... are the *same* account and eth_getBalance returns the same balance
+for every casing. The airdrop enforces "one claim per wallet" via _has_claimed
+and UNIQUE(github_username, wallet_address, chain). Before the fix, the wallet
+half of that invariant compared raw strings, so the same physical Base wallet
+could collect the airdrop multiple times (once per GitHub identity) simply by
+varying hex case — draining the Base allocation.
+
+Solana uses base58, which IS case-sensitive, so different casings there are
+genuinely different wallets and must stay allowed.
+"""
+import unittest
+
+from airdrop_v2 import AirdropV2
+
+
+class TestWalletCaseDedup(unittest.TestCase):
+    def setUp(self):
+        self.a = AirdropV2(":memory:")
+
+    def test_base_same_wallet_different_case_cannot_double_claim(self):
+        """Same Base wallet in different hex casing must NOT claim twice."""
+        checksum = "0xAbCdEf0000000000000000000000000000000001"
+        lower = "0xabcdef0000000000000000000000000000000001"
+        upper = "0xABCDEF0000000000000000000000000000000001"
+
+        ok1, _, _ = self.a.claim_airdrop(
+            "alice", checksum, "base", "contributor", skip_antisybil=True
+        )
+        ok2, msg2, _ = self.a.claim_airdrop(
+            "bob", lower, "base", "contributor", skip_antisybil=True
+        )
+        ok3, _, _ = self.a.claim_airdrop(
+            "carol", upper, "base", "contributor", skip_antisybil=True
+        )
+
+        self.assertTrue(ok1)
+        self.assertFalse(ok2, "lowercased same Base wallet should be rejected")
+        self.assertFalse(ok3, "uppercased same Base wallet should be rejected")
+        self.assertIn("already exists", msg2.lower())
+
+        base = self.a.get_allocation_status()["base"]
+        # Exactly one 'contributor' reward (50 wRTC) charged, not two or three.
+        self.assertEqual(base["claimed_wrtc"], 50.0)
+
+    def test_base_eligibility_check_rejects_case_variant(self):
+        """check_eligibility must also see the canonical form."""
+        self.a.claim_airdrop(
+            "alice",
+            "0xAbCdEf0000000000000000000000000000000001",
+            "base",
+            "contributor",
+            skip_antisybil=True,
+        )
+        res = self.a.check_eligibility(
+            "bob",
+            "0xABCDEF0000000000000000000000000000000001",
+            "base",
+            skip_antisybil=True,
+        )
+        self.assertFalse(res.eligible)
+
+    def test_solana_case_sensitivity_preserved(self):
+        """base58 Solana addresses are case-sensitive: distinct casings are
+        distinct wallets and must remain independently claimable."""
+        ok1, _, _ = self.a.claim_airdrop(
+            "carol", "AbCdEfSol111", "solana", "contributor", skip_antisybil=True
+        )
+        ok2, _, _ = self.a.claim_airdrop(
+            "dave", "abcdefSol111", "solana", "contributor", skip_antisybil=True
+        )
+        self.assertTrue(ok1)
+        self.assertTrue(ok2)
+        self.assertEqual(self.a.get_allocation_status()["solana"]["claimed_wrtc"], 100.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug: same Base (EVM) wallet can claim the airdrop multiple times by varying hex case

`node/airdrop_v2.py` enforces **one airdrop per GitHub account and per wallet** — `_has_claimed()` and `UNIQUE(github_username, wallet_address, chain)`. Only the GitHub half is canonicalized (`_normalize_github_username` casefolds it); `wallet_address` is compared as a **raw string** everywhere.

Base is EVM, where addresses are **case-insensitive on-chain**: `0xAbCd…`, `0xabcd…` and `0xABCD…` are the *same account* and `eth_getBalance` (`_check_base_wallet`) returns the identical balance for every casing — so every casing passes the anti-Sybil check. But `_has_claimed` and the `UNIQUE` index treat each casing as a *different* wallet, so the wallet-dedup leg is void for the entire Base chain.

### Impact
N aged, PR-merged GitHub accounts can all funnel the airdrop to **one physical Base wallet** by only changing hex case, and the global Base allocation is debited each time. Even a single honest user who claims with an EIP-55 checksummed address and re-submits the lowercased form gets a second allocation.

### Repro (deterministic, no network — `skip_antisybil=True`)
```python
a = AirdropV2(":memory:")
a.claim_airdrop("alice", "0xAbCdEf...01", "base", "contributor", skip_antisybil=True)  # ok
a.claim_airdrop("bob",   "0xabcdef...01", "base", "contributor", skip_antisybil=True)  # main: ALSO ok (bug)
# main -> base claimed_wrtc == 100 (same wallet paid twice)
```

### Fix
Add `_normalize_wallet(address, chain)` and canonicalize `wallet_address` at the entry of both `check_eligibility` and `claim_airdrop` (lowercase for `base`; **Solana base58 left untouched — it is genuinely case-sensitive**), so dedup, the UNIQUE index, the generated claim id and the RPC balance check all use one canonical form.

### Tests
- New `node/test_airdrop_wallet_case_dedup.py`: fails on main (Base wallet double-claims, 100 wRTC), passes with fix (50 wRTC, one claim); Solana distinct-case wallets stay independently claimable.
- Existing `node/test_airdrop_v2.py` — **31 passed**, no regressions.

Claiming under rustchain-bounties#71. Payout RTC: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`