### PR TITLE
Health CLI: fail the run when the chain tip check fails

### DIFF
--- a/tests/test_rustchain_health_verdict.py
+++ b/tests/test_rustchain_health_verdict.py
@@ -1,0 +1,150 @@
+"""Regression tests for tools/rustchain-health.py overall verdict.
+
+Issue #8055: the tool ran check_tip() and stored the result in the
+snapshot, but both all_ok expressions (the STATUS line in render() and
+the exit code in run_once()) ignored it. A dead chain tip still printed
+"ALL SYSTEMS OPERATIONAL" and exited 0, silencing any monitor built on
+top of this tool.
+
+These tests drive the real CLI entrypoint (main) with a mocked fetch()
+so the whole path is exercised: collect -> render -> exit code.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOL_PATH = Path(__file__).parent.parent / "tools" / "rustchain-health.py"
+
+
+def _load_health_module():
+    name = "rustchain_health_cli"
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, str(_TOOL_PATH))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def health_mod(monkeypatch):
+    mod = _load_health_module()
+    monkeypatch.setattr(mod, "_COLOR", False)
+    return mod
+
+
+HEALTH_BODY = {"ok": True, "version": "2.2.1-rip200", "uptime_s": 1000,
+               "db_rw": True, "tip_age_slots": 0}
+EPOCH_BODY = {"epoch": 424, "slot": 61000, "epoch_pot": 1.5,
+              "enrolled_miners": 8}
+MINERS_BODY = [{"miner_id": "dual-g4-125"}, {"miner_id": "sophia-nas-c4130"}]
+TIP_BODY = {"miner": "sophia-nas-c4130", "slot": 2941199,
+            "signature_prefix": "b3780cff190178456a0f"}
+
+
+def _fake_fetch(responses):
+    """Build a fetch() replacement keyed on URL suffix.
+
+    responses maps an endpoint suffix to (ok, data, status).
+    """
+    def fetch(url, timeout=8):
+        for suffix, (ok, data, status) in responses.items():
+            if url.endswith(suffix):
+                return ok, data, 1.0, status
+        raise AssertionError(f"unexpected URL fetched: {url}")
+    return fetch
+
+
+def _run_cli(health_mod, monkeypatch, capsys, responses):
+    monkeypatch.setattr(health_mod, "fetch", _fake_fetch(responses))
+    monkeypatch.setattr(sys, "argv",
+                        ["rustchain-health", "-u", "http://node.test",
+                         "--no-color"])
+    code = health_mod.main()
+    out = capsys.readouterr().out
+    return code, out
+
+
+def _healthy_responses():
+    return {
+        "/health": (True, dict(HEALTH_BODY), 200),
+        "/epoch": (True, dict(EPOCH_BODY), 200),
+        "/api/miners": (True, list(MINERS_BODY), 200),
+        "/headers/tip": (True, dict(TIP_BODY), 200),
+    }
+
+
+def test_all_healthy_exits_zero(health_mod, monkeypatch, capsys):
+    code, out = _run_cli(health_mod, monkeypatch, capsys,
+                         _healthy_responses())
+    assert code == 0
+    assert "ALL SYSTEMS OPERATIONAL" in out
+    assert "ISSUES DETECTED" not in out
+
+
+def test_tip_failure_exits_nonzero(health_mod, monkeypatch, capsys):
+    """Regression for #8055: a failing tip check must fail the run."""
+    responses = _healthy_responses()
+    responses["/headers/tip"] = (False, "<urlopen error timed out>", None)
+    code, out = _run_cli(health_mod, monkeypatch, capsys, responses)
+    assert code != 0
+    assert "ALL SYSTEMS OPERATIONAL" not in out
+    assert "ISSUES DETECTED" in out
+
+
+def test_tip_garbage_body_exits_nonzero(health_mod, monkeypatch, capsys):
+    """Tip endpoint answers but with no identifiable tip: also a failure."""
+    responses = _healthy_responses()
+    responses["/headers/tip"] = (True, "<html>gateway error</html>", 200)
+    code, out = _run_cli(health_mod, monkeypatch, capsys, responses)
+    assert code != 0
+    assert "ALL SYSTEMS OPERATIONAL" not in out
+
+
+def test_tip_endpoint_not_implemented_is_not_a_failure(health_mod,
+                                                       monkeypatch, capsys):
+    """A node without /headers/tip (404) should not trip a false alarm."""
+    responses = _healthy_responses()
+    responses["/headers/tip"] = (False, "HTTP Error 404: Not Found", 404)
+    code, out = _run_cli(health_mod, monkeypatch, capsys, responses)
+    assert code == 0
+    assert "ALL SYSTEMS OPERATIONAL" in out
+    assert "not supported" in out
+
+
+def test_epoch_content_missing_exits_nonzero(health_mod, monkeypatch, capsys):
+    """Sibling of #8055: epoch endpoint reachable but returning no epoch
+    used to show a red row while the overall verdict stayed green."""
+    responses = _healthy_responses()
+    responses["/epoch"] = (True, {"unexpected": "shape"}, 200)
+    code, out = _run_cli(health_mod, monkeypatch, capsys, responses)
+    assert code != 0
+    assert "ALL SYSTEMS OPERATIONAL" not in out
+
+
+def test_tip_accepts_slot_field(health_mod):
+    """RIP-200 nodes report the tip as "slot", not "height"."""
+    tip = {"reachable": True, "latency_ms": 1.0, "height": 2941199}
+    assert health_mod.tip_verdict(tip) is True
+
+
+def test_render_and_exit_code_share_one_predicate(health_mod):
+    """The verdict must come from a single function so the display and
+    the exit code cannot drift apart again."""
+    snapshot = {
+        "node": "http://node.test",
+        "checked_at": "2026-01-01T00:00:00Z",
+        "health": {"reachable": True, "ok": True, "latency_ms": 1.0},
+        "epoch": {"reachable": True, "epoch": 1, "latency_ms": 1.0},
+        "miners": {"reachable": True, "miner_count": 1, "latency_ms": 1.0},
+        "tip": {"reachable": False, "error": "boom", "latency_ms": 1.0},
+    }
+    assert health_mod.overall_ok(snapshot) is False
+    assert "ISSUES DETECTED" in health_mod.render(snapshot)
+    snapshot["tip"] = {"reachable": True, "height": 5, "latency_ms": 1.0}
+    assert health_mod.overall_ok(snapshot) is True
+    assert "ALL SYSTEMS OPERATIONAL" in health_mod.render(snapshot)

