### PR TITLE
test: add cited device classification corpus and fuzz regressions

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2671,7 +2671,7 @@ def derive_verified_device(device: dict, fingerprint: dict, fingerprint_passed: 
         is_apple_silicon = (
             "apple m" in cpu_brand_lower or "apple_silicon" in arch.lower()
             or any(f"m{n}" in cpu_brand_lower for n in ("1", "2", "3", "4"))
-            or device.get("platform_system", "").lower() == "darwin"
+            or str(device.get("platform_system") or "").lower() == "darwin"
             or "mac" in str(device.get("model") or device.get("device_model") or "").lower()
         )
         if is_apple_silicon:

--- a/tests/device_classification_corpus.json
+++ b/tests/device_classification_corpus.json
@@ -1,0 +1,306 @@
+[
+  {
+    "id": "intel-486-dx2",
+    "category": "vintage_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel0000480_486_CPUID.txt",
+    "device": {"family": "x86", "arch": "486", "machine": "i486", "cpu": "Intel 486DX2"},
+    "expected": {"device_family": "x86", "device_arch": "486"}
+  },
+  {
+    "id": "intel-p5-60",
+    "category": "vintage_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel0000517_P5_CPUID.txt",
+    "device": {"family": "x86", "arch": "pentium", "machine": "i586", "cpu": "Intel Pentium 60"},
+    "expected": {"device_family": "x86", "device_arch": "pentium"}
+  },
+  {
+    "id": "intel-p54c",
+    "category": "vintage_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel0000525_P54C_CPUID.txt",
+    "device": {"family": "x86", "arch": "pentium", "machine": "i586", "cpu": "Intel Pentium P54C"},
+    "expected": {"device_family": "x86", "device_arch": "pentium"}
+  },
+  {
+    "id": "intel-pentium-mmx",
+    "category": "vintage_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel0000543_P55C_CPUID.txt",
+    "device": {"family": "x86", "arch": "modern", "machine": "i586", "cpu": "Intel Pentium MMX"},
+    "expected": {"device_family": "x86", "device_arch": "pentium_mmx"}
+  },
+  {
+    "id": "amd-k6-233",
+    "category": "vintage_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/AuthenticAMD/AuthenticAMD0000562_K6_CPUID.txt",
+    "device": {"family": "x86", "arch": "retro", "machine": "i586", "cpu": "AMD-K6tm w/ multimedia extensions"},
+    "expected": {"device_family": "x86", "device_arch": "retro"}
+  },
+  {
+    "id": "amd-k6-iii-400",
+    "category": "vintage_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/AuthenticAMD/AuthenticAMD0000591_K6_Sharptooth_CPUID.txt",
+    "device": {"family": "x86", "arch": "retro", "machine": "i586", "cpu": "AMD-K6(tm) 3D+ Processor"},
+    "expected": {"device_family": "x86", "device_arch": "retro"}
+  },
+  {
+    "id": "intel-pentium-ii-klamath",
+    "category": "vintage_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel0000633_P2_Klamath_CPUID.txt",
+    "device": {"family": "x86", "arch": "modern", "machine": "i686", "cpu": "Intel(R) Pentium(R) II"},
+    "expected": {"device_family": "x86", "device_arch": "pentium_ii"}
+  },
+  {
+    "id": "intel-pentium-iii-katmai",
+    "category": "vintage_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel0000673_P3_Katmai_CPUID.txt",
+    "device": {"family": "x86", "arch": "modern", "machine": "i686", "cpu": "Intel(R) Pentium(R) III"},
+    "expected": {"device_family": "x86", "device_arch": "pentium_iii"}
+  },
+  {
+    "id": "intel-pentium-iii-coppermine",
+    "category": "vintage_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel0000686_P3_Coppermine_CPUID.txt",
+    "device": {"family": "x86", "arch": "modern", "machine": "i686", "cpu": "Intel(R) Pentium(R) III CPU family 6 model 8"},
+    "expected": {"device_family": "x86", "device_arch": "pentium_iii"}
+  },
+  {
+    "id": "intel-pentium-m-banias",
+    "category": "vintage_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel0000695_PM_Banias_CPUID.txt",
+    "device": {"family": "x86", "arch": "modern", "machine": "i686", "cpu": "Intel(R) Pentium(R) M processor 1500MHz"},
+    "expected": {"device_family": "x86", "device_arch": "pentium_m_banias"}
+  },
+  {
+    "id": "intel-pentium-m-dothan",
+    "category": "vintage_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel00006D8_PM_Dothan_CPUID.txt",
+    "device": {"family": "x86", "arch": "modern", "machine": "i686", "cpu": "Intel(R) Pentium(R) M processor 2.00GHz"},
+    "expected": {"device_family": "x86", "device_arch": "pentium_m_dothan"}
+  },
+  {
+    "id": "intel-core2-conroe",
+    "category": "modern_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel00006F6_Conroe_CPUID.txt",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": "Intel(R) Core(TM)2 CPU 6600 @ 2.40GHz"},
+    "expected": {"device_family": "x86_64", "device_arch": "modern"}
+  },
+  {
+    "id": "intel-nehalem",
+    "category": "modern_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel00106A4_Bloomfield_CPUID.txt",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": "Intel(R) Core(TM) i7 CPU 920 @ 2.67GHz"},
+    "expected": {"device_family": "x86_64", "device_arch": "modern"}
+  },
+  {
+    "id": "intel-sandy-bridge",
+    "category": "modern_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel00206A7_SandyBridge_CPUID.txt",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": "Intel(R) Core(TM) i7-2600K CPU @ 3.40GHz"},
+    "expected": {"device_family": "x86_64", "device_arch": "modern"}
+  },
+  {
+    "id": "intel-ivy-bridge",
+    "category": "modern_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel00306A9_IvyBridge_CPUID.txt",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": "Intel(R) Core(TM) i7-3770 CPU @ 3.40GHz"},
+    "expected": {"device_family": "x86_64", "device_arch": "modern"}
+  },
+  {
+    "id": "intel-haswell",
+    "category": "modern_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel00306C3_Haswell_CPUID.txt",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": "Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz"},
+    "expected": {"device_family": "x86_64", "device_arch": "modern"}
+  },
+  {
+    "id": "intel-skylake",
+    "category": "modern_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel00506E3_Skylake_CPUID.txt",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": "Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz"},
+    "expected": {"device_family": "x86_64", "device_arch": "modern"}
+  },
+  {
+    "id": "intel-kaby-lake",
+    "category": "modern_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel00906E9_KabyLake_01_CPUID.txt",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": "Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz"},
+    "expected": {"device_family": "x86_64", "device_arch": "modern"}
+  },
+  {
+    "id": "intel-alder-lake",
+    "category": "modern_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/GenuineIntel/GenuineIntel0090672_AlderLake_02_CPUID.txt",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": "12th Gen Intel(R) Core(TM) i9-12900K"},
+    "expected": {"device_family": "x86_64", "device_arch": "modern"}
+  },
+  {
+    "id": "amd-zen2-matisse",
+    "category": "modern_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/AuthenticAMD/AuthenticAMD0870F10_K17_Matisse_CPUID.txt",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": "AMD Ryzen 7 3700X 8-Core Processor"},
+    "expected": {"device_family": "x86_64", "device_arch": "modern"}
+  },
+  {
+    "id": "amd-zen3-vermeer",
+    "category": "modern_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/AuthenticAMD/AuthenticAMD0A20F12_K19_Vermeer_00_CPUID.txt",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": "AMD Ryzen 9 5950X 16-Core Processor"},
+    "expected": {"device_family": "x86_64", "device_arch": "modern"}
+  },
+  {
+    "id": "amd-epyc-rome",
+    "category": "modern_x86",
+    "provenance": "measured_cpuid",
+    "source": "https://github.com/InstLatx64/InstLatx64/blob/ae88464b1b88e364579083ff4445acd505ead471/AuthenticAMD/AuthenticAMD0830F10_K17_Rome_CPUID.txt",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": "AMD EPYC 7742 64-Core Processor"},
+    "expected": {"device_family": "x86_64", "device_arch": "modern"}
+  },
+  {
+    "id": "raspberry-pi-3",
+    "category": "arm_sbc",
+    "provenance": "published_hardware_facts",
+    "source": "https://github.com/Arksine/moonraker/blob/d5ee17128bb88434aacdab90c2e9e990e2b64e4a/docs/external_api/machine.md",
+    "device": {"family": "x86", "arch": "modern", "machine": "armv7l", "cpu": "ARMv7 Processor rev 4 (v7l)", "model": "Raspberry Pi 3 Model B Rev 1.2"},
+    "expected": {"device_family": "ARM", "device_arch": "armv7"}
+  },
+  {
+    "id": "raspberry-pi-4-aarch64",
+    "category": "arm_sbc",
+    "provenance": "published_hardware_facts",
+    "source": "https://github.com/linuxhw/HWInfo/tree/31b81aef173d9530eee80e016b90a4bd5c908e59/SBC/Raspberry-Pi-Foundation",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "aarch64", "cpu": "Cortex-A72", "model": "Raspberry Pi 4 Model B"},
+    "expected": {"device_family": "ARM", "device_arch": "aarch64"}
+  },
+  {
+    "id": "raspberry-pi-5-aarch64",
+    "category": "arm_sbc",
+    "provenance": "published_hardware_facts",
+    "source": "https://github.com/linuxhw/HWInfo/tree/31b81aef173d9530eee80e016b90a4bd5c908e59/SBC/Raspberry-Pi-Foundation",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "aarch64", "cpu": "Cortex-A76", "model": "Raspberry Pi 5 Model B"},
+    "expected": {"device_family": "ARM", "device_arch": "aarch64"}
+  },
+  {
+    "id": "orange-pi-5",
+    "category": "arm_sbc",
+    "provenance": "published_hardware_facts",
+    "source": "https://github.com/linuxhw/HWInfo/tree/31b81aef173d9530eee80e016b90a4bd5c908e59/SBC/Xunlong",
+    "device": {"family": "x86", "arch": "modern", "machine": "aarch64", "cpu": "Rockchip RK3588", "model": "Orange Pi 5"},
+    "expected": {"device_family": "ARM", "device_arch": "aarch64"}
+  },
+  {
+    "id": "jetson-nano",
+    "category": "arm_sbc",
+    "provenance": "published_hardware_facts",
+    "source": "https://github.com/jetsonhacks/jetsonUtilities/blob/9521a4be908966008de3fa98ac3d1ce2fe38efc8/jetsonInfo.py",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "aarch64", "cpu": "ARM Cortex-A57", "model": "NVIDIA Jetson Nano"},
+    "expected": {"device_family": "ARM", "device_arch": "aarch64"}
+  },
+  {
+    "id": "aws-graviton2",
+    "category": "arm_sbc",
+    "provenance": "published_cloud_inventory",
+    "source": "https://github.com/amazonlinux/amazon-linux-2023/blob/91175b5dfe13f8ba895060c017c9f1aac7c27d10/README.md",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "aarch64", "cpu": "Neoverse-N1", "model": "AWS Graviton2"},
+    "expected": {"device_family": "ARM", "device_arch": "aarch64"}
+  },
+  {
+    "id": "powerpc-g3-750",
+    "category": "powerpc",
+    "provenance": "project_honest_hardware_table",
+    "source": "https://github.com/Scottcjn/Rustchain/blob/fb4c163effbb7352d37d6dda99e42669dfb0674a/docs/zh-CN/VINTAGE_MINING_EXPLAINED.md",
+    "device": {"family": "PowerPC", "arch": "g3", "machine": "ppc", "cpu": "PowerPC G3 750"},
+    "expected": {"device_family": "PowerPC", "device_arch": "G3"}
+  },
+  {
+    "id": "powerpc-g4-7450",
+    "category": "powerpc",
+    "provenance": "project_honest_hardware_table",
+    "source": "https://github.com/Scottcjn/Rustchain/blob/fb4c163effbb7352d37d6dda99e42669dfb0674a/docs/zh-CN/VINTAGE_MINING_EXPLAINED.md",
+    "device": {"family": "PowerPC", "arch": "g4", "machine": "ppc", "cpu": "PowerPC G4 7450"},
+    "expected": {"device_family": "PowerPC", "device_arch": "G4"}
+  },
+  {
+    "id": "powerpc-g4-7447",
+    "category": "powerpc",
+    "provenance": "project_honest_hardware_table",
+    "source": "https://github.com/Scottcjn/Rustchain/blob/fb4c163effbb7352d37d6dda99e42669dfb0674a/docs/zh-CN/VINTAGE_MINING_EXPLAINED.md",
+    "device": {"family": "PowerPC", "arch": "g4", "machine": "powerpc", "cpu": "PowerPC G4 7447A"},
+    "expected": {"device_family": "PowerPC", "device_arch": "G4"}
+  },
+  {
+    "id": "powerpc-g5-970",
+    "category": "powerpc",
+    "provenance": "project_honest_hardware_table",
+    "source": "https://github.com/Scottcjn/Rustchain/blob/fb4c163effbb7352d37d6dda99e42669dfb0674a/docs/zh-CN/VINTAGE_MINING_EXPLAINED.md",
+    "device": {"family": "PowerPC", "arch": "g5", "machine": "ppc64", "cpu": "PowerPC G5 970"},
+    "expected": {"device_family": "PowerPC", "device_arch": "G5"}
+  },
+  {
+    "id": "ibm-power8-s824",
+    "category": "powerpc",
+    "provenance": "project_honest_hardware_table",
+    "source": "https://github.com/Scottcjn/Rustchain/blob/fb4c163effbb7352d37d6dda99e42669dfb0674a/docs/zh-CN/VINTAGE_MINING_EXPLAINED.md",
+    "device": {"family": "PowerPC", "arch": "power8", "machine": "ppc64le", "cpu": "IBM POWER8 8286"},
+    "expected": {"device_family": "PowerPC", "device_arch": "POWER8"}
+  },
+  {
+    "id": "qemu-virtual-cpu-2-5",
+    "category": "vm_qemu",
+    "provenance": "published_vm_inventory",
+    "source": "https://github.com/openstack/ironic/blob/751fa53d8d3b1ac330ac0082cdf68d11bb523228/api-ref/source/samples/node-inventory-response.json",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": "QEMU Virtual CPU version 2.5+"},
+    "expected": {"device_family": "x86_64", "device_arch": "modern"}
+  },
+  {
+    "id": "qemu-standard-pc",
+    "category": "vm_qemu",
+    "provenance": "published_vm_inventory",
+    "source": "https://github.com/libremesh/lime-app/blob/6d4ab7cb07fe0bc97353a420eeaee1e671993e29/plugins/lime-plugin-fbw/src/FbwPage.spec.js",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": "QEMU Virtual CPU version 2.5+", "model": "QEMU Standard PC (i440FX + PIIX, 1996)"},
+    "expected": {"device_family": "x86_64", "device_arch": "modern"}
+  },
+  {
+    "id": "kvm-common-processor",
+    "category": "vm_qemu",
+    "provenance": "published_hypervisor_model",
+    "source": "https://github.com/unicorn-engine/unicorn/blob/7c5db94191defc1e04a4f66f4eb1220903cba837/qemu/target/i386/cpu.c",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": "Common KVM processor"},
+    "expected": {"device_family": "x86_64", "device_arch": "modern"}
+  },
+  {
+    "id": "kvm-common-32-bit",
+    "category": "vm_qemu",
+    "provenance": "published_vm_fixture",
+    "source": "https://github.com/chef/ohai/blob/b7033361b2c67838606de7a0a1772076d79857f9/spec/unit/plugins/bsd/virtualization_spec.rb",
+    "device": {"family": "x86", "arch": "modern", "machine": "i686", "cpu": "Common 32-bit KVM processor"},
+    "expected": {"device_family": "x86", "device_arch": "modern"}
+  },
+  {
+    "id": "qemu-core2duo-model",
+    "category": "vm_qemu",
+    "provenance": "published_hypervisor_model",
+    "source": "https://github.com/i3boyacc/QEMU-Panel/blob/1a1dd6ded00803968bdda43581b9e3860475e085/emu_x86.cs",
+    "device": {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": "Intel(R) Core(TM)2 Duo CPU T7700 @ 2.40GHz", "model": "QEMU Standard PC"},
+    "expected": {"device_family": "x86_64", "device_arch": "modern"}
+  }
+]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -18,3 +18,4 @@ seaborn>=0.13.2
 psutil>=5.9.0
 # Needed by sdk/python/rustchain_sdk/client.py import during signed-transfer/SDK tests.
 httpx>=0.27.0
