### PR TITLE
Compute epoch enrolment weight from the verified device, not the request body

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5024,6 +5024,56 @@ def get_proposer_duty_calendar():
     )
 
 @app.route('/epoch/enroll', methods=['POST'])
+def resolve_enroll_hw_weight(db_path, miner_pk, miner_id=None):
+    """Resolve enrollment reward weight from the SERVER-DERIVED device.
+
+    The request body must never decide reward weight. A caller can put any
+    family/arch in it and self-grant a multiplier: HARDWARE_WEIGHTS["ARM"]["arm2"]
+    is 4.0 against an honest modern x86_64 at 0.8, a 5x uplift and higher than a
+    real G4. Because epoch_enroll is INSERT OR IGNORE, that forged row would also
+    win against the honest auto-enroll that follows.
+
+    The attestation path already runs derive_verified_device() and stores the
+    result, and check_enrollment_requirements() mandates an attestation no older
+    than ENROLL_TICKET_TTL_S, so a row is expected to exist here.
+
+    Returns (hw_weight, family, arch, source).
+    """
+    family, arch, source = "x86", "default", "no_attestation"
+    try:
+        with closing(sqlite3.connect(db_path, timeout=5)) as conn:
+            row = None
+            for key in (k for k in (miner_pk, miner_id) if k):
+                row = conn.execute(
+                    "SELECT device_family, device_arch FROM miner_attest_recent WHERE miner = ?",
+                    (key,),
+                ).fetchone()
+                if row:
+                    source = "attested"
+                    break
+        if row:
+            family = row[0] or "x86"
+            arch = row[1] or "default"
+    except Exception:
+        # Fail soft: an unreadable attestation row must not hand out a bonus tier,
+        # and must not deny enrolment either. The default bucket is neutral.
+        pass
+
+    bucket = HARDWARE_WEIGHTS.get(family, {})
+    if arch in bucket:
+        return bucket[arch], family, arch, source
+    # x86_64 and Windows carry only modern/default; their vintage archs (core2,
+    # retro, pentium_m...) live in the x86 bucket. Without this the macOS miner,
+    # which reports family x86_64 with arch core2, would be paid 0.8 instead of 1.3.
+    if family in ("x86_64", "Windows", "x86"):
+        x86_bucket = HARDWARE_WEIGHTS.get("x86", {})
+        if arch in x86_bucket:
+            return x86_bucket[arch], family, arch, source
+    if "default" in bucket:
+        return bucket["default"], family, arch, source
+    return 1.0, family, arch, source
+
+
 def enroll_epoch():
     """Enroll in current epoch"""
     data = request.get_json(silent=True)
@@ -5183,10 +5233,10 @@ def enroll_epoch():
         ENROLL_REJ[reason] = ENROLL_REJ.get(reason, 0) + 1
         return jsonify(check_result), 412
 
-    # Calculate weight based on hardware
-    family = device.get('family', 'x86')
-    arch = device.get('arch', 'default')
-    hw_weight = HARDWARE_WEIGHTS.get(family, {}).get(arch, 1.0)
+    # Calculate weight from the SERVER-DERIVED device, never the request body.
+    # See resolve_enroll_hw_weight: trusting device.get('family'/'arch') here let a
+    # caller self-grant up to 5x, and INSERT OR IGNORE made the forged row stick.
+    hw_weight, family, arch, _hw_src = resolve_enroll_hw_weight(DB_PATH, miner_pk, data.get('miner_id'))
 
     # RIP-PoA Phase 2: failed fingerprints are tracked but receive zero rewards.
     fingerprint_failed = check_result.get('fingerprint_failed', False)

