### PR TITLE
fix: replace innerHTML with textContent to prevent DOM XSS [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -1595,7 +1595,7 @@ HTML_TEMPLATE = """
             submitBtn.disabled = true;
             submitBtn.textContent = 'Processing...';
             result.className = 'result';
-            result.innerHTML = '';
+            result.textContent = '';
 
             const wallet = walletInput.value.trim();
 
@@ -1611,7 +1611,7 @@ HTML_TEMPLATE = """
                 result.className = 'result show ' + (data.ok ? 'success' : 'error');
                 
                 if (data.ok) {
-                    result.innerHTML = '';
+                    result.textContent = '';
                     const strong = document.createElement('strong');
                     strong.textContent = '✅ Success!';
                     result.appendChild(strong);
@@ -1627,7 +1627,7 @@ HTML_TEMPLATE = """
                     walletInput.value = '';
                     loadStats();
                 } else {
-                    result.innerHTML = '';
+                    result.textContent = '';
                     const strong = document.createElement('strong');
                     strong.textContent = `❌ ${data.error}`;
                     result.appendChild(strong);
@@ -1640,7 +1640,7 @@ HTML_TEMPLATE = """
                 }
             } catch (err) {
                 result.className = 'result show error';
-                result.innerHTML = '';
+                result.textContent = '';
                 const strong = document.createElement('strong');
                 strong.textContent = '❌ Error: ';
                 result.appendChild(strong);


### PR DESCRIPTION
## Summary

Replaces all 4 occurrences of `result.innerHTML = ""` with `result.textContent = ""` in `faucet_service.py`.

## Problem

The faucet service JavaScript code uses `result.innerHTML = ""` to clear a `<div>` before appending new DOM nodes. While the actual dynamic content is safely set via `textContent` and `createTextNode` (which are not vulnerable to XSS), using `innerHTML` for the reset is inconsistent with the security pattern used elsewhere and could be a maintenance risk if future code adds user-controlled content to the innerHTML assignment.

## Fix

Replaced all 4 occurrences of `result.innerHTML = ""` with `result.textContent = ""` (lines 1598, 1614, 1630, 1643). This is more consistent with the rest of the codebase which already uses secure DOM manipulation methods (`textContent`, `createTextNode`, `appendChild`).

Closes #7160