+hypothesis>=6.100,<7

--- a/tests/test_device_classification_corpus.py
+++ b/tests/test_device_classification_corpus.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: MIT
+"""Corpus and property regressions for device classification.
+
+The fixture records device strings from immutable, public hardware inventories.
+These tests exercise the production ``derive_verified_device`` function rather
+than duplicating its classification logic.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, given, settings, strategies as st
+
+
+NODE = sys.modules["integrated_node"]
+CORPUS_PATH = Path(__file__).with_name("device_classification_corpus.json")
+PINNED_GITHUB_URL = re.compile(
+    r"^https://github\.com/[^/]+/[^/]+/(?:blob|tree)/[0-9a-f]{40}/.+$"
+)
+
+
+def _load_corpus() -> list[dict]:
+    return json.loads(CORPUS_PATH.read_text(encoding="utf-8"))
+
+
+CORPUS = _load_corpus()
+
+
+def _classify(device: dict, fingerprint: object = None, passed: bool = True) -> dict:
+    return NODE.derive_verified_device(device, fingerprint or {}, passed)
+
+
+def test_corpus_has_at_least_thirty_cited_unique_devices():
+    """The regression input must remain reviewable, immutable, and substantial."""
+    assert len(CORPUS) >= 30
+    assert len({row["id"] for row in CORPUS}) == len(CORPUS)
+    assert len({json.dumps(row["device"], sort_keys=True) for row in CORPUS}) == len(CORPUS)
+    for row in CORPUS:
+        assert row["provenance"]
+        assert PINNED_GITHUB_URL.fullmatch(row["source"]), row["source"]
+        assert set(row["expected"]) == {"device_family", "device_arch"}
+
+
+@pytest.mark.parametrize("sample", CORPUS, ids=lambda sample: sample["id"])
+def test_cited_device_classification_corpus(sample):
+    assert _classify(sample["device"]) == sample["expected"]
+
+
+@pytest.mark.parametrize(
+    ("cpu", "expected_arch"),
+    [
+        ("Intel Pentium 166", "modern"),
+        ("Intel Pentium Pro 200", "pentium_pro"),
+        ("Intel Pentium II 450", "pentium_ii"),
+        ("Intel Pentium III 933", "pentium_iii"),
+        ("Intel Pentium MMX 233", "pentium_mmx"),
+        ("Intel Pentium M processor 1600MHz", "pentium_m_banias"),
+        ("Intel Pentium 4 2.40GHz", "modern"),
+    ],
+)
+def test_pentium_name_boundaries_do_not_overlap(cpu, expected_arch):
+    device = {"family": "x86", "arch": "modern", "machine": "i686", "cpu": cpu}
+    assert _classify(device)["device_arch"] == expected_arch
+
+
+def _hardware_weight(classification: dict) -> float:
+    family = classification["device_family"]
+    arch = classification["device_arch"]
+    family_weights = NODE.HARDWARE_WEIGHTS.get(family, {})
+    return float(family_weights.get(arch, family_weights.get("default", 1.0)))
+
+
+@pytest.mark.parametrize(
+    ("device", "expected"),
+    [
+        (
+            {"family": "x86", "arch": "modern"},
+            {"device_family": "ARM", "device_arch": "aarch64"},
+        ),
+        (
+            {
+                "family": "x86_64",
+                "arch": "modern",
+                "machine": "aarch64",
+                "cpu": "Intel Core i7-12700K",
+            },
+            {"device_family": "ARM", "device_arch": "aarch64"},
+        ),
+    ],
+)
+def test_spoof_shaped_payloads_are_not_vintage(device, expected):
+    result = _classify(device, {}, False)
+    assert result == expected
+    assert _hardware_weight(result) <= 1.0
+
+
+def test_mixed_legacy_and_new_field_names_use_current_identity_fields():
+    """Cover the mixed-schema trap tracked in Rustchain#7991."""
+    device = {
+        "device_family": "x86_64",
+        "family": "PowerPC",
+        "device_arch": "modern",
+        "arch": "g4",
+        "machine": "x86_64",
+        "cpu": "Intel Core i7-12700K",
+        "cpu_brand": "PowerPC G4 7450",
+    }
+    fingerprint = {
+        "checks": {
+            "thermal_drift": {
+                "passed": True,
+                "data": {"ratio": 1.0, "drift_ratio": 1.2},
+            },
+            "cache_timing": {
+                "passed": True,
+                "data": {"L1": 5.0, "l1_ns": 5.1, "l2_l1_ratio": 2.8},
+            },
+            "instruction_jitter": {
+                "passed": True,
+                "data": {"cv": 0.1, "int_avg_ns": 9100, "int_stdev": 40},
+            },
+        }
+    }
+    assert _classify(device, fingerprint) == {
+        "device_family": "x86_64",
+        "device_arch": "modern",
+    }
+
+
+@pytest.mark.parametrize(
+    "cpu",
+    [
+        "Intel Core i7 \N{SNOWMAN} \x00 Pentium III",
+        "A" * 16_384,
+        "\x00" * 128,
+    ],
+)
+def test_unicode_oversized_and_null_byte_fields_never_raise(cpu):
+    result = _classify(
+        {"family": "x86_64", "arch": "modern", "machine": "x86_64", "cpu": cpu},
+        {},
+        False,
+    )
+    assert set(result) == {"device_family", "device_arch"}
+    assert all(isinstance(value, str) for value in result.values())
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Modern family-6 brand injection is the core fix tracked by "
+        "https://github.com/Scottcjn/rustchain-bounties/issues/16271"
+    ),
+    strict=False,
+)
+def test_modern_family6_with_pentium_iii_injection_cannot_gain_vintage_weight():
+    device = {
+        "family": "x86_64",
+        "arch": "modern",
+        "machine": "x86_64",
+        "cpu": "Intel Core i7 family 6 model 158 Pentium III",
+        "cpu_family": "6",
+    }
+    assert _hardware_weight(_classify(device, {}, False)) <= 1.0
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Uncorroborated vintage reward claims are tracked by "
+        "https://github.com/Scottcjn/rustchain-bounties/issues/16271"
+    ),
+    strict=False,
+)
+@settings(max_examples=40, deadline=None, derandomize=True)
+@given(
+    claimed_arch=st.sampled_from(
+        ["386", "486", "pentium", "pentium_mmx", "pentium_ii", "pentium_iii"]
+    ),
+    cpu=st.sampled_from(
+        ["Intel Core i7-12700K", "AMD Ryzen 9 5950X", "Intel Xeon Gold 6248R"]
+    ),
+)
+def test_no_vintage_multiplier_without_positive_vintage_evidence(claimed_arch, cpu):
+    device = {
+        "family": "x86",
+        "arch": claimed_arch,
+        "machine": "x86_64",
+        "cpu": cpu,
+        "cpu_family": "6",
+    }
+    fingerprint = {
+        "checks": {
+            "simd_identity": {
+                "passed": True,
+                "data": {
+                    "has_sse": True,
+                    "has_avx": True,
+                    "x86_features": ["sse2", "avx2"],
+                },
+            }
+        }
+    }
+    assert _hardware_weight(_classify(device, fingerprint, True)) <= 1.0
+
+
+JSON_SCALAR = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(min_value=-(2**31), max_value=2**31 - 1),
+    st.floats(allow_nan=True, allow_infinity=True, width=32),
+    st.text(max_size=80),
+)
+JSONISH = st.recursive(
+    JSON_SCALAR,
+    lambda children: st.one_of(
+        st.lists(children, max_size=4),
+        st.dictionaries(st.text(max_size=20), children, max_size=4),
+    ),
+    max_leaves=12,
+)
+DEVICE_KEYS = st.sampled_from(
+    [
+        "device_family",
+        "family",
+        "device_arch",
+        "arch",
+        "machine",
+        "cpu",
+        "model",
+        "device_model",
+        "brand",
+        "platform_system",
+    ]
+)
+
+
+@settings(
+    max_examples=120,
+    deadline=None,
+    derandomize=True,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+@given(
+    device=st.dictionaries(DEVICE_KEYS, JSONISH, max_size=10),
+    fingerprint=JSONISH,
+    passed=st.booleans(),
+)
+def test_bounded_malformed_payloads_never_raise(device, fingerprint, passed):
+    """Untrusted nested values must resolve to a string-valued classification."""
+    result = _classify(device, fingerprint, passed)
+    assert set(result) == {"device_family", "device_arch"}
+    assert all(isinstance(value, str) for value in result.values())
+
+
+@settings(max_examples=60, deadline=None, derandomize=True)
+@given(
+    sample=st.sampled_from(CORPUS),
+    hostname=st.text(max_size=50),
+    cores=st.integers(min_value=0, max_value=4096),
+    ram_mb=st.integers(min_value=0, max_value=2**31 - 1),
+)
+def test_unrelated_inventory_metadata_does_not_change_classification(
+    sample, hostname, cores, ram_mb
+):
+    enriched = dict(sample["device"], hostname=hostname, cores=cores, ram_mb=ram_mb)
+    assert _classify(enriched) == sample["expected"]
+


### PR DESCRIPTION
## Summary

Adds focused test armor around the production `derive_verified_device()` path for public bounty [rustchain-bounties#16257](https://github.com/Scottcjn/rustchain-bounties/issues/16257).

- commits 38 unique device samples with immutable, cited sources: vintage/modern x86, ARM SBCs, PowerPC, and VM/QEMU identities
- asserts the corpus directly against the production classifier, including Pentium name boundaries
- covers empty identity, ARM/x86 contradiction, mixed legacy/current keys from #7991, Unicode, 16 KiB, and NUL-byte inputs
- adds deterministic, bounded Hypothesis cases for arbitrary dict-shaped payloads and metadata stability
- records two current reward/spoof gaps as linked `xfail` cases tracked by [rustchain-bounties#16271](https://github.com/Scottcjn/rustchain-bounties/issues/16271)
- adds one test-proven crash fix: normalize `platform_system` before `.lower()` when the untrusted field is `null` or non-string
- adds Hypothesis to the existing test requirements

The diff is limited to four files and does not alter classification policy beyond that crash fix.

## Validation

- `python -m pytest tests/test_device_classification_corpus.py tests/test_entropy_profile_real_producer_schema.py node/tests/test_arch_multiplier_guard_t32.py -q`
  - **75 passed, 2 xfailed**
- `python -m ruff check tests/test_device_classification_corpus.py --select E9,F63,F7,F82`
  - **All checks passed**
- `python -m py_compile tests/test_device_classification_corpus.py node/rustchain_v2_integrated_v2.2.1_rip200.py`
- `git diff --check`
- representative pinned citations checked live: **4/4 HTTP 200**

BCOS-L1

Closes https://github.com/Scottcjn/rustchain-bounties/issues/16257