### PR TITLE
fix(attest): scope attestation signature enforcement per miner (#8016)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Thumbs.db
 .pytest_cache/
 pytest-cache-files-*/
 tests/.tmp_attestation/
+tests/.tmp_attest_8016/
 
 # Windows miner build artifacts
 Rustchain/miners/windows/dist/

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -322,6 +322,11 @@ def _attest_mapping(value):
 _ATTEST_MINER_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
 _SOLANA_WALLET_RE = re.compile(r"^[1-9A-HJ-NP-Za-km-z]{32,44}$")
 _ED25519_PUBKEY_HEX_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+# Canonical RTC wallet shape produced by address_from_pubkey(): "RTC" + 40 hex.
+# NOTE: several legacy miners use a *suffix* form instead (``<38hex>RTC``,
+# ``ppc_g5_130_<md5>RTC``). Those deliberately do NOT match here — they are not
+# derivable from a public key and are handled as named identities.
+_RTC_ADDRESS_RE = re.compile(r"^RTC[0-9a-fA-F]{40}$")
 
 
 def _attest_text(value):
@@ -353,6 +358,40 @@ def _valid_ed25519_pubkey_hex(value):
     if text and _ED25519_PUBKEY_HEX_RE.fullmatch(text):
         return text.lower()
     return None
+
+
+def _attest_is_rtc_address(value):
+    """Return True when ``value`` has the derivable RTC wallet shape.
+
+    ``address_from_pubkey()`` builds addresses as ``RTC`` + 40 hex chars, so an
+    identity of that shape is *self-authenticating*: exactly one Ed25519 public
+    key can produce it. Identities of any other shape (``dual-g4-125``,
+    ``power8-s824-sophia``) are not derivable from a key and must be pinned on
+    first use instead.
+    """
+    text = _attest_text(value)
+    return bool(text and _RTC_ADDRESS_RE.fullmatch(text))
+
+
+# Miner clients in this repository that structurally cannot produce an Ed25519
+# signature. They are documented here so operators can audit which identities
+# are expected to stay unsigned; the list grants NO extra privilege on its own.
+# Unsigned attestations are accepted purely by the per-miner rule in
+# _attest_authorize_signing_key(): an identity with no signing key on record.
+#
+# SECURITY NOTE: identities used by these clients are only ever as strong as
+# their first-seen binding. Anyone can attest as a never-keyed legacy identity.
+# What the surrounding fixes guarantee is that such a forgery can no longer
+# steal from or lock out its target: it cannot lower an existing epoch weight
+# (MAX(weight) upsert), cannot erase a stored signing key (COALESCE upsert),
+# and cannot rewrite a recorded device_arch (COALESCE upsert).
+UNSIGNED_ATTEST_CLIENT_ALLOWLIST = (
+    "miners/apple2/miner6502.c",       # 6502, no Ed25519 possible
+    "miners/i386/miner386.c",          # 16/32-bit DOS-era x86
+    "miners/floppy-miner/",            # boot-floppy miner, no crypto library
+    "miners/ppc/g5/g5_miner.sh",       # POSIX shell + curl only
+    "miners/rust/src/main.rs",         # legacy Rust miner, unsigned payload
+)
 
 
 def _attest_field_error(code, message, status=400):
@@ -3162,7 +3201,7 @@ def _projected_multiplier_growth(current_mult: float, device_arch: str) -> dict:
     }
 
 
-def record_attestation_success(miner: str, device: dict, fingerprint_passed: bool = False, source_ip: str = None, signals: dict = None, fingerprint: dict = None, signing_pubkey: str = None, entropy_score: float = 0.0):
+def record_attestation_success(miner: str, device: dict, fingerprint_passed: bool = False, source_ip: str = None, signals: dict = None, fingerprint: dict = None, signing_pubkey: str = None, entropy_score: float = 0.0, identity_proven: bool = True):
     now = int(time.time())
     # Miner-name platform hints — helps detect Apple Silicon / POWER8 when client doesn't send rich device info
     _device = dict(device or {})
