### PR TITLE
fix(attest): temporal profile reads keys no fingerprint producer emits (3 of 4 anti-spoof bands dead)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3269,11 +3269,30 @@ def extract_temporal_profile(fingerprint: dict) -> dict:
     jitter = _check_data("instruction_jitter")
     cache = _check_data("cache_timing")
 
+    # Prefer the keys the fingerprint producers (fingerprint_checks.py) actually
+    # emit; keep the legacy names as fallbacks so older payloads still populate.
+    # check_thermal_drift emits `drift_ratio` (not `variance`),
+    # check_instruction_jitter emits `int_stdev`/`int_avg_ns` (not `cv`/`stddev_ns`),
+    # check_cache_timing emits `l2_l1_ratio` (not `hierarchy_ratio`). Without this
+    # three of the four TEMPORAL_DRIFT_BANDS read 0.0 for every real miner and are
+    # silently skipped (validate_temporal_consistency scores <3-sample metrics 1.0),
+    # collapsing the anti-spoofing detector onto clock_drift_cv alone. Mirrors the
+    # primary/legacy handling already used for cache ratios at _detect_x86_evidence.
+    int_avg = _attest_metric_float(jitter.get("int_avg_ns", 0.0))
+    int_stdev = _attest_metric_float(jitter.get("int_stdev", 0.0))
+    jitter_cv = jitter.get("cv", jitter.get("stddev_ns"))
+    if jitter_cv is None:
+        jitter_cv = (int_stdev / int_avg) if int_avg > 0 else 0.0
+
     return {
         "clock_drift_cv": _attest_metric_float(clock.get("cv", 0.0)),
-        "thermal_variance": _attest_metric_float(thermal.get("variance", 0.0)),
-        "jitter_cv": _attest_metric_float(jitter.get("cv", jitter.get("stddev_ns", 0.0))),
-        "cache_hierarchy_ratio": _attest_metric_float(cache.get("hierarchy_ratio", 0.0)),
+        "thermal_variance": _attest_metric_float(
+            thermal.get("drift_ratio", thermal.get("variance", 0.0))
+        ),
+        "jitter_cv": _attest_metric_float(jitter_cv),
+        "cache_hierarchy_ratio": _attest_metric_float(
+            cache.get("l2_l1_ratio", cache.get("hierarchy_ratio", 0.0))
+        ),
     }
 
 

--- a/tests/test_temporal_profile_producer_keys.py
+++ b/tests/test_temporal_profile_producer_keys.py
@@ -1,0 +1,70 @@
+"""Regression: extract_temporal_profile must read the keys the fingerprint
+producers (fingerprint_checks.py) actually emit.
+
+The real miner builds its attestation payload as
+    {"checks": validate_all_checks()...}
+where each check's ``data`` uses:
+    thermal_drift      -> drift_ratio   (NOT "variance")
+    instruction_jitter -> int_stdev/int_avg_ns  (NOT "cv"/"stddev_ns")
+    cache_timing       -> l2_l1_ratio   (NOT "hierarchy_ratio")
+
+Before the fix, extract_temporal_profile read variance/cv/hierarchy_ratio, so
+thermal_variance, jitter_cv and cache_hierarchy_ratio were 0.0 for every real
+attestation. validate_temporal_consistency scores any metric with <3 non-zero
+samples a perfect 1.0, so three of the four TEMPORAL_DRIFT_BANDS were silently
+skipped and the anti-spoofing detector ran on clock_drift_cv alone.
+"""
+
+import integrated_node
+
+
+def _producer_fp(drift_ratio, int_avg_ns, int_stdev, l2_l1_ratio, cv=0.02):
+    """A fingerprint shaped exactly like miners/*/*.py send it."""
+    return {
+        "checks": {
+            "clock_drift": {"data": {"cv": cv}},
+            "thermal_drift": {"data": {"drift_ratio": drift_ratio}},
+            "instruction_jitter": {
+                "data": {"int_avg_ns": int_avg_ns, "int_stdev": int_stdev}
+            },
+            "cache_timing": {"data": {"l2_l1_ratio": l2_l1_ratio}},
+        }
+    }
+
+
+def test_profile_populates_from_producer_keys():
+    prof = integrated_node.extract_temporal_profile(
+        _producer_fp(drift_ratio=1.18, int_avg_ns=800, int_stdev=40, l2_l1_ratio=3.2)
+    )
+    # clock always worked; the other three must no longer be silently zero.
+    assert prof["clock_drift_cv"] > 0
+    assert prof["thermal_variance"] > 0, "thermal band read from producer drift_ratio"
+    assert prof["jitter_cv"] > 0, "jitter band derived from int_stdev/int_avg_ns"
+    assert prof["cache_hierarchy_ratio"] > 0, "cache band read from producer l2_l1_ratio"
+    # jitter_cv must be the coefficient of variation stdev/avg = 40/800 = 0.05
+    assert abs(prof["jitter_cv"] - 0.05) < 1e-6
+
+
+def test_frozen_fingerprint_replay_flagged_on_all_bands():
+    """A replayed/frozen fingerprint (identical thermal/jitter/cache readings on
+    every attestation) is a spoofing signal the temporal detector is meant to
+    catch via its ``frozen_profile`` rule. Before the fix these three bands read
+    a constant 0.0, were filtered out (v>0) and skipped with a perfect 1.0 score,
+    so a frozen profile could never be flagged on them. After the fix the real
+    producer values feed the bands, the frozen rule fires, and each drops to 0.2.
+    """
+    seq = []
+    for i in range(5):
+        prof = integrated_node.extract_temporal_profile(
+            # identical producer readings every attestation -> frozen profile
+            _producer_fp(drift_ratio=1.18, int_avg_ns=800, int_stdev=40, l2_l1_ratio=3.2)
+        )
+        seq.append({"ts": i + 1, "profile": prof})
+
+    review = integrated_node.validate_temporal_consistency(seq)
+    scores = review["check_scores"]
+    for band in ("thermal_variance", "jitter_cv", "cache_hierarchy_ratio"):
+        # skipped bands score exactly 1.0; an evaluated frozen band scores <=0.2
+        assert scores.get(band, 1.0) < 1.0, f"{band} must be evaluated, not skipped"
+        assert f"frozen_profile:{band}" in review["flags"]
+    assert review["review_flag"] is True


