### PR TITLE
fix(security): freeze fund-exit for blocked/under-review wallets (block gate only guarded /attest)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5837,6 +5837,19 @@ def ensure_wallet_review_tables(conn):
     )
     conn.execute("CREATE INDEX IF NOT EXISTS idx_wallet_review_wallet ON wallet_review_holds(wallet, created_at DESC)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_wallet_review_status ON wallet_review_holds(status, created_at DESC)")
+    # get_wallet_review_entry() also reads the legacy blocked_wallets table, so
+    # ensure it exists here too — otherwise the gate raises "no such table:
+    # blocked_wallets" on any DB where the main startup init never ran (e.g. a
+    # node/tool that only touches the review helpers). The gate must be safe to
+    # call from every endpoint, not just /attest/submit.
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS blocked_wallets(
+            wallet TEXT PRIMARY KEY,
+            reason TEXT
+        )
+        """
+    )
 
 
 _ADMIN_SESSIONS: dict = {}
@@ -6483,6 +6496,17 @@ def request_withdrawal():
 
     if not all([miner_pk, destination, signature, nonce]):
         return jsonify({"error": "Missing required fields"}), 400
+
+    # SECURITY: a wallet under review / blocked (wallet_review_holds or the
+    # legacy blocked_wallets table) must not be able to move funds out. The
+    # same gate already guards /attest/submit, but the fund-EXIT paths never
+    # consulted it — so a flagged wallet could drain its whole balance before
+    # a maintainer released it, defeating the entire purpose of a review hold.
+    # Checked before the BEGIN IMMEDIATE write transaction below so the gate's
+    # own read connection cannot contend with the reserved write lock.
+    review_gate = wallet_review_gate_response(miner_pk)
+    if review_gate is not None:
+        return review_gate
 
     # SECURITY: Validate amount is a number (CVE-style float injection)
     raw_amount = data.get('amount', 0)
@@ -11313,6 +11337,16 @@ def wallet_transfer_signed():
     to_address = pre.details["to_address"]
     nonce_int = pre.details["nonce"]
     chain_id = pre.details.get("chain_id")
+
+    # SECURITY: freeze fund-exit for a wallet under review / blocked. Mirrors
+    # the guard on /attest/submit and /withdraw/request — a flagged sender must
+    # not be able to sweep its balance to another address while a maintainer
+    # review is pending. Checked on the sender (from_address) before any state
+    # mutation or the debit below.
+    review_gate = wallet_review_gate_response(from_address)
+    if review_gate is not None:
+        return review_gate
+
     # SECURITY (#6127): Validate signature/public_key types before str() coercion
     _raw_sig = data.get("signature")
     _raw_pubkey = data.get("public_key")

--- a/node/tests/test_blocked_wallet_fund_exit_freeze.py
+++ b/node/tests/test_blocked_wallet_fund_exit_freeze.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression: a wallet marked in the block/review registry must not be able to
+move funds out.
+
+The gate `wallet_review_gate_response()` (backed by `wallet_review_holds` and
+the legacy `blocked_wallets` table) was wired to exactly one endpoint —
+/attest/submit (line ~4631). Every fund-EXIT path (/withdraw/request,
+/wallet/transfer/signed, /utxo/transfer) ignored it, so a wallet an operator
+had just frozen for fraud/compromise could still drain its entire balance
+before a maintainer released it. Freezing the ability to *earn* while leaving
+the ability to *spend* wide open defeats the whole purpose of a review hold.
+
+These tests drive the real Flask endpoints with a genuinely blocked wallet and
+assert the request is refused (403 wallet_blocked) with the balance untouched.
+They FAIL on the pre-fix code (which returns 404/401 from the later
+registration/signature checks, having debited nothing only by accident) and
+PASS once the gate is consulted on the sender before any state mutation.
+"""
+
+import gc
+import importlib.util
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+# Valid RTC address form (RTC + 40 hex) so it clears the transfer validator and
+# reaches the sender block-gate rather than being rejected on address format.
+BLOCKED = "RTC" + "a" * 40
+
+
+class TestBlockedWalletFundExitFreeze(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.mkdtemp(prefix="blocked-fund-exit-")
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._tmp, "import.db")
+        os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
+
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+        spec = importlib.util.spec_from_file_location(
+            "rustchain_integrated_blocked_fund_exit_test", MODULE_PATH
+        )
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+        cls.client = cls.mod.app.test_client()
+
+        # Seed a blocked-registry entry and a balance for BLOCKED.
+        with sqlite3.connect(cls.mod.DB_PATH) as conn:
+            cls.mod.ensure_wallet_review_tables(conn)
+            conn.execute(
+                """INSERT INTO wallet_review_holds
+                   (wallet, status, reason, coach_note, reviewer_note, created_at, reviewed_at)
+                   VALUES (?, 'blocked', 'fraud-review', '', '', ?, 0)""",
+                (BLOCKED, int(time.time())),
+            )
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS balances (
+                       miner_id TEXT PRIMARY KEY, miner_pk TEXT,
+                       amount_i64 INTEGER DEFAULT 0, balance_rtc REAL DEFAULT 0)"""
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO balances (miner_id, miner_pk, amount_i64, balance_rtc) "
+                "VALUES (?, ?, ?, ?)",
+                (BLOCKED, BLOCKED, 100 * cls.mod.ACCOUNT_UNIT, 100.0),
+            )
+            conn.commit()
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.mod.app.do_teardown_appcontext()
+        except Exception:
+            pass
+        cls.client = None
+        cls.mod = None
+        for key, prev in (
+            ("RUSTCHAIN_DB_PATH", cls._prev_db_path),
+            ("RC_ADMIN_KEY", cls._prev_admin_key),
+        ):
+            if prev is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prev
+        gc.collect()
+        shutil.rmtree(cls._tmp, ignore_errors=True)
+
+    def _balance_i64(self):
+        with sqlite3.connect(self.mod.DB_PATH) as conn:
+            row = conn.execute(
+                "SELECT amount_i64 FROM balances WHERE miner_id = ?", (BLOCKED,)
+            ).fetchone()
+        return row[0] if row else 0
+
+    def test_withdraw_from_blocked_wallet_denied(self):
+        before = self._balance_i64()
+        resp = self.client.post(
+            "/withdraw/request",
+            json={
+                "miner_pk": BLOCKED,
+                "amount": 10,
+                "destination": "RTCsomewhereelse00000000000000000000000000",
+                "signature": "00",
+                "nonce": "n-block-1",
+            },
+        )
+        self.assertEqual(resp.status_code, 403, resp.get_json())
+        self.assertEqual(resp.get_json().get("error"), "wallet_blocked")
+        self.assertEqual(self._balance_i64(), before, "balance must be untouched")
+
+    def test_signed_transfer_from_blocked_wallet_denied(self):
+        before = self._balance_i64()
+        resp = self.client.post(
+            "/wallet/transfer/signed",
+            json={
+                "from_address": BLOCKED,
+                "to_address": "RTC" + "b" * 40,
+                "amount_rtc": 10,
+                "nonce": int(time.time()),
+                "signature": "00",
+                "public_key": "00" * 32,
+            },
+        )
+        # 400 only if the payload is rejected before the gate; the gate must win.
+        self.assertEqual(resp.status_code, 403, resp.get_json())
+        self.assertEqual(resp.get_json().get("error"), "wallet_blocked")
+        self.assertEqual(self._balance_i64(), before, "balance must be untouched")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Security bug: wallet block/review gate is enforced only on `/attest/submit`, not on any fund-exit path

`wallet_review_gate_response()` (backed by `wallet_review_holds` and the legacy `blocked_wallets` table) is the control an operator uses to freeze a compromised / fraud / sanctioned wallet. It is wired to exactly **one** call site — the attestation handler (`review_gate = wallet_review_gate_response(miner)`), which literally comments "Check wallet review / block registry".

Every path that lets value **leave** the ledger ignores it:

- `POST /withdraw/request` — verifies nonce, balance, encumbrance, daily limit and signature, then debits — but never consults the block registry.
- `POST /wallet/transfer/signed` — same, on the signed sender.

### Impact
A wallet an admin has just marked `blocked` / `needs_review` / `held` / `escalated` (via `/admin/wallet-review-holds`, resolve action `block`, or a legacy `blocked_wallets` row) can still **drain its entire balance** to any address before a maintainer releases it. Freezing the ability to *earn* (attest) while leaving the ability to *spend* wide open defeats the whole purpose of a review hold — draining funds is exactly the action a flagged wallet is most likely to take.

### Fix
- Consult `wallet_review_gate_response()` on the acting wallet (`miner_pk` / `from_address`) **before any state mutation** in `/withdraw/request` and `/wallet/transfer/signed`. The gate already returns a ready `(json, 403|409)` response, so blocked → `403 wallet_blocked`, under-review → `409 wallet_under_review`. Checked before the `BEGIN IMMEDIATE` write txn so the gate's own read connection can't contend with the reserved write lock.
- `ensure_wallet_review_tables()` now also creates the legacy `blocked_wallets` table that `get_wallet_review_entry()` reads. Previously the gate raised `no such table: blocked_wallets` on any DB where the main startup init hadn't created it — which is why it had never been safe to call outside the one attest path.

### Test
`node/tests/test_blocked_wallet_fund_exit_freeze.py` drives **both real endpoints** with a genuinely blocked wallet holding a balance, and asserts `403 wallet_blocked` with the balance untouched. Mutation-checked: neutralizing the gate makes both tests fail (the request proceeds past where it should stop); with the fix both pass. Existing withdraw/transfer/attest test suites remain green.