@@ -3200,18 +3239,41 @@ def record_attestation_success(miner: str, device: dict, fingerprint_passed: boo
         # If the miner already has fingerprint_passed=1, a later failed attestation
         # should not downgrade it. We still update ts_ok to keep the attestation fresh.
         new_fp = 1 if fingerprint_passed else 0
+        # Issue #8016 hardening of this upsert:
+        #
+        #   signing_pubkey — COALESCE(excluded, existing). Previously this was
+        #     an unconditional `= excluded.signing_pubkey`, so ANY unsigned
+        #     submission naming a miner (no auth required at the time) wrote
+        #     NULL over that miner's stored key. That silently locked the
+        #     victim out of the hardened signed /epoch/enroll path, which
+        #     returns 412 ENROLLMENT_SIGNING_KEY_REQUIRED when no key is
+        #     stored. A key can now only ever be added or rotated, never
+        #     erased by a submission that did not carry one.
+        #
+        #   device_family / device_arch — only an identity-proven (signed and
+        #     key-authorized) attestation may change them. Rewards read
+        #     device_arch directly (rewards_implementation_rip200.py:276-280
+        #     -> get_time_aged_multiplier), so an unauthenticated overwrite
+        #     could drop a G4 from 2.5x to 1.0x. For a never-keyed legacy
+        #     identity the node genuinely cannot tell the owner from a forger,
+        #     so the first recorded value wins. That is deliberately symmetric:
+        #     it blocks a forged DOWNGRADE and a forged UPGRADE equally. A
+        #     plain MAX-by-multiplier would have blocked only the downgrade
+        #     while making arch spoofing permanent.
         conn.execute("""
             INSERT INTO miner_attest_recent (miner, ts_ok, device_family, device_arch, entropy_score, fingerprint_passed, source_ip, signing_pubkey, fingerprint_checks_json)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(miner) DO UPDATE SET
                 ts_ok = excluded.ts_ok,
-                device_family = excluded.device_family,
-                device_arch = excluded.device_arch,
+                device_family = CASE WHEN ? THEN excluded.device_family
+                                     ELSE COALESCE(miner_attest_recent.device_family, excluded.device_family) END,
+                device_arch = CASE WHEN ? THEN excluded.device_arch
+                                   ELSE COALESCE(miner_attest_recent.device_arch, excluded.device_arch) END,
                 source_ip = excluded.source_ip,
                 fingerprint_passed = MAX(miner_attest_recent.fingerprint_passed, excluded.fingerprint_passed),
-                signing_pubkey = excluded.signing_pubkey,
+                signing_pubkey = COALESCE(excluded.signing_pubkey, miner_attest_recent.signing_pubkey),
                 fingerprint_checks_json = excluded.fingerprint_checks_json
-        """, (miner, now, verified_device["device_family"], verified_device["device_arch"], entropy_score, new_fp, source_ip, signing_pubkey, fingerprint_checks_json))
+        """, (miner, now, verified_device["device_family"], verified_device["device_arch"], entropy_score, new_fp, source_ip, signing_pubkey, fingerprint_checks_json, 1 if identity_proven else 0, 1 if identity_proven else 0))
         _ = append_fingerprint_snapshot(conn, miner, fingerprint if isinstance(fingerprint, dict) else {}, now)
         # C3 fix: Record attestation history for first_attest tracking
         conn.execute("""
@@ -4414,6 +4476,119 @@ def _check_hardware_binding(miner_id: str, device: dict, signals: dict = None, s
             return False, f'Hardware bound to {bound_miner[:16]}...', bound_miner
 
 
+def _attest_lookup_signing_pubkey(miner):
+    """Return the Ed25519 signing key already pinned to ``miner``, or None.
+
+    A missing table/column (pre-migration node) is reported as "no key on
+    record" so a fresh database still accepts legacy unsigned miners.
+    """
+    try:
+        with closing(sqlite3.connect(DB_PATH)) as conn:
+            row = conn.execute(
+                "SELECT signing_pubkey FROM miner_attest_recent WHERE miner = ?",
+                (miner,),
+            ).fetchone()
+    except Exception as exc:
+        logging.warning("[ATTEST/KEY] signing key lookup failed for %r: %r",
+                        str(miner)[:24], exc)
+        return None
+    if row and row[0]:
+        return _valid_ed25519_pubkey_hex(row[0])
+    return None
+
+
+def _attest_rotation_message(miner, old_pubkey, new_pubkey, nonce):
+    """Canonical bytes a key rotation must be signed over by the OLD key."""
+    return "rotate|{}|{}|{}|{}".format(
+        miner, old_pubkey, new_pubkey, nonce
+    ).encode("utf-8")
+
+
+def _attest_authorize_signing_key(miner, pubkey_hex, signature_verified,
+                                  rotation_sig_hex, nonce):
+    """Decide whether this submission may attest as ``miner``, per-miner scoped.
+
+    Issue #8016 (reported by @draycolix): ``if sig_hex and pubkey_hex:`` guarded
+    every signature check with no ``else``, so omitting both fields skipped
+    verification entirely. Two blunt fixes were considered and rejected:
+
+      * Reject all unsigned attestations. This takes the honest vintage fleet
+        offline. A 6502 (``miners/apple2/miner6502.c``) cannot compute Ed25519
+        at all; the DOS-era i386 miner, the boot-floppy miner, the G5 shell
+        script and the legacy Rust miner send no signature either.
+      * A global ``ALLOW_UNSIGNED`` env flag. That is a no-op the moment an
+        operator sets it, and it restores the full bypass for every identity
+        at once. It also cannot express the thing that actually matters.
+
+    The rule enforced here is scoped to a single identity instead:
+
+      1. Unsigned is accepted ONLY while the identity has no signing key on
+         record. The 6502 keeps working; a miner that has ever signed can never
+         be impersonated by an unsigned request again.
+      2. Trust on first use. The first signed attestation pins the key.
+      3. Key binding. A canonical ``RTC<40hex>`` identity is self-authenticating,
+         so the presented key must actually derive it. Named identities
+         (``dual-g4-125``, ``power8-s824-sophia``) are not derivable from any
+         key, so they are TOFU-pinned instead. This mirrors the existing
+         ``_header_key_authorized()`` policy for block-header keys.
+      4. Rotation. Replacing a pinned key requires a signature from the CURRENT
+         pinned key over ``rotate|miner|old|new|nonce``. Without that, a forger
+         who generates a fresh keypair cannot displace the real one.
+
+    Returns ``(ok, error_tuple_or_None, pubkey_to_store_or_None)`` where
+    ``error_tuple`` is ``(code, message, http_status)``.
+    """
+    stored = _attest_lookup_signing_pubkey(miner)
+
+    if not signature_verified:
+        # Unsigned submission. Allowed only for a never-keyed identity.
+        if stored:
+            return False, (
+                "ATTESTATION_SIGNATURE_REQUIRED",
+                "This miner has a signing key on record; attestations for it "
+                "must be signed with that key.",
+                401,
+            ), None
+        # Legacy path: nothing pinned, nothing to pin.
+        return True, None, None
+
+    # Signature already verified against pubkey_hex by the caller.
+    if _attest_is_rtc_address(miner):
+        try:
+            derived = address_from_pubkey(pubkey_hex)
+        except Exception:
+            derived = None
+        if not derived or derived.lower() != miner.lower():
+            return False, (
+                "ATTESTATION_KEY_IDENTITY_MISMATCH",
+                "The supplied public key does not derive the claimed RTC "
+                "address.",
+                403,
+            ), None
+        return True, None, pubkey_hex
+
+    # Named/legacy identity: no derivation exists, so pin on first use.
+    if stored is None or stored == pubkey_hex:
+        return True, None, pubkey_hex
+
+    # Rotation attempt: must be authorized by the key currently on record.
+    rotation_sig = _attest_text(rotation_sig_hex)
+    if rotation_sig and HAVE_NACL and verify_rtc_signature(
+        stored,
+        _attest_rotation_message(miner, stored, pubkey_hex, nonce),
+        rotation_sig.strip().lower(),
+    ):
+        return True, None, pubkey_hex
+
+    return False, (
+        "ATTESTATION_KEY_ROTATION_UNAUTHORIZED",
+        "This miner is already pinned to a different signing key. A rotation "
+        "must carry 'rotation_signature' over "
+        "'rotate|miner|old_pubkey|new_pubkey|nonce' signed by the current key.",
+        403,
+    ), None
+
+
 @app.route('/attest/submit', methods=['POST'])
 def submit_attestation():
     """Submit hardware attestation with fingerprint validation"""
@@ -4490,6 +4665,11 @@ def _submit_attestation_impl():
     pubkey_hex = (raw_pubkey or '').strip().lower()
     miner_id_raw = _attest_valid_miner(data.get('miner_id')) or miner
     commitment = report.get('commitment') or ''
+    # Issue #8016: track whether a signature was actually PROVEN, so the
+    # per-miner authorization gate below can tell "unsigned" apart from
+    # "signed and verified". Reaching the end of the block with this still
+    # False means no signature was supplied at all.
+    signature_verified = False
     if sig_hex and pubkey_hex:
         if HAVE_NACL:
             # Type-guard signature_type too — reject a non-string value with 400,
@@ -4547,6 +4727,7 @@ def _submit_attestation_impl():
                     "message": "Ed25519 signature verification failed — report may have been tampered",
                     "code": "INVALID_SIGNATURE",
                 }), 400
