### PR TITLE
docs: WHAT_IF emission row no longer cites halvings

### DIFF
--- a/docs/WHAT_IF_RTC_FUNDAMENTALS.md
+++ b/docs/WHAT_IF_RTC_FUNDAMENTALS.md
@@ -35,7 +35,7 @@ inflated, or conservative?**
 | Held by the 4 founder wallets | 286,275 RTC | Explorer: `founder_founders`, `founder_dev_fund`, `founder_team_bounty`, `founder_community` |
 | **External circulating float** | **~158,743 RTC** | Issued minus founder-held |
 | Holders with positive balance | 1,248 | `facts.json` → `activity_density` |
-| New emission | 1.5 RTC per ~24h epoch ≈ **548 RTC/year** max | `PER_BLOCK_RTC` in node source; halvings (README §Tokenomics) only *lower* this |
+| New emission | 1.5 RTC per ~24h epoch ≈ **548 RTC/year** max | `PER_BLOCK_RTC` in node source; fixed rate, no halving (RIP-0004, README §Tokenomics) |
 | Public repo, core code | 562,200 lines (excl. `bounties/` submissions) | `git clone` this repo and count |
 | Deployed node codebase | ~84,000 lines (overlapping + node-local) | Operator-attested |
 | On-chain bounty payouts | 670 payouts, 21,130 RTC from `founder_team_bounty` | `participation.json`; ledger debits in explorer |


### PR DESCRIPTION
docs/WHAT_IF_RTC_FUNDAMENTALS.md line 38 said halvings (README Tokenomics) only lower the 548 RTC/year emission. The README Tokenomics section, RIP-0004, and `PER_BLOCK_RTC` in the node code all say emission is a fixed 1.5 RTC per epoch with no halving, so the row now says that.

Flagging, not changed: docs/api-reference.md (lines ~552-554), docs/API_REFERENCE.md (~1198-1216) and the zh-CN copy advertise `/beacon/api/x402/status` and `/beacon/api/premium/*` endpoints. All of them return 404 on the live node today (the non-premium `/beacon/api/agents`, `/contracts`, `/reputation` are 200). I could not tell whether the x402/premium surface is undeployed or retired, so I left those docs for a human call.