--- a/node/tests/test_enroll_hw_weight_from_attestation.py
+++ b/node/tests/test_enroll_hw_weight_from_attestation.py
@@ -1,0 +1,114 @@
+"""Regression tests for the /epoch/enroll reward-weight source.
+
+Encodes the defect found 2026-07-25: enroll_epoch computed reward weight from
+device.family / device.arch in the raw request body, so any caller could
+self-grant a multiplier. HARDWARE_WEIGHTS["ARM"]["arm2"] is 4.0 against an
+honest modern x86_64 at 0.8, and because epoch_enroll is INSERT OR IGNORE the
+forged row also won against the honest auto-enroll that followed.
+"""
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+NODE = Path(__file__).resolve().parents[1] / "rustchain_v2_integrated_v2.2.1_rip200.py"
+SRC = NODE.read_text()
+
+
+def _load():
+    """Load HARDWARE_WEIGHTS and the resolver without importing the 11k-line app."""
+    ns = {"sqlite3": sqlite3}
+    from contextlib import closing
+    ns["closing"] = closing
+    hw = re.search(r"^HARDWARE_WEIGHTS = \{.*?^\}", SRC, re.S | re.M)
+    assert hw, "HARDWARE_WEIGHTS block not found"
+    exec(hw.group(0), ns)
+    fn = re.search(r"^def resolve_enroll_hw_weight\(.*?(?=^\S)", SRC, re.S | re.M)
+    assert fn, "resolve_enroll_hw_weight not found"
+    exec(fn.group(0), ns)
+    return ns
+
+
+NS = _load()
+resolve = NS["resolve_enroll_hw_weight"]
+HW = NS["HARDWARE_WEIGHTS"]
+
+
+@pytest.fixture
+def db(tmp_path):
+    p = tmp_path / "t.db"
+    c = sqlite3.connect(p)
+    c.execute("CREATE TABLE miner_attest_recent (miner TEXT PRIMARY KEY, device_family TEXT, device_arch TEXT)")
+    c.commit(); c.close()
+    return str(p)
+
+
+def _attest(db, miner, family, arch):
+    c = sqlite3.connect(db)
+    c.execute("INSERT OR REPLACE INTO miner_attest_recent VALUES (?,?,?)", (miner, family, arch))
+    c.commit(); c.close()
+
+
+def test_arm2_selfgrant_is_ignored(db):
+    """The exploit: attest as modern, then enroll claiming ARM/arm2 for 4.0."""
+    _attest(db, "attacker", "x86_64", "modern")
+    weight, family, arch, src = resolve(db, "attacker")
+    assert weight == HW["x86_64"]["modern"] == 0.8
+    assert (family, arch) == ("x86_64", "modern")
+    assert src == "attested"
+    assert weight < HW["ARM"]["arm2"], "must not reach the self-claimed ARM tier"
+
+
+def test_body_cannot_reach_any_vintage_tier(db):
+    """No body-supplied arch can raise a modern miner above its attested tier."""
+    _attest(db, "m", "x86_64", "modern")
+    for family, arch in (("PowerPC", "G4"), ("ARM", "arm2"), ("x86", "386"), ("x86", "pentium_mmx")):
+        assert HW[family][arch] > 0.8, "test would be vacuous"
+    assert resolve(db, "m")[0] == 0.8
+
+
+def test_honest_vintage_keeps_its_multiplier(db):
+    """The fleet this chain exists for must be untouched."""
+    for miner, family, arch, expected in (
+        ("g4", "PowerPC", "G4", HW["PowerPC"]["G4"]),
+        ("g5", "PowerPC", "G5", HW["PowerPC"]["G5"]),
+        ("t40", "x86", "pentium_m_banias", HW["x86"]["pentium_m_banias"]),
+        ("qube", "x86", "retro", HW["x86"]["retro"]),
+    ):
+        _attest(db, miner, family, arch)
+        assert resolve(db, miner)[0] == expected, f"{miner} lost its tier"
+
+
+def test_macos_x86_64_vintage_arch_uses_x86_bucket(db):
+    """The macOS miner reports family x86_64 with vintage archs like core2.
+
+    x86_64 carries only modern/default, so a naive nested default would pay a
+    Core 2 Mac 0.8 instead of the intended 1.3. This is the under-pay failure
+    mode that a careless tightening would introduce.
+    """
+    _attest(db, "mac", "x86_64", "core2")
+    weight, _, _, _ = resolve(db, "mac")
+    assert weight == HW["x86"]["core2"] == 1.3
+    assert weight != HW["x86_64"]["default"]
+
+
+def test_missing_attestation_is_neutral_not_a_bonus(db):
+    """No attestation row must not grant a vintage tier."""
+    weight, family, arch, src = resolve(db, "ghost")
+    assert src == "no_attestation"
+    assert weight <= 1.0
+    assert weight < HW["PowerPC"]["G4"]
+
+
+def test_miner_id_fallback_resolves(db):
+    """Enrolment may present miner_id when miner_pk has no attestation row."""
+    _attest(db, "named-g5", "PowerPC", "G5")
+    assert resolve(db, "unknown-pk", "named-g5")[0] == HW["PowerPC"]["G5"]
+
+
+def test_unreadable_db_fails_soft_without_bonus(tmp_path):
+    """A broken database must neither grant a tier nor deny enrolment."""
+    weight, _, _, _ = resolve(str(tmp_path / "missing.db"), "m")
+    assert weight <= 1.0