+            signature_verified = True
         else:
             # pynacl is not available but the client provided a signature.
             # Fail-closed: reject the attestation rather than accepting an
@@ -4566,6 +4747,30 @@ def _submit_attestation_impl():
                 ),
                 "code": "ED25519_UNAVAILABLE",
             }), 503
+
+    # Issue #8016: per-miner signing-key authorization.
+    # Runs BEFORE the nonce is consumed so a rejected forgery cannot burn the
+    # challenge the rightful owner is about to use.
+    auth_ok, auth_err, pubkey_to_store = _attest_authorize_signing_key(
+        miner=miner,
+        pubkey_hex=pubkey_hex,
+        signature_verified=signature_verified,
+        rotation_sig_hex=data.get('rotation_signature'),
+        nonce=nonce,
+    )
+    if not auth_ok:
+        err_code, err_message, err_status = auth_err
+        print(f"[ATTEST/KEY] REJECTED {err_code}: miner={str(miner)[:24]}... "
+              f"pubkey={(pubkey_hex or '(none)')[:16]}...")
+        return jsonify({
+            "ok": False,
+            "error": err_code.lower(),
+            "message": err_message,
+            "code": err_code,
+        }), err_status
+    if not signature_verified:
+        logging.info("[ATTEST/KEY] unsigned attestation accepted for never-keyed "
+                     "identity %r (legacy vintage client path)", str(miner)[:24])
 
     # IP rate limiting (Security Hardening 2026-02-02)
     ip_ok, ip_reason = check_ip_rate_limit(client_ip, miner)
@@ -4829,7 +5034,12 @@ def _submit_attestation_impl():
         except Exception:
             pass
 
-    record_attestation_success(miner, device, fingerprint_passed, client_ip, signals=signals, fingerprint=fingerprint, signing_pubkey=pubkey_hex or None, entropy_score=entropy_score)
+    # Issue #8016: only persist a key the authorization gate actually approved,
+    # and mark whether this submission proved key ownership. An unsigned legacy
+    # attestation is NOT authoritative for device_arch (see
+    # record_attestation_success), because for a never-keyed identity the node
+    # cannot tell the owner from anyone else.
+    record_attestation_success(miner, device, fingerprint_passed, client_ip, signals=signals, fingerprint=fingerprint, signing_pubkey=pubkey_to_store, entropy_score=entropy_score, identity_proven=signature_verified)
 
     temporal_review = {"score": 1.0, "review_flag": False, "reason": "insufficient_history", "flags": [], "check_scores": {}}
     try:
@@ -4894,12 +5104,23 @@ def _submit_attestation_impl():
                 "INSERT OR IGNORE INTO balances (miner_pk, balance_rtc) VALUES (?, 0)",
                 (miner,)
             )
-            # FIX: Use INSERT OR IGNORE for epoch_enroll to prevent a later
-            # low-weight (e.g. fingerprint-failed) attestation from overwriting
-            # a prior high-weight enrollment within the same epoch. This avoids
-            # "attestation overwrite causes prior-epoch reward loss".
+            # Issue #8016: keep the HIGHEST weight seen this epoch instead of
+            # first-write-wins.
+            #
+            # INSERT OR IGNORE blocked a later low-weight write, but it also
+            # meant whoever wrote FIRST owned the row for the whole epoch.
+            # Because FAILED_FINGERPRINT_WEIGHT_UNITS is 0, an attacker who
+            # submitted a fingerprint-failing attestation for a victim at the
+            # start of an epoch pinned that victim to weight 0, and the
+            # victim's own honest enrollment was then silently ignored. Sweeping
+            # every known wallet that way let the attacker absorb the fixed
+            # per-epoch RTC pot. MAX() keeps the anti-downgrade property that
+            # INSERT OR IGNORE was added for while removing the front-run,
+            # mirroring the MAX(fingerprint_passed) precedent above.
             enroll_conn.execute(
-                "INSERT OR IGNORE INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)",
+                "INSERT INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?) "
+                "ON CONFLICT(epoch, miner_pk) DO UPDATE SET "
+                "weight = MAX(epoch_enroll.weight, excluded.weight)",
                 (epoch, miner, enroll_weight_units)
             )
             header_pubkey = _valid_ed25519_pubkey_hex(pubkey_hex) or _valid_ed25519_pubkey_hex(miner)
@@ -5215,15 +5436,15 @@ def enroll_epoch():
         )
 
         # Enroll in epoch
-        # FIX: Use INSERT OR IGNORE to prevent external actors from downgrading
-        # a miner's epoch weight via repeated /epoch/enroll calls. The first
-        # enrollment in an epoch wins (whether from auto-enroll or explicit).
-        # This closes the "zero-weight miner reward distortion" vector where an
-        # attacker could overwrite a legitimate miner's weight (e.g. 2.5) with
-        # a near-zero value (1e-9) by calling this endpoint with failed-fingerprint
-        # or default device data.
+        # Issue #8016: MAX() upsert rather than INSERT OR IGNORE, for the same
+        # reason as the auto-enroll site in _submit_attestation_impl. Keeping
+        # the highest weight still blocks the "downgrade a legitimate 2.5 to
+        # ~0" vector that INSERT OR IGNORE was introduced to stop, but it no
+        # longer lets whoever writes first pin a victim to zero for the epoch.
         c.execute(
-            "INSERT OR IGNORE INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)",
+            "INSERT INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?) "
+            "ON CONFLICT(epoch, miner_pk) DO UPDATE SET "
+            "weight = MAX(epoch_enroll.weight, excluded.weight)",
             (epoch, miner_pk, weight_units)
         )
 

