### PR TITLE
fix: /health tip_age_slots now computes real tip age instead of returning 0 [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -9001,11 +9001,21 @@ def _backup_age_hours():
     return None
 
 def _tip_age_slots():
-    """Check tip freshness - query DB directly to avoid Response object"""
+    """Check tip freshness - query DB directly to avoid Response object
+
+    Returns the number of slots since the most recent header, or None if
+    the headers table is empty or the query fails.  A healthy chain that
+    produces one block per slot should have an age of 0-2 slots.
+    """
     try:
         with sqlite3.connect(DB_PATH, timeout=3) as db:
             row = db.execute("SELECT slot FROM headers ORDER BY slot DESC LIMIT 1").fetchone()
-        return 0 if row else None
+        if row is None:
+            return None
+        latest_slot = row[0]
+        now_slot = current_slot()
+        age = now_slot - latest_slot
+        return max(0, age)
     except Exception:
         return None
 


### PR DESCRIPTION
## Problem

`/health` reports `"tip_age_slots": 0` on a node whose newest block header is **234 days old**. The `_tip_age_slots()` function selects the latest header slot but then discards it and returns a hardcoded `0` whenever any row exists.

```python
def _tip_age_slots():
    try:
        with sqlite3.connect(DB_PATH, timeout=3) as db:
            row = db.execute("SELECT slot FROM headers ORDER BY slot DESC LIMIT 1").fetchone()
        return 0 if row else None  # <-- always 0, discards the actual slot value!
    except Exception:
        return None
```

## Fix

Compute the actual tip age as `current_slot() - latest_header_slot`. The result is in slots (matching the field name `tip_age_slots`). A healthy chain producing one block per slot should show 0-2 slots of age.

Kept out of the `ok` boolean as recommended in the issue — the field is informative for humans/dashboards, not a health gate.

Related: #8055 and PR #8056 (same class of defect in the health CLI).

Fixes #8057