### PR DESCRIPTION
## Bug: temporal anti-spoofing detector reads keys no fingerprint producer emits

`extract_temporal_profile` (node/rustchain_v2_integrated_v2.2.1_rip200.py) builds the per-attestation profile that feeds `validate_temporal_consistency` (the RIP anti-spoofing detector). It read the wrong dict keys:

| band | key read (before) | key the producer actually emits |
|---|---|---|
| `clock_drift_cv` | `cv` | ✅ `cv` — the only one that worked |
| `thermal_variance` | `variance` | ❌ `check_thermal_drift` → `drift_ratio` |
| `jitter_cv` | `cv`/`stddev_ns` | ❌ `check_instruction_jitter` → `int_stdev`/`int_avg_ns` |
| `cache_hierarchy_ratio` | `hierarchy_ratio` | ❌ `check_cache_timing` → `l2_l1_ratio` |

The real miner sends `{"checks": validate_all_checks()...}` (see `miners/linux/rustchain_linux_miner.py:343-345,642`), and `validate_all_checks` (fingerprint_checks.py:890) wraps each check's `data` under its name. So for **every real attestation** `thermal_variance`, `jitter_cv` and `cache_hierarchy_ratio` were `0.0`.

Downstream, `validate_temporal_consistency` filters values with `if v > 0`, and any band left with `< 3` samples is scored a perfect `1.0` and skipped. Result: three of the four `TEMPORAL_DRIFT_BANDS` were permanently dead and the detector effectively ran on `clock_drift_cv` alone — a frozen/replayed thermal, jitter or cache profile could never be flagged.

Not by-design: `TEMPORAL_DRIFT_BANDS` configures plausibility bands for all four metrics, and the codebase already reads the real cache key (`l2_l1_ratio` primary, `hierarchy_ratio` legacy fallback) in `_detect_x86_evidence` — `extract_temporal_profile` was just never updated the same way. It's on the live attestation path (Flask app in this module; `record_attestation_success → append_fingerprint_snapshot → extract_temporal_profile`, then `validate_temporal_consistency(fetch_miner_fingerprint_sequence(...))`).

## Fix
Read the producer keys, keeping the legacy names as fallbacks so older payloads (and the existing suite) still populate. Mirrors the primary/legacy handling already used for cache ratios.

## Tests
`tests/test_temporal_profile_producer_keys.py` (new):
- producer-shaped payload populates all four bands (`jitter_cv` = `int_stdev/int_avg_ns`);
- a frozen (replayed) fingerprint now trips `frozen_profile` on all three previously-dead bands.

Both **fail on current main** (mutation-checked: bands score `1.0`/skipped) and pass with the fix. Existing `test_entropy_temporal_validation.py` (4) and `test_consensus_invariant_attractor.py` (7) stay green.

/claim rustchain-bounties#71

RTC payout: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`