--- a/node/sophia_elya_service.py
+++ b/node/sophia_elya_service.py
@@ -197,11 +197,14 @@ def inc_epoch_block(epoch):
 def enroll_epoch(epoch, miner_pk, weight):
     """Enroll miner in epoch with weight.
 
-    FIX: Use INSERT OR IGNORE to prevent external weight downgrades.
-    The first enrollment in an epoch wins; subsequent calls for the same
-    (epoch, miner_pk) are no-ops. This closes the zero-weight reward
-    distortion vector where an attacker could overwrite a legitimate
-    miner's weight via repeated enroll calls.
+    Keeps the HIGHEST weight seen for (epoch, miner_pk).
+
+    This started as INSERT OR IGNORE to stop external weight downgrades, but
+    first-write-wins let whoever enrolled first own the row for the entire
+    epoch, so a low-but-positive forged enrollment could hold a miner down
+    until settlement. MAX() keeps the anti-downgrade property without the
+    front-run. Same change as the two epoch_enroll sites in
+    rustchain_v2_integrated_v2.2.1_rip200.py (issue #8016).
     """
     weight = float(weight)
     # Backstop: never persist a non-positive / non-finite weight. A negative
@@ -211,7 +214,12 @@ def enroll_epoch(epoch, miner_pk, weight):
     if not math.isfinite(weight) or weight <= 0:
         return
     with sqlite3.connect(DB_PATH) as c:
-        c.execute("INSERT OR IGNORE INTO epoch_enroll(epoch, miner_pk, weight) VALUES (?,?,?)", (epoch, miner_pk, weight))
+        c.execute(
+            "INSERT INTO epoch_enroll(epoch, miner_pk, weight) VALUES (?,?,?) "
+            "ON CONFLICT(epoch, miner_pk) DO UPDATE SET "
+            "weight = MAX(epoch_enroll.weight, excluded.weight)",
+            (epoch, miner_pk, weight),
+        )
 
 def finalize_epoch(epoch, per_block_rtc):
     """Finalize epoch and distribute rewards"""