### PR DESCRIPTION
## The defect

`enroll_epoch` computed reward weight from the request body:

```python
family = device.get('family', 'x86')      # device = data.get('device', {})
arch   = device.get('arch', 'default')
hw_weight = HARDWARE_WEIGHTS.get(family, {}).get(arch, 1.0)
```

`derive_verified_device()` was never called here, and the `device_arch` the server derived at attestation time was never read. The caller named their own multiplier.

`HARDWARE_WEIGHTS["ARM"]["arm2"]` is **4.0** against an honest modern x86_64 at **0.8**. That is a 5x self-granted uplift, higher than a real G4 at 2.5.

The surrounding machinery does not stop it:

- Signing does not help. The signature proves the caller owns *their own* wallet, which the attacker does.
- `fingerprint_passed` is a one-way `MAX()` ratchet, so one honest attestation from any machine satisfies the enrolment gate permanently.
- `epoch_enroll` is `INSERT OR IGNORE`, so the forged row wins the epoch and the honest auto-enrolment that follows is silently discarded. The anti-downgrade behaviour ends up protecting the forgery.

Since `PER_EPOCH_RTC` is a fixed pot split proportionally, anything gained here comes directly out of every honest miner's share.

**This is the path that matters.** The shipped Linux miner re-attests only when its 24h attestation expires, but calls `/epoch/enroll` every 600 seconds. So `/epoch/enroll` sets the weight for most epochs, and hardening only the attestation path leaves the actual hole open.

## The fix

Enrolment now resolves family and arch from `miner_attest_recent`, which `derive_verified_device()` already wrote. `check_enrollment_requirements()` already requires an attestation no older than `ENROLL_TICKET_TTL_S`, so the row is expected to exist, and the attestation path has always resolved weight this way. The two enrolment paths now agree, which they did not before.

The resolver falls back to the `x86` bucket for `x86_64` and `Windows` families before falling back to a family default. That detail is load-bearing: the macOS miner reports family `x86_64` with vintage archs such as `core2`, and `x86_64` carries only `modern`/`default`, so a naive nested default would pay a Core 2 Mac **0.8** instead of the intended **1.3**. Under-paying the fleet you meant to protect is the failure mode this project has already hit once.

Missing or unreadable attestation data fails soft to a neutral 1.0. It never grants a vintage tier and never blocks enrolment.

## Live impact, measured rather than assumed

Every distinct `(device_family, device_arch)` pair attested on the live chain in the last 30 days was run through both the old and new resolution. **20 unchanged, 7 changed.**

**No vintage tier moves.** G4, G5, POWER8, Apple Silicon, `pentium_m_banias` and `retro` are all identical.

The 7 changes are Windows device strings such as `Intel64 Family 6 Model 158 Stepping 10, GenuineIntel`, which matched no key in the `Windows` bucket and fell through to the literal `1.0` rather than that bucket's own `0.8` default:

| family | arch | before | after |
|---|---|---|---|
| Windows | Intel64 Family 6 Model 158/140/58/181/60 … | 1.000 | 0.800 |
| Windows | x86_64 | 1.000 | 0.800 |
| Windows | i386 | 1.000 | 0.800 |

These are modern Windows machines that were being paid above the modern rate. Correcting them returns that surplus to everyone else, including the vintage fleet. **It is still a reduction for real miners and worth announcing rather than shipping quietly.**

## Tests

`node/tests/test_enroll_hw_weight_from_attestation.py`, 7 tests, all passing. They encode the actual incident rather than abstractions: the ARM/arm2 self-grant is refused; no body-supplied arch reaches any vintage tier; honest G4, G5, T40 Pentium M and Cobalt Qube keep their exact multipliers; the Core 2 Mac keeps 1.3 through the x86-bucket fallback; a missing attestation is neutral rather than a bonus; a broken database fails soft.

## Not deployed

This has not been applied to any production node. It changes reward weight, so it needs a maintainer rollout decision, and the Windows tier correction above should probably be communicated to those miners first.

## Relationship to other open work

Related to #8016 and the attestation-bypass work. Complementary to #8022, which hardens the attestation path but, on its own, does not close this one because `/epoch/enroll` is where the weight is actually set for most epochs. #8013 touches the same line and should be rebased onto this shared resolver rather than reintroducing a separate literal fallback.