--- a/tools/rustchain-health.py
+++ b/tools/rustchain-health.py
@@ -71,8 +71,8 @@ def _ssl_ctx() -> ssl.SSLContext:
     ctx.verify_mode = ssl.CERT_NONE
     return ctx
 
-def fetch(url: str, timeout: int = 8) -> Tuple[bool, Any, float]:
-    """GET *url*, return (ok, parsed_json_or_None, latency_ms)."""
+def fetch(url: str, timeout: int = 8) -> Tuple[bool, Any, float, Optional[int]]:
+    """GET *url*, return (ok, parsed_json_or_None, latency_ms, http_status)."""
     t0 = time.time()
     try:
         req = Request(url, headers={
@@ -82,18 +82,22 @@ def fetch(url: str, timeout: int = 8) -> Tuple[bool, Any, float]:
         with urlopen(req, timeout=timeout, context=_ssl_ctx()) as resp:
             body = resp.read(2 * 1024 * 1024).decode("utf-8", errors="replace")
             latency = (time.time() - t0) * 1000
+            status = getattr(resp, "status", None) or resp.getcode()
             try:
-                return True, json.loads(body), latency
+                return True, json.loads(body), latency, status
             except json.JSONDecodeError:
-                return True, body.strip(), latency
-    except (HTTPError, URLError, OSError) as exc:
+                return True, body.strip(), latency, status
+    except HTTPError as exc:
         latency = (time.time() - t0) * 1000
-        return False, str(exc), latency
+        return False, str(exc), latency, exc.code
+    except (URLError, OSError) as exc:
+        latency = (time.time() - t0) * 1000
+        return False, str(exc), latency, None
 
 # ── individual checks ──────────────────────────────────────────────────────
 
 def check_health(base: str, timeout: int) -> Dict[str, Any]:
-    ok, data, ms = fetch(f"{base}/health", timeout)
+    ok, data, ms, _status = fetch(f"{base}/health", timeout)
     result: Dict[str, Any] = {"reachable": ok, "latency_ms": round(ms, 1)}
     if ok and isinstance(data, dict):
         result["ok"] = data.get("ok", False)
@@ -110,7 +114,7 @@ def check_health(base: str, timeout: int) -> Dict[str, Any]:
     return result
 
 def check_epoch(base: str, timeout: int) -> Dict[str, Any]:
-    ok, data, ms = fetch(f"{base}/epoch", timeout)
+    ok, data, ms, _status = fetch(f"{base}/epoch", timeout)
     result: Dict[str, Any] = {"reachable": ok, "latency_ms": round(ms, 1)}
     if ok and isinstance(data, dict):
         result["epoch"] = data.get("epoch")
@@ -126,7 +130,7 @@ def check_epoch(base: str, timeout: int) -> Dict[str, Any]:
     return result
 
 def check_miners(base: str, timeout: int) -> Dict[str, Any]:
-    ok, data, ms = fetch(f"{base}/api/miners", timeout)
+    ok, data, ms, _status = fetch(f"{base}/api/miners", timeout)
     result: Dict[str, Any] = {"reachable": ok, "latency_ms": round(ms, 1)}
     if ok and isinstance(data, list):
         result["miner_count"] = len(data)
@@ -142,17 +146,58 @@ def check_miners(base: str, timeout: int) -> Dict[str, Any]:
     return result
 
 def check_tip(base: str, timeout: int) -> Dict[str, Any]:
-    ok, data, ms = fetch(f"{base}/headers/tip", timeout)
+    ok, data, ms, status = fetch(f"{base}/headers/tip", timeout)
     result: Dict[str, Any] = {"reachable": ok, "latency_ms": round(ms, 1)}
     if ok and isinstance(data, dict):
-        result["height"] = data.get("height", data.get("block_height"))
+        # Nodes report the tip position as "height", "block_height", or
+        # (RIP-200 nodes) "slot" -- accept any of them.
+        height = data.get("height", data.get("block_height"))
+        if height is None:
+            height = data.get("slot")
+        result["height"] = height
         result["hash"] = data.get("hash", data.get("block_hash"))
         result["timestamp"] = data.get("timestamp")
     elif ok:
         result["raw"] = str(data)[:200]
     else:
         result["error"] = str(data)
+        # An HTTP 404/405/501 means this node simply does not expose
+        # /headers/tip. That is "not applicable", not "broken" -- record it
+        # so the verdict does not raise a false alarm.
+        if status in (404, 405, 501):
+            result["supported"] = False
     return result
+
+# ── verdict ─────────────────────────────────────────────────────────────────
+# Single source of truth for pass/fail. render() (the STATUS line and the
+# per-row dots) and run_once() (the process exit code) must both go through
+# these predicates so the display and the exit code can never drift apart.
+
+def health_ok(h: Dict[str, Any]) -> bool:
+    return bool(h.get("reachable")) and bool(h.get("ok", False))
+
+def epoch_ok(e: Dict[str, Any]) -> bool:
+    return bool(e.get("reachable")) and e.get("epoch") is not None
+
+def miners_ok(m: Dict[str, Any]) -> bool:
+    return bool(m.get("reachable"))
+
+def tip_verdict(t: Dict[str, Any]) -> Optional[bool]:
+    """True = tip check passed, False = failed, None = endpoint not
+    implemented on this node (does not count against the verdict)."""
+    if t.get("supported") is False:
+        return None
+    if not t.get("reachable"):
+        return False
+    return t.get("height") is not None
+
+def overall_ok(snapshot: Dict[str, Any]) -> bool:
+    """Overall verdict: every applicable check must pass."""
+    if not (health_ok(snapshot["health"])
+            and epoch_ok(snapshot["epoch"])
+            and miners_ok(snapshot["miners"])):
+        return False
+    return tip_verdict(snapshot["tip"]) is not False
 
 # ── aggregator ──────────────────────────────────────────────────────────────
 
@@ -201,7 +246,7 @@ def render(snapshot: Dict[str, Any]) -> str:
 
     # ── Health ───
     h = snapshot["health"]
-    h_ok = h.get("ok", False) and h["reachable"]
+    h_ok = health_ok(h)
     lines.append(f"  {status_dot(h_ok)}  {bold('Health')}          "
                  f"{green('healthy') if h_ok else red('UNHEALTHY')}  "
                  f"{dim(str(round(h['latency_ms'])) + ' ms')}")
@@ -218,7 +263,7 @@ def render(snapshot: Dict[str, Any]) -> str:
 
     # ── Epoch ───
     e = snapshot["epoch"]
-    e_ok = e["reachable"] and e.get("epoch") is not None
+    e_ok = epoch_ok(e)
     lines.append(f"  {status_dot(e_ok)}  {bold('Epoch')}           "
                  f"{green(str(e.get('epoch', '?'))) if e_ok else red('unavailable')}  "
                  f"{dim(str(round(e['latency_ms'])) + ' ms')}")
@@ -237,11 +282,20 @@ def render(snapshot: Dict[str, Any]) -> str:
 
     # ── Chain Tip ───
     t = snapshot["tip"]
-    t_ok = t["reachable"] and t.get("height") is not None
-    lines.append(f"  {status_dot(t_ok)}  {bold('Chain Tip')}       "
-                 f"{'#' + str(t.get('height', '?')) if t_ok else yellow('unknown')}  "
+    t_verdict = tip_verdict(t)
+    if t_verdict is True:
+        tip_label = "#" + str(t.get("height", "?"))
+        tip_dot = green("●")
+    elif t_verdict is None:
+        tip_label = yellow("n/a (endpoint not supported)")
+        tip_dot = yellow("●")
+    else:
+        tip_label = red("FAILED")
+        tip_dot = red("●")
+    lines.append(f"  {tip_dot}  {bold('Chain Tip')}       "
+                 f"{tip_label}  "
                  f"{dim(str(round(t['latency_ms'])) + ' ms')}")
-    if t_ok:
+    if t_verdict is True:
         lines.append(f"     Hash           : {_trunc_hash(t.get('hash'))}")
         if t.get("timestamp"):
             lines.append(f"     Timestamp      : {t['timestamp']}")
@@ -273,9 +327,7 @@ def render(snapshot: Dict[str, Any]) -> str:
     lines.append("")
 
     # ── Overall ───
-    all_ok = (h.get("ok", False) and h["reachable"]
-              and e["reachable"]
-              and m["reachable"])
+    all_ok = overall_ok(snapshot)
     lines.append(dim("  " + "─" * w))
     if all_ok:
         lines.append(f"  {green(bold('STATUS: ALL SYSTEMS OPERATIONAL'))}")
@@ -354,12 +406,8 @@ def main() -> int:
             print(json.dumps(snapshot, indent=2))
         else:
             print(render(snapshot))
-        # exit 0 if healthy, 1 otherwise
-        all_ok = (snapshot["health"].get("ok", False)
-                  and snapshot["health"]["reachable"]
-                  and snapshot["epoch"]["reachable"]
-                  and snapshot["miners"]["reachable"])
-        return 0 if all_ok else 1
+        # exit 0 if healthy, 1 otherwise -- same predicate the display uses
+        return 0 if overall_ok(snapshot) else 1
 
     if args.watch > 0:
         try:


### PR DESCRIPTION
## The bug

`tools/rustchain-health.py` runs `check_tip()` and stores the result in the snapshot, but both `all_ok` expressions ignored it: the STATUS line in `render()` (old line 276) and the exit code in `run_once()` (old line 358) were built from health + epoch + miners reachability only. With the chain tip check failing, the tool still printed "ALL SYSTEMS OPERATIONAL" and exited 0, so any monitor watching the exit code never fired. A monitor that exits 0 on failure is worse than no monitor.

Fixes #8055. Thanks to @mumuzhong3 for the report.

## The fix

Instead of adding `tip` to both copies of `all_ok`, the verdict is now one shared set of predicates: `health_ok`, `epoch_ok`, `miners_ok`, `tip_verdict`, and `overall_ok(snapshot)`. Both the display path and the exit-code path call `overall_ok`, so they cannot drift apart again. That drift is exactly how this bug happened: the two copies had already diverged once (the display required epoch content, the exit path only required epoch reachability).

Details:

- `tip_verdict` returns True / False / None. None means the node answered 404/405/501 for `/headers/tip`, i.e. the endpoint is not implemented there. That renders as a yellow "n/a (endpoint not supported)" and does not count against the verdict, so nodes without that route do not raise false alarms. An unreachable endpoint or a body with no identifiable tip is a real failure.
- `check_tip` now also accepts `slot` as the tip position. RIP-200 nodes return `{"miner": ..., "slot": ..., "tip_age": ...}` from `/headers/tip`, so before this change a perfectly healthy production node showed its tip as "unknown".
- Sibling of the reported bug: `/epoch` reachable but returning no `epoch` field used to draw a red "unavailable" row while the overall status stayed green and the exit code stayed 0. It now fails the verdict, matching the row. Miner count 0 remains a yellow warning, not a failure, same as before.
- `fetch()` now returns the HTTP status code so the 404-vs-network-error distinction is possible.

## Verified

- New `tests/test_rustchain_health_verdict.py` (7 tests) drives the real CLI entrypoint with a mocked `fetch`: failing tip exits non-zero and does not print "ALL SYSTEMS OPERATIONAL"; garbage tip body fails; 404 tip does not fail; empty epoch fails; healthy path exits 0. All 7 pass on this branch and fail on main.
- Reproduced the original bug on main: dead tip, output said "ALL SYSTEMS OPERATIONAL", exit code 0.
- Ran the fixed tool against the live node at 50.28.86.131: all four rows green, tip resolves to #2941199 (was "unknown" before the `slot` fix), STATUS ALL SYSTEMS OPERATIONAL, exit 0.
- Unreachable node exits 1. `ruff check` clean on both files.