--- a/tests/test_attest_signing_key_scope_8016.py
+++ b/tests/test_attest_signing_key_scope_8016.py
@@ -1,0 +1,512 @@
+"""Issue #8016 — per-miner signing-key scope on /attest/submit.
+
+Reported by @draycolix: ``if sig_hex and pubkey_hex:`` guarded every signature
+check with no ``else``, so omitting both fields skipped verification entirely
+and the request fell through to nonce validation, hardware binding, fingerprint
+validation, auto-enrollment and ticket issuance.
+
+These tests cover BOTH directions, because a fix that only locks things down
+would take the vintage fleet offline:
+
+  attacker side
+    - cannot attest unsigned for a miner that has a signing key on record
+    - cannot present a key that does not derive a canonical RTC identity
+    - cannot displace a pinned key on a named identity without signing the
+      rotation with the CURRENT key
+    - cannot erase a stored signing key with an unsigned submission
+    - cannot front-run an epoch enrollment to pin a victim at weight 0
+    - cannot rewrite a vintage miner's device_arch
+
+  honest side
+    - an unsigned legacy miner with no stored key still attests and still
+      earns a non-zero epoch weight
+    - a correctly signed RTC-address miner still attests
+    - a genuine key rotation signed by the current key still succeeds
+"""
+
+import json
+import sqlite3
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+from nacl.signing import SigningKey
+
+integrated_node = sys.modules["integrated_node"]
+
+EPOCH = 85
+
+
+# --------------------------------------------------------------------------
+# harness
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def attest_client(monkeypatch):
+    """A Flask test client wired to a fresh on-disk SQLite database.
+
+    An on-disk file (not ``:memory:``) is required because the handler opens
+    several independent connections per request.
+    """
+    tmp_dir = Path(__file__).parent / ".tmp_attest_8016"
+    tmp_dir.mkdir(exist_ok=True)
+    db_path = tmp_dir / f"{uuid.uuid4().hex}.sqlite3"
+
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    monkeypatch.setattr(integrated_node, "HW_BINDING_V2", False, raising=False)
+    monkeypatch.setattr(integrated_node, "HW_PROOF_AVAILABLE", False, raising=False)
+    monkeypatch.setattr(integrated_node, "HAVE_REPLAY_DEFENSE", False, raising=False)
+    monkeypatch.setattr(integrated_node, "_check_hardware_binding",
+                        lambda *a, **k: (True, "ok", ""))
+    monkeypatch.setattr(integrated_node, "check_ip_rate_limit",
+                        lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(integrated_node, "check_challenge_rate_limit",
+                        lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(integrated_node, "record_macs", lambda *a, **k: None)
+    monkeypatch.setattr(integrated_node, "auto_induct_to_hall", lambda *a, **k: None)
+    monkeypatch.setattr(integrated_node, "current_slot", lambda: 12345)
+    monkeypatch.setattr(integrated_node, "slot_to_epoch", lambda slot: EPOCH)
+    integrated_node.init_db()
+
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as client:
+        yield client, db_path
+
+    try:
+        db_path.unlink()
+    except OSError:
+        pass
+
+
+def _passing_vintage_fingerprint():
+    """A fingerprint the server-side validator accepts for a G4.
+
+    For vintage archs ``validate_fingerprint_data`` only strictly requires
+    anti_emulation, but the extra checks keep this close to a real payload.
+    """
+    return {
+        "all_passed": True,
+        "checks": {
+            "anti_emulation": {
+                "passed": True,
+                "data": {
+                    "vm_indicators": [],
+                    "paths_checked": ["/proc/cpuinfo"],
+                    "dmesg_scanned": True,
+                },
+            },
+            "clock_drift": {"passed": True, "data": {"cv": 0.06, "samples": 80}},
+            "simd_identity": {
+                "passed": True,
+                "data": {"has_altivec": True, "has_sse": False,
+                         "has_avx": False, "vec_perm": True},
+            },
+            "cache_timing": {
+                "passed": True,
+                "data": {"arch": "powerpc", "l2_l1_ratio": 1.42,
+                         "l3_l2_ratio": 1.18},
+            },
+        },
+    }
+
+
+def _challenge(client, miner):
+    resp = client.post("/attest/challenge", json={"miner": miner})
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    return resp.get_json()["nonce"]
+
+
+def _payload(miner, nonce, arch="G4", family="PowerPC"):
+    return {
+        "miner": miner,
+        "miner_id": miner,
+        "device": {
+            "device_family": family,
+            "device_arch": arch,
+            "arch": arch,
+            "family": family,
+            "cores": 2,
+            "model": "PowerMac G4",
+            "cpu": "PowerPC G4",
+            "machine": "ppc",
+        },
+        "signals": {"hostname": "vintage-host",
+                    "macs": ["AA:BB:CC:DD:EE:01"]},
+        "report": {"nonce": nonce, "commitment": "commit-" + nonce[:8]},
+        "fingerprint": _passing_vintage_fingerprint(),
+    }
+
+
+def _sign(payload, signing_key):
+    """Attach a v3 canonical-JSON Ed25519 signature, as the node reconstructs it."""
+    body = {k: v for k, v in payload.items()
+            if k not in ("signature", "signature_type", "public_key")}
+    canonical = json.dumps(body, sort_keys=True, separators=(",", ":")).encode()
+    payload["signature"] = signing_key.sign(canonical).signature.hex()
+    payload["public_key"] = signing_key.verify_key.encode().hex()
+    payload["signature_type"] = "ed25519"
+    return payload
+
+
+def _rtc_identity(signing_key):
+    return integrated_node.address_from_pubkey(
+        signing_key.verify_key.encode().hex()
+    )
+
+
+def _stored_key(db_path, miner):
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT signing_pubkey FROM miner_attest_recent WHERE miner = ?",
+            (miner,),
+        ).fetchone()
+    return row[0] if row else None
+
+
+def _stored_arch(db_path, miner):
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT device_arch FROM miner_attest_recent WHERE miner = ?",
+            (miner,),
+        ).fetchone()
+    return row[0] if row else None
+
+
+def _enrolled_weight(db_path, miner, epoch=EPOCH):
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT weight FROM epoch_enroll WHERE epoch = ? AND miner_pk = ?",
+            (epoch, miner),
+        ).fetchone()
+    return row[0] if row else None
+
+
+# --------------------------------------------------------------------------
+# honest side — the vintage fleet must keep working
+# --------------------------------------------------------------------------
+
+def test_unsigned_legacy_miner_with_no_stored_key_is_accepted(attest_client):
+    """A 6502/i386/floppy-class client sends no signature at all.
+
+    It must still attest. This is the case PR #8052 broke.
+    """
+    client, db_path = attest_client
+    miner = "dual-g4-125"
+    payload = _payload(miner, _challenge(client, miner))
+
+    resp = client.post("/attest/submit", json=payload)
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert resp.get_json()["ok"] is True
+
+
+def test_unsigned_legacy_miner_still_earns_nonzero_weight(attest_client):
+    """Accepting the attestation is not enough; it must still enroll to earn."""
+    client, db_path = attest_client
+    miner = "apple2-miner"
+    payload = _payload(miner, _challenge(client, miner))
+
+    resp = client.post("/attest/submit", json=payload)
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+
+    weight = _enrolled_weight(db_path, miner)
+    assert weight is not None, "unsigned legacy miner was not enrolled at all"
+    assert weight > 0, f"unsigned legacy miner enrolled at zero weight ({weight})"
+
+
+def test_unsigned_legacy_miner_can_reattest_repeatedly(attest_client):
+    """Successive unsigned attestations must not lock the miner out of itself.
+
+    An unsigned submission stores no key, so the per-miner gate must stay open
+    for it rather than pinning something that then rejects the next call.
+    """
+    client, db_path = attest_client
+    miner = "i386-miner"
+
+    for _ in range(3):
+        payload = _payload(miner, _challenge(client, miner))
+        resp = client.post("/attest/submit", json=payload)
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+
+    assert _stored_key(db_path, miner) is None
+
+
+def test_signed_rtc_address_miner_is_accepted_and_pins_its_key(attest_client):
+    """The signing client (rustchain-miner) path still works and pins TOFU."""
+    client, db_path = attest_client
+    key = SigningKey.generate()
+    miner = _rtc_identity(key)
+    payload = _sign(_payload(miner, _challenge(client, miner)), key)
+
+    resp = client.post("/attest/submit", json=payload)
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert _stored_key(db_path, miner) == key.verify_key.encode().hex()
+
+
+def test_named_identity_pins_key_on_first_signed_attestation(attest_client):
+    client, db_path = attest_client
+    key = SigningKey.generate()
+    miner = "power8-s824-sophia"
+    payload = _sign(_payload(miner, _challenge(client, miner)), key)
+
+    resp = client.post("/attest/submit", json=payload)
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert _stored_key(db_path, miner) == key.verify_key.encode().hex()
+
+
+def test_authorized_rotation_signed_by_current_key_succeeds(attest_client):
+    """A real operator rotating their key can still do so, with proof."""
+    client, db_path = attest_client
+    old_key = SigningKey.generate()
+    new_key = SigningKey.generate()
+    miner = "power8-s824-sophia"
+
+    first = _sign(_payload(miner, _challenge(client, miner)), old_key)
+    assert client.post("/attest/submit", json=first).status_code == 200
+
+    old_hex = old_key.verify_key.encode().hex()
+    new_hex = new_key.verify_key.encode().hex()
+    nonce = _challenge(client, miner)
+    payload = _payload(miner, nonce)
+    payload["rotation_signature"] = old_key.sign(
+        integrated_node._attest_rotation_message(miner, old_hex, new_hex, nonce)
+    ).signature.hex()
+    payload = _sign(payload, new_key)
+
+    resp = client.post("/attest/submit", json=payload)
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert _stored_key(db_path, miner) == new_hex
+
+
+# --------------------------------------------------------------------------
+# attacker side
+# --------------------------------------------------------------------------
+
+def test_unsigned_forgery_rejected_once_miner_has_a_key(attest_client):
+    """The core #8016 bypass: unsigned submission naming a keyed victim."""
+    client, db_path = attest_client
+    victim_key = SigningKey.generate()
+    victim = _rtc_identity(victim_key)
+
+    honest = _sign(_payload(victim, _challenge(client, victim)), victim_key)
+    assert client.post("/attest/submit", json=honest).status_code == 200
+
+    forged = _payload(victim, _challenge(client, victim), arch="modern",
+                      family="x86")
+
+    resp = client.post("/attest/submit", json=forged)
+
+    assert resp.status_code == 401, resp.get_data(as_text=True)
+    assert resp.get_json()["code"] == "ATTESTATION_SIGNATURE_REQUIRED"
+
+
+def test_self_signed_forgery_with_fresh_keypair_rejected_for_rtc_identity(attest_client):
+    """Signing with an attacker-generated key must not authorize a victim's
+    RTC address. The address derives from the key, so the derivation is checked."""
+    client, db_path = attest_client
+    victim_key = SigningKey.generate()
+    victim = _rtc_identity(victim_key)
+    attacker_key = SigningKey.generate()
+
+    forged = _sign(_payload(victim, _challenge(client, victim)), attacker_key)
+
+    resp = client.post("/attest/submit", json=forged)
+
+    assert resp.status_code == 403, resp.get_data(as_text=True)
+    assert resp.get_json()["code"] == "ATTESTATION_KEY_IDENTITY_MISMATCH"
+
+
+def test_unsigned_rotation_cannot_displace_pinned_key_on_named_identity(attest_client):
+    client, db_path = attest_client
+    owner_key = SigningKey.generate()
+    attacker_key = SigningKey.generate()
+    miner = "dual-g4-125"
+
+    first = _sign(_payload(miner, _challenge(client, miner)), owner_key)
+    assert client.post("/attest/submit", json=first).status_code == 200
+
+    forged = _sign(_payload(miner, _challenge(client, miner)), attacker_key)
+
+    resp = client.post("/attest/submit", json=forged)
+
+    assert resp.status_code == 403, resp.get_data(as_text=True)
+    assert resp.get_json()["code"] == "ATTESTATION_KEY_ROTATION_UNAUTHORIZED"
+    assert _stored_key(db_path, miner) == owner_key.verify_key.encode().hex()
+
+
+def test_rotation_signed_by_the_wrong_key_is_rejected(attest_client):
+    """A rotation proof must come from the CURRENT key, not the new one."""
+    client, db_path = attest_client
+    owner_key = SigningKey.generate()
+    attacker_key = SigningKey.generate()
+    miner = "dual-g4-125"
+
+    first = _sign(_payload(miner, _challenge(client, miner)), owner_key)
+    assert client.post("/attest/submit", json=first).status_code == 200
+
+    old_hex = owner_key.verify_key.encode().hex()
+    new_hex = attacker_key.verify_key.encode().hex()
+    nonce = _challenge(client, miner)
+    payload = _payload(miner, nonce)
+    # Self-signed rotation proof: signed by the attacker's own new key.
+    payload["rotation_signature"] = attacker_key.sign(
+        integrated_node._attest_rotation_message(miner, old_hex, new_hex, nonce)
+    ).signature.hex()
+    payload = _sign(payload, attacker_key)
+
+    resp = client.post("/attest/submit", json=payload)
+
+    assert resp.status_code == 403, resp.get_data(as_text=True)
+    assert resp.get_json()["code"] == "ATTESTATION_KEY_ROTATION_UNAUTHORIZED"
+    assert _stored_key(db_path, miner) == old_hex
+
+
+def test_unsigned_submission_cannot_null_a_stored_signing_key(attest_client):
+    """Consequence 2 of #8016: erasing the key locked the victim out of the
+    hardened signed /epoch/enroll path with a 412."""
+    client, db_path = attest_client
+    key = SigningKey.generate()
+    miner = _rtc_identity(key)
+
+    honest = _sign(_payload(miner, _challenge(client, miner)), key)
+    assert client.post("/attest/submit", json=honest).status_code == 200
+    assert _stored_key(db_path, miner) == key.verify_key.encode().hex()
+
+    client.post("/attest/submit", json=_payload(miner, _challenge(client, miner)))
+
+    assert _stored_key(db_path, miner) == key.verify_key.encode().hex(), \
+        "an unsigned submission erased the stored signing key"
+
+
+def test_forged_low_weight_enrollment_cannot_front_run_the_victim(attest_client):
+    """Consequence 1 of #8016, the actual theft vector.
+
+    epoch_enroll used INSERT OR IGNORE, so a forged fingerprint-FAILING
+    attestation submitted first pinned the victim to weight 0 for the whole
+    epoch and their honest enrollment was silently ignored.
+    """
+    client, db_path = attest_client
+    miner = "g4-powerbook-115"
+
+    # Attacker moves first with a VM-flagged (weight 0) attestation.
+    forged = _payload(miner, _challenge(client, miner))
+    forged["fingerprint"] = {
+        "all_passed": False,
+        "checks": {
+            "anti_emulation": {
+                "passed": False,
+                "data": {"vm_indicators": ["cpuinfo:hypervisor"]},
+            },
+        },
+    }
+    assert client.post("/attest/submit", json=forged).status_code == 200
+    assert _enrolled_weight(db_path, miner) == 0
+
+    # The rightful owner then attests honestly.
+    honest = _payload(miner, _challenge(client, miner))
+    assert client.post("/attest/submit", json=honest).status_code == 200
+
+    weight = _enrolled_weight(db_path, miner)
+    assert weight > 0, (
+        f"honest enrollment was ignored after a forged zero-weight front-run "
+        f"(weight={weight})"
+    )
+
+
+def test_high_weight_enrollment_is_not_downgraded_by_a_later_zero(attest_client):
+    """The MAX() upsert must keep the anti-downgrade property that
+    INSERT OR IGNORE was originally added for."""
+    client, db_path = attest_client
+    miner = "g4-powerbook-real"
+
+    honest = _payload(miner, _challenge(client, miner))
+    assert client.post("/attest/submit", json=honest).status_code == 200
+    good_weight = _enrolled_weight(db_path, miner)
+    assert good_weight > 0
+
+    forged = _payload(miner, _challenge(client, miner))
+    forged["fingerprint"] = {
+        "all_passed": False,
+        "checks": {"anti_emulation": {"passed": False,
+                                      "data": {"vm_indicators": ["qemu"]}}},
+    }
+    client.post("/attest/submit", json=forged)
+
+    assert _enrolled_weight(db_path, miner) == good_weight, \
+        "a later zero-weight attestation downgraded the epoch weight"
+
+
+def test_unsigned_submission_cannot_rewrite_device_arch(attest_client):
+    """Consequence 3 of #8016: rewards read device_arch straight out of
+    miner_attest_recent, so an overwrite drops a G4 from 2.5x to 1.0x."""
+    client, db_path = attest_client
+    miner = "dual-g4-125"
+
+    assert client.post(
+        "/attest/submit", json=_payload(miner, _challenge(client, miner))
+    ).status_code == 200
+    original_arch = _stored_arch(db_path, miner)
+    assert original_arch is not None
+
+    downgrade = _payload(miner, _challenge(client, miner),
+                         arch="modern", family="x86")
+    downgrade["device"]["machine"] = "x86_64"
+    client.post("/attest/submit", json=downgrade)
+
+    assert _stored_arch(db_path, miner) == original_arch, \
+        "an unsigned submission rewrote the recorded device_arch"
+
+
+# --------------------------------------------------------------------------
+# unit-level checks on the authorization helper itself
+# --------------------------------------------------------------------------
+
+def test_rtc_address_shape_only_matches_canonical_form():
+    """Legacy suffix wallets (``<hex>RTC``) must NOT be treated as derivable.
+
+    miners/ppc/g5/g5_miner.sh uses ``ppc_g5_130_<md5>RTC`` and cannot sign; if
+    that shape were classified as a canonical RTC address the derivation check
+    would reject it outright.
+    """
+    key = SigningKey.generate()
+    canonical = integrated_node.address_from_pubkey(
+        key.verify_key.encode().hex()
+    )
+
+    assert integrated_node._attest_is_rtc_address(canonical) is True
+    assert integrated_node._attest_is_rtc_address("ppc_g5_130_abc123RTC") is False
+    assert integrated_node._attest_is_rtc_address(
+        "eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC") is False
+    assert integrated_node._attest_is_rtc_address("dual-g4-125") is False
+    assert integrated_node._attest_is_rtc_address("apple2-miner") is False
+
+
+def test_floppy_miner_rtc_identity_stays_unsigned_capable(attest_client):
+    """miners/floppy-miner uses a canonical RTC address AND cannot sign.
+
+    Unsigned must therefore still be accepted for it while no key is pinned,
+    which is exactly why the rule keys off "has a stored key", not "looks
+    like an RTC address".
+    """
+    client, db_path = attest_client
+    miner = "RTC2fe3c33c77666ff76a1cd0999fd4466ee81250ff"
+
+    resp = client.post("/attest/submit",
+                       json=_payload(miner, _challenge(client, miner)))
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert _enrolled_weight(db_path, miner) > 0
+
+
+def test_unsigned_client_allowlist_is_documented():
+    """The allowlist is documentation, not a privilege grant."""
+    allowlist = integrated_node.UNSIGNED_ATTEST_CLIENT_ALLOWLIST
+    assert "miners/apple2/miner6502.c" in allowlist
+    assert "miners/i386/miner386.c" in allowlist
+    assert "miners/floppy-miner/" in allowlist
+    assert "miners/ppc/g5/g5_miner.sh" in allowlist
+    assert "miners/rust/src/main.rs" in allowlist


### PR DESCRIPTION
Fixes the unsigned attestation bypass reported in #8016 by @draycolix.

**This is not deployed.** Nothing was run against a production node. Rolling it out is a maintainer decision, and the "Rollout notes" section below lists what breaks if you do.

## What is actually wrong

Verified against `node/rustchain_v2_integrated_v2.2.1_rip200.py` at `0ddfeb3`:

- **Line 4493**, `_submit_attestation_impl`: `if sig_hex and pubkey_hex:` guards every signature check and has no `else`. Omitting both fields skips verification entirely and execution falls through to IP rate limiting (4571), nonce validation (4589), hardware binding (4641), fingerprint validation, auto-enrollment (4901) and ticket issuance (4947).
- **Line 4263**, `/attest/challenge`: unauthenticated, rate-limited only, and it binds the nonce to the identity the *requester names* (4326, 4331). So the nonce protects nothing. Ask for a challenge naming the victim and you get one.
- `address_from_pubkey` (defined at 10844) is never called anywhere in the attestation handler. Nothing binds the submitted `public_key` to the claimed `miner`, so a self-signed forgery with a freshly generated keypair passes too. The codebase already knows this; `_header_key_authorized` says so in its docstring at line 5384.

Three things follow from that, all confirmed in code:

1. **The theft vector.** `epoch_enroll` has PK `(epoch, miner_pk)` (1403, 1711) and both insert sites used `INSERT OR IGNORE` (4902 and 5226). `FAILED_FINGERPRINT_WEIGHT_UNITS` is `0` (1364). A forged fingerprint-failing attestation writes weight 0 for a victim, and the victim's own honest enrollment is then silently ignored for the rest of the epoch. Sweep every known wallet at epoch start and you absorb the fixed per-epoch RTC pot.
2. **Lockout.** `record_attestation_success` did `signing_pubkey = excluded.signing_pubkey` unconditionally (3212). An unsigned forgery passes `signing_pubkey=None`, which NULLs the victim's stored key. The hardened signed `/epoch/enroll` path then returns 412 `ENROLLMENT_SIGNING_KEY_REQUIRED` (5124) and the victim cannot enroll.
3. **Multiplier downgrade.** `device_arch` was overwritten with no protection (3209), unlike `fingerprint_passed` which is `MAX`-guarded (3211). Rewards read `device_arch` straight out of `miner_attest_recent` (`rewards_implementation_rip200.py:276-280` into `get_time_aged_multiplier`), so this drops a G4 from 2.5x to 1.0x.

## Why per-miner scope, and not the obvious alternatives

Most miner clients in this repo do not sign at all. I checked every one:

| Client | Signs | Identity |
|---|---|---|
| `miners/apple2/miner6502.c` | no | `apple2-miner` |
| `miners/i386/miner386.c` | no | `i386-miner` |
| `miners/floppy-miner/` | no | `RTC2fe3c33c…` |
| `miners/ppc/g5/g5_miner.sh` | no | `ppc_g5_130_<md5>RTC` |
| `miners/rust/src/main.rs` | no | `default-miner` |
| `miners/ppc/g4/rustchain_miner.c`, `_v6.c` | no | `dual-g4-125` |
| `miners/power8/rustchain_power8_miner.py` | no | `power8-s824-<host>` |
| `miners/macos/…v2.4.py`, `macos/intel/…v2.4.py` | no | legacy names |
| `miners/pico_bridge/`, `mining/n64-miner/`, `mining/crt-attestation/` | no | legacy names |
| `rustchain-miner/src/attestation.rs` | **yes** | RTC wallet |
| `miners/linux/rustchain_linux_miner.py` | **yes**, conditional | `<38hex>RTC` |
| `miners/macos/rustchain_mac_miner_v2.5.py` | **yes**, if key loaded | canonical RTC |
| `miners/windows/rustchain_windows_miner.py` | **yes**, sha512 fallback with no pubkey | user wallet |

So:

- **Rejecting all unsigned attestations takes the honest fleet offline.** That is what PR #8052 did. A 6502 cannot compute Ed25519. Neither can a boot floppy or a shell script with curl.
- **A global allow-flag is a no-op the moment an operator sets it.** It restores the complete bypass for every identity simultaneously, and it cannot express the thing that actually matters, which is "this *particular* miner has proven it can sign, so stop accepting unsigned submissions *for it*".

The rule this PR enforces is scoped to one identity at a time, in `_attest_authorize_signing_key`:

1. **Unsigned is accepted only while the identity has no signing key on record.** The 6502 keeps working forever. A miner that has ever signed can never be impersonated by an unsigned request again.
2. **Trust on first use.** The first signed attestation pins the key.
3. **Key bound to identity.** A canonical `RTC<40hex>` address is self-authenticating, so the presented key must actually derive it (`address_from_pubkey(pubkey) == miner`). Named identities like `dual-g4-125` and `power8-s824-sophia` are not derivable from any key, so they get TOFU-pinned instead. This is the same policy `_header_key_authorized` already applies to block-header keys.
4. **Rotation needs the old key.** Replacing a pinned key requires `rotation_signature` over `rotate|miner|old_pubkey|new_pubkey|nonce`, signed by the key currently on record. A forger with a fresh keypair cannot displace the real one.

Note the RTC-shape check deliberately matches only the `RTC` + 40 hex *prefix* form. Several legacy wallets are a *suffix* form (`<38hex>RTC`, `ppc_g5_130_<md5>RTC`); treating those as derivable would reject them outright.

The gate runs before the nonce is consumed, so a rejected forgery cannot burn the challenge the rightful owner is about to use.

## The other three fixes

These matter independently, because they are what protect the legacy identities that still cannot sign:

- `epoch_enroll` at both sites is now an upsert taking `MAX(weight)`, mirroring the existing `MAX(fingerprint_passed)` precedent. This keeps the anti-downgrade property `INSERT OR IGNORE` was added for while removing the front-run. Same one-line change applied to `node/sophia_elya_service.py:214`, which had the same pattern.
- `signing_pubkey` is now `COALESCE(excluded, existing)`, so a key can be added or rotated but never erased by a submission that did not carry one.
- `device_family`/`device_arch` only change on an identity-proven attestation. For a never-keyed legacy identity the node genuinely cannot tell the owner from a forger, so the first recorded value wins. That is deliberately symmetric: it blocks a forged downgrade and a forged upgrade equally. A plain MAX-by-multiplier would have blocked only the downgrade while making arch spoofing permanent.

## Allowlist

`UNSIGNED_ATTEST_CLIENT_ALLOWLIST` documents the five client families that structurally cannot sign. It grants no privilege on its own; acceptance is decided purely by "does this identity have a key on record". It exists so operators can audit which identities are expected to stay unsigned.

To be explicit about the residual risk: **identities used by those clients are only ever as strong as their first-seen binding.** Anyone can still attest as a never-keyed legacy identity. What changed is that doing so can no longer steal from or lock out the target, because the forgery cannot lower an existing epoch weight, cannot erase a stored key, and cannot rewrite a recorded arch. Closing that last gap needs either signing hardware or an admin-seeded bootstrap allowlist like the one `_header_key_strict_bootstrap` already uses for header keys. I did not build that here.

## Tests

New file `tests/test_attest_signing_key_scope_8016.py`, 17 tests, driving the real Flask handler end to end against a temp SQLite DB.

Attacker side: unsigned forgery rejected once a miner has a key; self-signed forgery with a fresh keypair rejected for an RTC identity; unsigned rotation cannot displace a pinned key; rotation signed by the wrong key rejected; unsigned submission cannot NULL a stored key; forged zero-weight enrollment cannot front-run the victim; unsigned submission cannot rewrite `device_arch`.

Honest side: unsigned legacy miner with no stored key still attests, still enrolls at non-zero weight, and can re-attest repeatedly; signed RTC miner works and pins its key; named identity pins on first signed attestation; genuine rotation signed by the current key succeeds; the floppy miner's canonical-RTC-but-unsigned case still works.

Real numbers:

```
new tests, against this branch:      17 passed
new tests, against unpatched node:   10 failed, 7 passed
```

The 7 that pass both ways are the honest-fleet tests. They are supposed to pass before and after; that is the regression guard.

Full suite, excluding the new file, with and without this change:

```
with fix:     4 failed, 3665 passed, 46 skipped
without fix:  4 failed, 3665 passed, 46 skipped
```

Identical, so no regressions. Those 4 failures are pre-existing in `tests/test_epoch_settlement_formal.py` and fail the same way on unmodified `main`. `tests/test_device_classification_corpus.py` cannot be collected at all because `hypothesis` is not installed; also pre-existing and unrelated.

`py_compile` clean on all three changed files.

## Rollout notes

Not deployed. Before this goes out, two behaviours are worth a decision:

1. **A miner that signs conditionally and then stops will be locked out.** `miners/linux/rustchain_linux_miner.py` falls through unsigned on exception, and `miners/windows/rustchain_windows_miner.py` falls back to a sha512 signature with no `public_key`, which this handler treats as unsigned. Once either has pinned a key, a later unsigned submission gets 401. That is the intended security property, but it is a live-fleet consideration and those two clients may want fixing first.
2. **A canonical-RTC identity whose wallet was set by hand rather than derived from its own key will get 403.** `rustchain_mac_miner_v2.5.py` returns `self.wallet` as the attestation identity whenever it starts with `RTC`, so a manually configured wallet that the local key does not derive would be rejected. Worth checking before rollout whether any live miner is in that state.

Neither is a code defect here. Both are the fix doing what it is supposed to do, surfaced early so the rollout is not a surprise.
