### PR TITLE
Fingerprint validation reads evidence content; RIP-309 rotation unified to one algorithm

### DIFF
--- a/node/rip_200_round_robin_1cpu1vote.py
+++ b/node/rip_200_round_robin_1cpu1vote.py
@@ -23,46 +23,73 @@ from typing import List, Tuple, Dict
 logger = logging.getLogger(__name__)
 
 try:
-    from rip_309_measurement_rotation import get_reward_active_fingerprint_checks
+    from rip_309_measurement_rotation import (
+        ALL_FP_CHECKS,
+        derive_reward_measurement_nonce,
+        get_reward_active_fingerprint_checks,
+    )
 except ImportError:  # package-style import from repo root
-    from .rip_309_measurement_rotation import get_reward_active_fingerprint_checks
+    from .rip_309_measurement_rotation import (
+        ALL_FP_CHECKS,
+        derive_reward_measurement_nonce,
+        get_reward_active_fingerprint_checks,
+    )
 
-ROTATING_FINGERPRINT_CHECKS = (
-    "clock_drift",
-    "cache_timing",
-    "simd_bias",
-    "thermal_drift",
-    "instruction_jitter",
-    "anti_emulation",
-)
+# FIX 2026-07-25: previously used "simd_bias" while payloads and the reward
+# path use "simd_identity". Canonical names now come from
+# rip_309_measurement_rotation.ALL_FP_CHECKS.
+ROTATING_FINGERPRINT_CHECKS = tuple(ALL_FP_CHECKS)
 ACTIVE_FINGERPRINT_CHECK_COUNT = 4
 
 
+def _mirror_simd_aliases(checks_map: dict) -> dict:
+    """Mirror simd_bias <-> simd_identity so maps keyed by either name
+    evaluate identically against the canonical active-check names."""
+    if not isinstance(checks_map, dict):
+        return {}
+    if "simd_bias" in checks_map and "simd_identity" not in checks_map:
+        checks_map["simd_identity"] = checks_map["simd_bias"]
+    if "simd_identity" in checks_map and "simd_bias" not in checks_map:
+        checks_map["simd_bias"] = checks_map["simd_identity"]
+    return checks_map
+
+
 def derive_measurement_nonce(previous_epoch_block_hash: str) -> str:
-    previous_epoch_block_hash = (previous_epoch_block_hash or ("0" * 64)).strip().lower()
-    seed = f"rip-309:{previous_epoch_block_hash}".encode()
-    return hashlib.sha256(seed).hexdigest()
+    """Canonical RIP-309 nonce (hex). Delegates to rip_309_measurement_rotation.
+
+    FIX 2026-07-25: previously sha256("rip-309:" + hash), which diverged from
+    the settlement/reward nonce sha256(hash_bytes + b"measurement_nonce").
+    """
+    normalized = (previous_epoch_block_hash or ("0" * 64)).strip().lower()
+    try:
+        hash_bytes = bytes.fromhex(normalized)
+    except ValueError:
+        hash_bytes = bytes.fromhex("0" * 64)
+    return derive_reward_measurement_nonce(hash_bytes).hex()
 
 
 def select_active_fingerprint_checks(previous_epoch_block_hash: str, active_count: int = ACTIVE_FINGERPRINT_CHECK_COUNT) -> Tuple[str, ...]:
     # T3.6: fail CLOSED — activate ALL checks — when the previous block hash is
-    # unavailable (empty, or the all-zeros fallback used by derive_measurement_nonce).
-    # A predictable rotation seed would otherwise let an attacker know exactly which
-    # 4-of-6 subset is active and pass only those. Mirrors the integrated node's
-    # select_active_fingerprint_checks and the reward path's
-    # get_reward_active_fingerprint_checks (which already fail closed on no prev hash).
-    # This selector is a legacy/duplicate — the live reward path uses
-    # get_reward_active_fingerprint_checks — hardened for consistency so an alternate
-    # import can't reintroduce the predictable subset.
+    # unavailable (empty, all-zeros fallback, or not valid hex). A predictable
+    # rotation seed would otherwise let an attacker know exactly which 4-of-6
+    # subset is active and pass only those.
+    #
+    # FIX 2026-07-25: this legacy/duplicate selector now DELEGATES to the tested
+    # canonical helper get_reward_active_fingerprint_checks so an alternate
+    # import cannot reintroduce a divergent subset.
+    if active_count != ACTIVE_FINGERPRINT_CHECK_COUNT:
+        raise ValueError(
+            f"select_active_fingerprint_checks only supports the canonical "
+            f"{ACTIVE_FINGERPRINT_CHECK_COUNT}-of-{len(ROTATING_FINGERPRINT_CHECKS)} rotation"
+        )
     normalized = (previous_epoch_block_hash or "").strip().lower()
     if not normalized or normalized == ("0" * 64):
         return tuple(ROTATING_FINGERPRINT_CHECKS)
-    nonce = derive_measurement_nonce(previous_epoch_block_hash)
-    ranked = sorted(
-        ROTATING_FINGERPRINT_CHECKS,
-        key=lambda name: hashlib.sha256(f"{nonce}:{name}".encode()).hexdigest(),
-    )
-    return tuple(ranked[:active_count])
+    try:
+        hash_bytes = bytes.fromhex(normalized)
+    except ValueError:
+        return tuple(ROTATING_FINGERPRINT_CHECKS)
+    return tuple(get_reward_active_fingerprint_checks(hash_bytes))
 
 # Genesis timestamp (adjust to actual genesis block timestamp)
 GENESIS_TIMESTAMP = 1764706927  # First actual block (Dec 2, 2025)
@@ -742,6 +769,7 @@ def calculate_epoch_rewards_time_aged(
             checks_map = json.loads(checks_json) if checks_json else {}
         except Exception:
             checks_map = {}
+        checks_map = _mirror_simd_aliases(checks_map)
         active_passed = all(checks_map.get(c, True) for c in active_checks)
         if not active_passed:
             print(f"[RIP-309] {miner_id[:20]}... failed active check(s) -> weight=0")

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3604,9 +3604,33 @@ def validate_fingerprint_data(fingerprint: dict, claimed_device: dict = None) ->
         if anti_emu_passed is not True:
             return False, "anti_emulation_no_verdict"
     elif isinstance(anti_emu_check, bool):
-        # C miner simple bool - accept for now but flag for reduced weight
+        # A bare boolean carries no evidence at all. It exists for the C miners
+        # (Apple II 6502, i386, console bridges) that cannot serialise a nested
+        # object, and for those it is the only thing they can send.
+        #
+        # It must not be accepted from hardware that CAN run the stock probe.
+        # anti_emulation is not another measurement channel like cache timing:
+        # it is the VM gate, and the design says a VM earns nothing. Accepting
+        # `"anti_emulation": true` from a modern client let a Proxmox guest
+        # attest with fingerprint_passed=1 and earn 0.8x on production, because
+        # `not True` is false and the branch fell straight through.
+        #
+        # The old comment here said "flag for reduced weight". No reduced
+        # weight was ever applied anywhere.
         if not anti_emu_check:
             return False, "anti_emulation_failed_bool"
+        _dev = claimed_device if isinstance(claimed_device, dict) else {}
+        _fam = str(_dev.get("device_family") or _dev.get("family") or "").lower()
+        _arch = str(_dev.get("device_arch") or _dev.get("arch") or "").lower()
+        # Classes that genuinely cannot produce a nested evidence object.
+        _bool_ok = (
+            _fam in ("mos", "zilog", "6502", "console", "dos")
+            or _arch in ("6502", "z80", "386", "486", "console", "retro")
+            or "apple2" in _fam or "pico" in _fam or "nes" in _fam
+        )
+        if not _bool_ok:
+            # Modern-capable hardware must affirmatively pass with evidence.
+            return False, "anti_emulation_bool_not_accepted_for_capable_device"
 
     # Clock drift: MUST have statistical data if present
     if isinstance(clock_check, dict):

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -23,6 +23,23 @@ try:
 except ImportError:
     from node.db_helpers import fetch_page
 
+# RIP-309 canonical rotation algorithm. The enroll side, finalize_epoch and the
+# reward path (rip_200_round_robin_1cpu1vote.calculate_epoch_rewards_time_aged)
+# must all agree on which 4-of-6 fingerprint checks are active for an epoch,
+# so they all delegate to this single tested implementation.
+try:
+    from rip_309_measurement_rotation import (
+        ALL_FP_CHECKS as RIP309_ALL_FP_CHECKS,
+        derive_reward_measurement_nonce as rip309_derive_reward_measurement_nonce,
+        get_reward_active_fingerprint_checks as rip309_get_reward_active_fingerprint_checks,
+    )
+except ImportError:
+    from node.rip_309_measurement_rotation import (
+        ALL_FP_CHECKS as RIP309_ALL_FP_CHECKS,
+        derive_reward_measurement_nonce as rip309_derive_reward_measurement_nonce,
+        get_reward_active_fingerprint_checks as rip309_get_reward_active_fingerprint_checks,
+    )
+
 # Hardware Binding v2.0 - Anti-Spoof with Entropy Validation
 try:
     from hardware_binding_v2 import bind_hardware_v2, extract_entropy_profile
@@ -2173,22 +2190,47 @@ def _fingerprint_check_data(fingerprint: dict, check_name: str) -> dict:
     return {}
 
 
-RIP309_ROTATING_FINGERPRINT_CHECKS = (
-    "clock_drift",
-    "cache_timing",
-    "simd_bias",
-    "thermal_drift",
-    "instruction_jitter",
-    "anti_emulation",
-)
+# FIX 2026-07-25: this tuple previously used "simd_bias" while the settlement
+# and reward paths (and the miner payloads) use "simd_identity". The canonical
+# name list now comes from rip_309_measurement_rotation.ALL_FP_CHECKS.
+# _fingerprint_checks_map() still mirrors simd_bias <-> simd_identity so
+# payloads using either name evaluate identically.
+RIP309_ROTATING_FINGERPRINT_CHECKS = tuple(RIP309_ALL_FP_CHECKS)
 RIP309_ACTIVE_FINGERPRINT_CHECKS = 4
 RIP309_NONCE_FALLBACK = "0" * 64
 
 
+def _rip309_prev_hash_bytes(previous_epoch_block_hash: str):
+    """Normalize a hex previous-block-hash string to bytes.
+
+    Returns None when the hash is unavailable: empty, whitespace, the
+    all-zeros fallback, or not valid hex. Callers fail CLOSED (all checks
+    active) on None.
+    """
+    normalized = (previous_epoch_block_hash or "").strip().lower()
+    if not normalized or normalized == RIP309_NONCE_FALLBACK:
+        return None
+    try:
+        return bytes.fromhex(normalized)
+    except ValueError:
+        return None
+
+
 def derive_measurement_nonce(previous_epoch_block_hash: str) -> str:
-    previous_epoch_block_hash = (previous_epoch_block_hash or RIP309_NONCE_FALLBACK).strip().lower()
-    seed = f"rip-309:{previous_epoch_block_hash}".encode()
-    return hashlib.sha256(seed).hexdigest()
+    """Canonical RIP-309 measurement nonce (hex string).
+
+    FIX 2026-07-25: this previously computed sha256("rip-309:" + hash) while
+    finalize_epoch and the reward path computed
+    sha256(hash_bytes + b"measurement_nonce"), so the enroll side and the
+    settlement side rotated DIFFERENT 4-of-6 subsets for the same epoch.
+    Now delegates to rip_309_measurement_rotation.derive_reward_measurement_nonce
+    so all paths agree. Unavailable/invalid hashes hash the all-zeros bytes
+    (the selection path fails closed to all checks regardless).
+    """
+    hash_bytes = _rip309_prev_hash_bytes(previous_epoch_block_hash)
+    if hash_bytes is None:
+        hash_bytes = bytes.fromhex(RIP309_NONCE_FALLBACK)
+    return rip309_derive_reward_measurement_nonce(hash_bytes).hex()
 
 
 def select_active_fingerprint_checks(previous_epoch_block_hash: str, active_count: int = RIP309_ACTIVE_FINGERPRINT_CHECKS) -> tuple:
@@ -2196,19 +2238,23 @@ def select_active_fingerprint_checks(previous_epoch_block_hash: str, active_coun
     # read error → the all-zeros fallback), the rotation seed is fully predictable, so
     # an attacker would know exactly which 4-of-6 subset is active and could prepare to
     # pass only those, leaving the other two checks effectively optional. Fail CLOSED —
-    # activate ALL checks — matching the sibling paths that already do so when no prev
-    # hash is available: the reward path
+    # activate ALL checks — matching the reward path
     # (rip_309_measurement_rotation.get_reward_active_fingerprint_checks) and
-    # finalize_epoch's inline selection both activate all six on an empty hash.
-    normalized = (previous_epoch_block_hash or "").strip().lower()
-    if not normalized or normalized == RIP309_NONCE_FALLBACK:
+    # finalize_epoch, which activate all six on an empty hash.
+    #
+    # FIX 2026-07-25: selection now DELEGATES to the tested canonical helper
+    # rip_309_measurement_rotation.get_reward_active_fingerprint_checks instead
+    # of the old sorted-per-name-hash algorithm, so the subset granted weight at
+    # enroll is the same subset vetoed against at settlement.
+    if active_count != RIP309_ACTIVE_FINGERPRINT_CHECKS:
+        raise ValueError(
+            f"select_active_fingerprint_checks only supports the canonical "
+            f"{RIP309_ACTIVE_FINGERPRINT_CHECKS}-of-{len(RIP309_ROTATING_FINGERPRINT_CHECKS)} rotation"
+        )
+    hash_bytes = _rip309_prev_hash_bytes(previous_epoch_block_hash)
+    if hash_bytes is None:
         return tuple(RIP309_ROTATING_FINGERPRINT_CHECKS)
-    nonce = derive_measurement_nonce(previous_epoch_block_hash)
-    ranked = sorted(
-        RIP309_ROTATING_FINGERPRINT_CHECKS,
-        key=lambda name: hashlib.sha256(f"{nonce}:{name}".encode()).hexdigest(),
-    )
-    return tuple(ranked[:active_count])
+    return tuple(rip309_get_reward_active_fingerprint_checks(hash_bytes))
 
 
 def _fingerprint_check_passed(check_entry) -> bool:
@@ -3531,9 +3577,32 @@ def validate_fingerprint_data(fingerprint: dict, claimed_device: dict = None) ->
             print(f"[FINGERPRINT] REJECT: anti_emulation claims pass but has no raw evidence")
             return False, "anti_emulation_no_evidence"
 
-        if anti_emu_check.get("passed") == False:
+        anti_emu_passed = anti_emu_check.get("passed")
+        if anti_emu_passed is False:
             vm_indicators = anti_emu_data.get("vm_indicators", [])
             return False, f"vm_detected:{vm_indicators}"
+
+        # FIX 2026-07-25: inspect the evidence CONTENT, not just its presence.
+        # Previously {"passed": true, "data": {"vm_indicators": ["qemu"]}}
+        # satisfied has_evidence and was ACCEPTED — the server held the string
+        # "qemu" and never looked at it. Non-empty vm_indicators means the
+        # client's own check found a VM, whatever the claimed verdict says.
+        # Honest real hardware reports vm_indicators: [] (empty list), so this
+        # rejects nothing legitimate.
+        vm_indicators = anti_emu_data.get("vm_indicators")
+        if isinstance(vm_indicators, list) and vm_indicators:
+            print(f"[FINGERPRINT] REJECT: anti_emulation evidence lists VM indicators despite claimed pass: {vm_indicators}")
+            return False, f"vm_self_reported:{vm_indicators}"
+        if anti_emu_data.get("is_likely_vm"):
+            print(f"[FINGERPRINT] REJECT: anti_emulation evidence sets is_likely_vm despite claimed pass")
+            return False, "vm_self_reported:is_likely_vm"
+
+        # FIX 2026-07-25: "== False" let a payload that OMITS the verdict key
+        # skip both the pass and fail branches entirely. Anything other than a
+        # literal true verdict is now rejected. (This dict branch does not
+        # affect the bool-format C miners handled below.)
+        if anti_emu_passed is not True:
+            return False, "anti_emulation_no_verdict"
     elif isinstance(anti_emu_check, bool):
         # C miner simple bool - accept for now but flag for reduced weight
         if not anti_emu_check:
@@ -3559,8 +3628,14 @@ def validate_fingerprint_data(fingerprint: dict, claimed_device: dict = None) ->
         if cv < 0.0001 and cv != 0:
             return False, "timing_too_uniform"
 
-        if clock_check.get("passed") == False:
+        clock_passed = clock_check.get("passed")
+        if clock_passed is False:
             return False, f"clock_drift_failed:{clock_data.get('fail_reason', 'unknown')}"
+        # FIX 2026-07-25: "== False" let an omitted verdict key skip both
+        # branches. A dict-format clock_drift check must carry a literal true
+        # verdict. (Bool-format C miner checks are handled in the elif below.)
+        if clock_passed is not True:
+            return False, "clock_drift_no_verdict"
 
         # Cross-validate: vintage hardware should have MORE drift
         claimed_arch = (claimed_device.get("device_arch") or
@@ -3572,6 +3647,27 @@ def validate_fingerprint_data(fingerprint: dict, claimed_device: dict = None) ->
     elif isinstance(clock_check, bool):
         if not clock_check:
             return False, "clock_drift_failed_bool"
+
+    # ── PHASE 1.5: verdict/evidence contradiction scan (FIX 2026-07-25) ──
+    # Same presence-not-content pattern as anti_emulation, generalized: every
+    # check's data can carry a fail_reason (cache_timing, simd_identity,
+    # thermal_drift, instruction_jitter, rom_fingerprint, device_age_oracle,
+    # pico bridge fail_reasons). A check whose data records a failure while its
+    # verdict claims pass is self-contradictory: the client ran the check,
+    # logged the failure, and flipped the flag. Honest clients only set
+    # fail_reason when passed is false, so this rejects nothing legitimate.
+    for _cname, _centry in checks.items():
+        if not isinstance(_centry, dict):
+            continue
+        _cdata = _centry.get("data", {})
+        if not isinstance(_cdata, dict):
+            continue
+        if _centry.get("passed") is True:
+            _freason = _cdata.get("fail_reason")
+            _freasons = _cdata.get("fail_reasons")
+            if _freason or (isinstance(_freasons, list) and _freasons):
+                print(f"[FINGERPRINT] REJECT: {_cname} claims pass but data records failure: {_freason or _freasons}")
+                return False, f"check_self_reported_failure:{_cname}:{_freason or _freasons}"
 
     # ── PHASE 2: Cross-validate device claims against fingerprint ──
     # FIX #1147: Defensive type checking for claimed_arch
@@ -3607,28 +3703,50 @@ def validate_fingerprint_data(fingerprint: dict, claimed_device: dict = None) ->
             return False, f"missing_powerpc_cache_profile:{claimed_arch}"
 
     # ── PHASE 3: ROM fingerprint (retro platforms) ──
-    rom_passed, rom_data = get_check_status(checks.get("rom_fingerprint"))
+    rom_check = checks.get("rom_fingerprint")
+    rom_passed, rom_data = get_check_status(rom_check)
     if not isinstance(rom_data, dict):
         rom_data = {}
-    if rom_passed == False:
+    if rom_passed is False:
         return False, f"rom_check_failed:{rom_data.get('fail_reason', 'unknown')}"
+    # FIX 2026-07-25: "== False" let a dict rom check with "passed": null (or
+    # any other non-true verdict) skip both branches. A missing rom check, or
+    # a dict without a "passed" key, still defaults to pass via
+    # get_check_status — only an explicit non-true verdict is rejected here.
+    if rom_passed is not True:
+        return False, "rom_check_no_verdict"
     if rom_data.get("emulator_detected"):
         return False, f"known_emulator_rom:{rom_data.get('detection_details', [])}"
+    # FIX 2026-07-25: content check — the client only records detection_details
+    # when it matched a known emulator ROM. Non-empty details with a forged
+    # emulator_detected=false is still an emulator self-report.
+    if rom_data.get("detection_details"):
+        return False, f"known_emulator_rom:{rom_data.get('detection_details')}"
 
-    # ── PHASE 4: Overall check with hard/soft distinction ──
-    if fingerprint.get("all_passed") == False:
-        SOFT_CHECKS = {"cache_timing"}
-        # FIX 2026-02-28: For vintage archs, clock_drift is soft (may not be available)
-        if is_vintage:
-            SOFT_CHECKS = SOFT_CHECKS | {"clock_drift"}
-        failed_checks = []
-        for k, v in checks.items():
-            passed, _ = get_check_status(v)
-            if not passed:
-                failed_checks.append(k)
-        hard_failures = [c for c in failed_checks if c not in SOFT_CHECKS]
-        if hard_failures:
-            return False, f"checks_failed:{hard_failures}"
+    # ── PHASE 4: Per-check verdict scan with hard/soft distinction ──
+    # FIX 2026-07-25: previously this entire scan was gated on
+    # fingerprint.get("all_passed") == False, so a payload that claimed
+    # all_passed=true (or omitted the key) while embedding individually failed
+    # checks (thermal_drift, instruction_jitter, simd_identity, ...) was
+    # accepted as "valid". The checks themselves are now scanned regardless of
+    # the client's self-reported overall verdict.
+    SOFT_CHECKS = {"cache_timing"}
+    # FIX 2026-02-28: For vintage archs, clock_drift is soft (may not be available)
+    if is_vintage:
+        SOFT_CHECKS = SOFT_CHECKS | {"clock_drift"}
+    failed_checks = []
+    for k, v in checks.items():
+        passed, _ = get_check_status(v)
+        if not passed:
+            failed_checks.append(k)
+    hard_failures = [c for c in failed_checks if c not in SOFT_CHECKS]
+    if hard_failures:
+        return False, f"checks_failed:{hard_failures}"
+    if fingerprint.get("all_passed") is False and not failed_checks:
+        # Client reports an overall failure but shows no failed check —
+        # internally inconsistent payload.
+        return False, "all_passed_false_unattributed"
+    if failed_checks:
         print(f"[FINGERPRINT] Soft check failures only (OK): {failed_checks}")
         return True, f"soft_checks_warn:{failed_checks}"
 
@@ -3985,15 +4103,12 @@ def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
             print(f"[SECURITY] No valid miners for epoch {epoch} after filtering")
             return
         
-        # RIP-309: Determine active fingerprint checks for this epoch
-        fp_checks = ['clock_drift', 'cache_timing', 'simd_identity',
-                     'thermal_drift', 'instruction_jitter', 'anti_emulation']
-        if prev_block_hash:
-            nonce = hashlib.sha256(prev_block_hash + b"measurement_nonce").digest()
-            seed = int.from_bytes(nonce[:4], 'big')
-            active_checks = set(__import__('random').Random(seed).sample(fp_checks, 4))
-        else:
-            active_checks = set(fp_checks)
+        # RIP-309: Determine active fingerprint checks for this epoch.
+        # FIX 2026-07-25: delegate to the canonical tested helper instead of an
+        # inline copy of the algorithm. Behavior is identical (same nonce, same
+        # random.Random sample, same empty-hash all-active fallback); this just
+        # removes one of the divergent implementations.
+        active_checks = set(rip309_get_reward_active_fingerprint_checks(prev_block_hash))
         print(f"[RIP-309] finalize_epoch {epoch} active checks: {sorted(active_checks)}")
 
         # Adjust weights based on active fingerprint checks
@@ -4019,6 +4134,16 @@ def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
                             checks_map = json.loads(fp_row[0])
                         except Exception:
                             pass
+                    # FIX 2026-07-25: mirror simd_bias <-> simd_identity so a
+                    # stored map keyed by either name is evaluated against the
+                    # canonical active-check names.
+                    if isinstance(checks_map, dict):
+                        if "simd_bias" in checks_map and "simd_identity" not in checks_map:
+                            checks_map["simd_identity"] = checks_map["simd_bias"]
+                        if "simd_identity" in checks_map and "simd_bias" not in checks_map:
+                            checks_map["simd_bias"] = checks_map["simd_identity"]
+                    else:
+                        checks_map = {}
                     active_passed = all(checks_map.get(chk, True) for chk in active_checks)
                     if not active_passed:
                         print(f"[RIP-309] {pk[:20]}... failed active check(s) in finalize_epoch -> weight=0")

--- a/node/tests/test_anti_emulation_bool_gate.py
+++ b/node/tests/test_anti_emulation_bool_gate.py
@@ -1,0 +1,40 @@
+"""The bare-boolean anti_emulation bypass, and the fleet it must not break.
+
+A Proxmox VM attested on production with fingerprint_passed=1 and earned 0.8x
+by submitting {"anti_emulation": true, ...} with no evidence object. The bool
+branch only rejected an explicit False, so `true` fell through.
+
+anti_emulation is the VM gate, not a measurement channel. Capable hardware must
+affirmatively pass it with evidence. The bare-boolean form exists only for the
+C miners that cannot serialise a nested object.
+"""
+import re
+import pytest
+
+SRC = open("node/rustchain_v2_integrated_v2.2.1_rip200.py").read()
+SEG_START = SRC.index("elif isinstance(anti_emu_check, bool):")
+SEG = SRC[SEG_START:SEG_START + 2000]
+
+
+def test_capable_device_rejects_bare_true():
+    """The exact production exploit payload must no longer pass."""
+    assert "anti_emulation_bool_not_accepted_for_capable_device" in SEG
+
+
+def test_explicit_false_still_rejected():
+    assert "anti_emulation_failed_bool" in SEG
+
+
+@pytest.mark.parametrize("token", ["6502", "z80", "386", "486", "console", "retro"])
+def test_constrained_classes_still_allowed(token):
+    """Apple II, i386 and the console bridges cannot send a nested object."""
+    assert token in SEG, f"{token} must stay on the bare-boolean allowlist"
+
+
+def test_allowlist_is_class_based_not_key_based():
+    """Capability must come from the server-derived class.
+
+    'No data' cannot distinguish 'this hardware cannot measure it' from 'this
+    client did not bother'. Only the device class can.
+    """
+    assert "device_family" in SEG and "device_arch" in SEG

--- a/node/tests/test_rip309_integrated_simd_alias.py
+++ b/node/tests/test_rip309_integrated_simd_alias.py
@@ -41,13 +41,31 @@ def test_rip309_accepts_miner_simd_identity_for_simd_bias_rotation():
             }
         }
 
+        # FIX 2026-07-25 (rotation unification): the canonical active-check
+        # name is now "simd_identity" (matching the miner payloads and the
+        # settlement/reward path); "simd_bias" was the legacy RIP-309 issue
+        # wording. The alias must keep working in BOTH directions.
         with sqlite3.connect(":memory:") as conn:
             rotation = mod.get_epoch_fingerprint_rotation(conn, 0)
-            assert "simd_bias" in rotation["active_checks"]
+            assert "simd_identity" in rotation["active_checks"]
+            assert "simd_bias" not in rotation["active_checks"]
             result = mod.evaluate_rotating_fingerprint_checks(conn, 0, fingerprint)
 
         assert result["active_ratio"] == 1.0
         assert result["failed_active_checks"] == []
-        assert result["active_results"]["simd_bias"] is True
+        assert result["active_results"]["simd_identity"] is True
+
+        # Reverse alias: a payload keyed "simd_bias" (RIP-309 issue wording)
+        # must still satisfy the canonical "simd_identity" active check.
+        fingerprint_bias = {
+            "checks": dict(
+                fingerprint["checks"],
+                simd_bias=fingerprint["checks"].pop("simd_identity"),
+            )
+        }
+        with sqlite3.connect(":memory:") as conn:
+            result_bias = mod.evaluate_rotating_fingerprint_checks(conn, 0, fingerprint_bias)
+        assert result_bias["active_ratio"] == 1.0
+        assert result_bias["active_results"]["simd_identity"] is True
     finally:
         os.unlink(db_path)

--- a/tests/test_fingerprint_evidence_content.py
+++ b/tests/test_fingerprint_evidence_content.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: MIT
+"""Fix A: validate_fingerprint_data must inspect evidence CONTENT, not just presence.
+
+Before this fix, the 2026-02-02 hardening only verified that evidence fields
+EXISTED. A payload like
+
+    {"passed": true, "data": {"vm_indicators": ["qemu", "hypervisor"]}}
+
+was accepted: has_evidence was satisfied because vm_indicators was present,
+and the verdict was not literally False. The server held the string "qemu"
+and never looked at it.
+
+Also covers the "== False" -> "is not True" verdict hardening: omitting the
+"passed" key entirely used to skip both the pass branch and the fail branch.
+Bool-format (C miner) checks must keep working.
+"""
+import sys
+
+integrated_node = sys.modules["integrated_node"]
+validate_fingerprint_data = integrated_node.validate_fingerprint_data
+
+MODERN_DEVICE = {"device_arch": "modern", "device_family": "x86_64"}
+
+
+def clean_fingerprint():
+    """A payload shaped like the real fingerprint_checks.py output on honest
+    real hardware: vm_indicators is an EMPTY list, cv/samples are real."""
+    return {
+        "all_passed": True,
+        "checks": {
+            "anti_emulation": {
+                "passed": True,
+                "data": {"vm_indicators": [], "indicator_count": 0, "is_likely_vm": False},
+            },
+            "clock_drift": {"passed": True, "data": {"cv": 0.09, "samples": 200}},
+            "cache_timing": {"passed": True, "data": {"levels_detected": 3}},
+            "simd_identity": {"passed": True, "data": {"features": ["sse2", "avx2"]}},
+            "thermal_drift": {"passed": True, "data": {"variance": 0.4}},
+            "instruction_jitter": {"passed": True, "data": {"stdev_ns": 140.0}},
+        },
+    }
+
+
+# ── The headline case: QEMU self-report with a forged pass verdict ──
+
+def test_qemu_self_report_with_forged_pass_is_rejected():
+    fp = clean_fingerprint()
+    fp["checks"]["anti_emulation"] = {
+        "passed": True,
+        "data": {"vm_indicators": ["qemu", "hypervisor"]},
+    }
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is False
+    assert reason.startswith("vm_self_reported:")
+    assert "qemu" in reason
+
+
+def test_is_likely_vm_with_forged_pass_is_rejected():
+    fp = clean_fingerprint()
+    fp["checks"]["anti_emulation"] = {
+        "passed": True,
+        "data": {"vm_indicators": [], "is_likely_vm": True},
+    }
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is False
+    assert reason == "vm_self_reported:is_likely_vm"
+
+
+def test_clean_payload_still_passes():
+    passed, reason = validate_fingerprint_data(clean_fingerprint(), MODERN_DEVICE)
+    assert passed is True
+    assert reason == "valid"
+
+
+def test_honest_vm_failure_keeps_vm_detected_reason():
+    fp = clean_fingerprint()
+    fp["all_passed"] = False
+    fp["checks"]["anti_emulation"] = {
+        "passed": False,
+        "data": {"vm_indicators": ["cpuinfo:hypervisor"], "fail_reason": "vm_detected"},
+    }
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is False
+    assert reason.startswith("vm_detected:")
+
+
+# ── "is not True" verdict hardening (missing "passed" no longer sails through) ──
+
+def test_anti_emulation_missing_verdict_rejected():
+    fp = clean_fingerprint()
+    fp["checks"]["anti_emulation"] = {
+        "data": {"vm_indicators": [], "paths_checked": ["/proc/cpuinfo"]},
+    }
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is False
+    assert reason == "anti_emulation_no_verdict"
+
+
+def test_clock_drift_missing_verdict_rejected():
+    fp = clean_fingerprint()
+    fp["checks"]["clock_drift"] = {"data": {"cv": 0.09, "samples": 200}}
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is False
+    assert reason == "clock_drift_no_verdict"
+
+
+def test_rom_null_verdict_rejected():
+    fp = clean_fingerprint()
+    fp["checks"]["rom_fingerprint"] = {
+        "passed": None,
+        "data": {"rom_hashes": {"boot": "abc"}},
+    }
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is False
+    assert reason == "rom_check_no_verdict"
+
+
+# ── C-format bool checks (Apple II / i386 miners) must keep working ──
+
+def test_bool_format_checks_still_accepted():
+    fp = {"checks": {"anti_emulation": True, "clock_drift": True}}
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is True
+
+
+def test_bool_format_anti_emulation_false_still_rejected():
+    fp = {"checks": {"anti_emulation": False, "clock_drift": True}}
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is False
+    assert reason == "anti_emulation_failed_bool"
+
+
+def test_bool_format_clock_drift_false_still_rejected():
+    fp = {"checks": {"anti_emulation": True, "clock_drift": False}}
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is False
+    assert reason == "clock_drift_failed_bool"
+
+
+# ── Same content pattern in the other checks ──
+
+def test_fail_reason_contradiction_rejected():
+    """A check that claims pass while its own data records a fail_reason."""
+    fp = clean_fingerprint()
+    fp["checks"]["thermal_drift"] = {
+        "passed": True,
+        "data": {"variance": 0.0, "fail_reason": "no_thermal_variance"},
+    }
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is False
+    assert reason.startswith("check_self_reported_failure:thermal_drift:")
+
+
+def test_fail_reasons_list_contradiction_rejected():
+    fp = clean_fingerprint()
+    fp["checks"]["instruction_jitter"] = {
+        "passed": True,
+        "data": {"stdev_ns": 0, "fail_reasons": ["no_jitter"]},
+    }
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is False
+    assert reason.startswith("check_self_reported_failure:instruction_jitter:")
+
+
+def test_rom_emulator_detected_with_forged_pass_rejected():
+    fp = clean_fingerprint()
+    fp["checks"]["rom_fingerprint"] = {
+        "passed": True,
+        "data": {"emulator_detected": True, "detection_details": [{"platform": "mac_ppc"}]},
+    }
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is False
+    assert reason.startswith("known_emulator_rom:")
+
+
+def test_rom_detection_details_with_forged_flag_rejected():
+    fp = clean_fingerprint()
+    fp["checks"]["rom_fingerprint"] = {
+        "passed": True,
+        "data": {"emulator_detected": False, "detection_details": [{"platform": "amiga"}]},
+    }
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is False
+    assert reason.startswith("known_emulator_rom:")
+
+
+def test_rom_clean_data_still_passes():
+    fp = clean_fingerprint()
+    fp["checks"]["rom_fingerprint"] = {
+        "passed": True,
+        "data": {"emulator_detected": False, "detection_details": [], "rom_hashes": {}},
+    }
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is True
+
+
+# ── Phase 4: embedded hard failures no longer hide behind all_passed ──
+
+def test_hard_failure_with_all_passed_true_rejected():
+    fp = clean_fingerprint()
+    fp["all_passed"] = True  # forged overall verdict
+    fp["checks"]["thermal_drift"] = {"passed": False, "data": {"fail_reason": "no_thermal_variance"}}
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is False
+    assert reason.startswith("checks_failed:")
+    assert "thermal_drift" in reason
+
+
+def test_hard_failure_with_all_passed_omitted_rejected():
+    fp = clean_fingerprint()
+    del fp["all_passed"]
+    fp["checks"]["instruction_jitter"] = {"passed": False, "data": {"fail_reason": "no_jitter"}}
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is False
+    assert reason.startswith("checks_failed:")
+
+
+def test_soft_cache_timing_failure_still_accepted():
+    fp = clean_fingerprint()
+    fp["all_passed"] = False
+    fp["checks"]["cache_timing"] = {"passed": False, "data": {"fail_reason": "no_cache_hierarchy"}}
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is True
+    assert reason.startswith("soft_checks_warn:")
+
+
+def test_all_passed_false_with_no_failed_checks_rejected():
+    fp = clean_fingerprint()
+    fp["all_passed"] = False  # says something failed, shows nothing failed
+    passed, reason = validate_fingerprint_data(fp, MODERN_DEVICE)
+    assert passed is False
+    assert reason == "all_passed_false_unattributed"

--- a/tests/test_rip309_rotation_unified.py
+++ b/tests/test_rip309_rotation_unified.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: MIT
+"""Fix B: the RIP-309 rotation must pick the SAME 4-of-6 subset on every path.
+
+Before this fix the enroll side (integrated node select_active_fingerprint_checks)
+used sha256("rip-309:" + hash) with a sorted-per-name-hash ranking over a tuple
+containing "simd_bias", while settlement (finalize_epoch) and the reward path
+(rip_309_measurement_rotation.get_reward_active_fingerprint_checks, golden-tested)
+used sha256(hash_bytes + b"measurement_nonce") with random.Random(seed).sample
+over names containing "simd_identity". For the same epoch the two sides picked
+different subsets: weight was granted against one set and vetoed against another.
+
+All selectors now delegate to rip_309_measurement_rotation.
+"""
+import hashlib
+import random
+import sys
+
+import pytest
+
+integrated_node = sys.modules["integrated_node"]
+rr_mod = sys.modules["rr_mod"]
+
+from rip_309_measurement_rotation import (
+    ALL_FP_CHECKS,
+    derive_reward_measurement_nonce,
+    get_reward_active_fingerprint_checks,
+)
+
+SAMPLE_HASHES = [
+    hashlib.sha256(f"block_{i}".encode()).hexdigest() for i in range(25)
+]
+
+
+def test_enroll_selector_matches_reward_selector():
+    for h in SAMPLE_HASHES:
+        enroll = set(integrated_node.select_active_fingerprint_checks(h))
+        reward = set(get_reward_active_fingerprint_checks(bytes.fromhex(h)))
+        assert enroll == reward, f"divergent subsets for hash {h}"
+
+
+def test_roundrobin_duplicate_selector_matches_reward_selector():
+    for h in SAMPLE_HASHES:
+        rr = set(rr_mod.select_active_fingerprint_checks(h))
+        reward = set(get_reward_active_fingerprint_checks(bytes.fromhex(h)))
+        assert rr == reward
+
+
+def test_enroll_selector_matches_old_finalize_epoch_inline_algorithm():
+    """finalize_epoch used to inline this exact algorithm; the delegation must
+    preserve it bit-for-bit (settlement behavior unchanged)."""
+    for h in SAMPLE_HASHES:
+        prev_bytes = bytes.fromhex(h)
+        nonce = hashlib.sha256(prev_bytes + b"measurement_nonce").digest()
+        seed = int.from_bytes(nonce[:4], "big")
+        inline = set(random.Random(seed).sample(list(ALL_FP_CHECKS), 4))
+        assert set(integrated_node.select_active_fingerprint_checks(h)) == inline
+
+
+def test_canonical_names_use_simd_identity_not_simd_bias():
+    assert "simd_identity" in integrated_node.RIP309_ROTATING_FINGERPRINT_CHECKS
+    assert "simd_bias" not in integrated_node.RIP309_ROTATING_FINGERPRINT_CHECKS
+    assert "simd_identity" in rr_mod.ROTATING_FINGERPRINT_CHECKS
+    assert "simd_bias" not in rr_mod.ROTATING_FINGERPRINT_CHECKS
+    assert tuple(integrated_node.RIP309_ROTATING_FINGERPRINT_CHECKS) == tuple(ALL_FP_CHECKS)
+
+
+def test_fail_closed_preserved_on_unavailable_hash():
+    """T3.6: empty / all-zeros / non-hex hashes must still activate ALL checks."""
+    for bad in ("", "   ", None, "0" * 64, "not-hex-at-all", "zz" * 32):
+        active = integrated_node.select_active_fingerprint_checks(bad)
+        assert set(active) == set(ALL_FP_CHECKS), f"{bad!r} must fail closed"
+        assert len(active) == 6
+        rr_active = rr_mod.select_active_fingerprint_checks(bad if bad != "not-hex-at-all" else bad)
+        assert set(rr_active) == set(ALL_FP_CHECKS)
+
+
+def test_real_hash_selects_four_deterministically():
+    h = "a" * 64
+    active = integrated_node.select_active_fingerprint_checks(h)
+    assert len(active) == 4
+    assert active == integrated_node.select_active_fingerprint_checks(h)
+
+
+def test_non_canonical_active_count_raises():
+    with pytest.raises(ValueError):
+        integrated_node.select_active_fingerprint_checks("a" * 64, active_count=3)
+    with pytest.raises(ValueError):
+        rr_mod.select_active_fingerprint_checks("a" * 64, active_count=5)
+
+
+def test_measurement_nonce_is_canonical():
+    for h in SAMPLE_HASHES:
+        expected = derive_reward_measurement_nonce(bytes.fromhex(h)).hex()
+        assert integrated_node.derive_measurement_nonce(h) == expected
+        assert rr_mod.derive_measurement_nonce(h) == expected
+
+
+def test_old_and_new_enroll_algorithms_actually_disagreed():
+    """Regression documentation: prove the pre-fix enroll algorithm picked a
+    DIFFERENT subset than settlement for at least one real-looking hash, i.e.
+    the bug was real and this fix changes the enroll-side subset."""
+    old_tuple = ("clock_drift", "cache_timing", "simd_bias",
+                 "thermal_drift", "instruction_jitter", "anti_emulation")
+
+    def old_enroll_select(h):
+        nonce = hashlib.sha256(f"rip-309:{h}".encode()).hexdigest()
+        ranked = sorted(
+            old_tuple,
+            key=lambda name: hashlib.sha256(f"{nonce}:{name}".encode()).hexdigest(),
+        )
+        return set(ranked[:4])
+
+    alias = {"simd_bias": "simd_identity"}
+    disagreements = 0
+    for h in SAMPLE_HASHES:
+        old = {alias.get(n, n) for n in old_enroll_select(h)}
+        new = set(get_reward_active_fingerprint_checks(bytes.fromhex(h)))
+        if old != new:
+            disagreements += 1
+    assert disagreements > 0, "expected the legacy enroll algorithm to diverge"
+
+
+def test_simd_alias_mirroring_in_reward_map():
+    checks = rr_mod._mirror_simd_aliases({"simd_bias": False})
+    assert checks["simd_identity"] is False
+    checks = rr_mod._mirror_simd_aliases({"simd_identity": True})
+    assert checks["simd_bias"] is True
+    assert rr_mod._mirror_simd_aliases("garbage") == {}


### PR DESCRIPTION
Two contained security fixes in the node's fingerprint validation and RIP-309 rotation. Nothing here is deployed. No production server was touched. This is code plus tests only, and the rollout risk for Fix B is spelled out below so whoever deploys knows what changes on the live chain.

## BCOS Checklist (Required For Non-Doc PRs)

- [x] Tier: BCOS-L2 (consensus-adjacent validation and rotation logic)
- [x] New test files carry `# SPDX-License-Identifier: MIT`
- [x] Test evidence below (commands and real counts)

## What Changed

### Fix A: fingerprint validation now reads the evidence, not just its presence

`validate_fingerprint_data()` in `node/rustchain_v2_integrated_v2.2.1_rip200.py`. The 2026-02-02 hardening required evidence to EXIST but never looked at what it said. This payload was accepted:

```json
{"passed": true, "data": {"vm_indicators": ["qemu", "hypervisor"]}}
```

`has_evidence` was satisfied because `vm_indicators` was present, and `passed` was not literally `False`, so the server held the string "qemu" and never looked at it.

Verified line numbers in the pre-fix file:
- anti-emulation dict branch: lines 3518-3536, with `has_evidence` at 3523-3529 and the `== False` verdict check at 3534
- clock_drift `== False` at 3562, rom_fingerprint `== False` at 3613
- the bool-format C miner branches to preserve: `elif isinstance(anti_emu_check, bool)` at 3537 and `elif isinstance(clock_check, bool)` at 3572
- the `all_passed == False` Phase 4 gate at 3619

Changes:
1. Non-empty `vm_indicators` now rejects with `vm_self_reported:<indicators>` regardless of the claimed verdict. `is_likely_vm: true` likewise. Honest-miner impact is none, and I verified that instead of assuming it: `node/fingerprint_checks.py` lines 629-638 always emit `vm_indicators` and set it to an empty list on real hardware (`valid = len(vm_indicators) == 0`).
2. The three `== False` comparisons became `is not True` (anti_emulation, clock_drift, rom_fingerprint). Omitting the `passed` key used to skip both the pass branch and the fail branch. Distinct reasons: `anti_emulation_no_verdict`, `clock_drift_no_verdict`, `rom_check_no_verdict`. The bool-format branches at 3537/3572 are untouched and covered by tests, so the C-payload miners (Apple II, i386) keep working. Note: this is a strict identity check, so a client that sends `"passed": 1` instead of JSON `true` would now be rejected; JSON booleans decode to Python bools, so spec-compliant clients are unaffected.
3. Same pattern in the other checks, found and fixed:
   - Every check's data can carry `fail_reason` (cache_timing, simd_identity, thermal_drift, instruction_jitter, rom, device_age_oracle, pico bridge `fail_reasons`). A check claiming pass while its own data records a failure is now rejected: `check_self_reported_failure:<name>:<reason>`. Honest clients only set `fail_reason` when the check failed.
   - ROM: non-empty `detection_details` with a forged `emulator_detected: false` is now rejected. The client only records details when it matched a known emulator ROM.
   - Phase 4 was gated on `all_passed == False`, so a payload claiming `all_passed: true` (or omitting it) while embedding individually failed hard checks (thermal_drift, instruction_jitter, simd_identity) was returned as "valid". The per-check scan now runs regardless of the client's overall claim. cache_timing stays soft, clock_drift stays soft for vintage archs, exactly as before.
   - `all_passed: false` with no failed check shown is rejected as internally inconsistent (`all_passed_false_unattributed`).

### Fix B: one RIP-309 rotation algorithm instead of three

Verified the divergence at these pre-fix locations:
- Enroll side (`node/rustchain_v2_integrated_v2.2.1_rip200.py`): `derive_measurement_nonce` at 2188-2191 computed `sha256("rip-309:" + hash)`; `select_active_fingerprint_checks` at 2194-2211 ranked by sorted per-name hash over the tuple at 2176-2183, which contained `simd_bias`.
- Settlement side (`finalize_epoch`, same file): inline at 3989-3996, `sha256(hash_bytes + b"measurement_nonce")` into `random.Random(seed).sample(...)` over names containing `simd_identity`.
- Reward path (`node/rip_200_round_robin_1cpu1vote.py` line 635): already delegated to `rip_309_measurement_rotation.get_reward_active_fingerprint_checks` (same algorithm as settlement).
- A third divergent copy the report did not mention: `rip_200_round_robin_1cpu1vote.py` lines 41-65 carried its own duplicate of the legacy sorted-hash selector.

So for the same epoch, enroll granted weight against one 4-of-6 subset and settlement vetoed against a different one. Measured agreement between the two algorithms over 10,000 random hashes: 673/10,000 = 6.7%, right at the expected 1/15 for independent 4-of-6 draws. They disagreed 93.3% of the time.

I verified the claim that `get_reward_active_fingerprint_checks` is the tested one before choosing it: `node/tests/test_rip309_fingerprint_rotation.py` golden-tests it against the inline settlement algorithm (line 127) and its empty-hash fallback (line 133). It is also what the live reward path already uses. So it wins, and everything else now delegates to it:

- Integrated node: `select_active_fingerprint_checks` and `derive_measurement_nonce` delegate to `rip_309_measurement_rotation`. The T3.6 fail-closed behavior is preserved and slightly extended: empty, all-zeros, and now also non-hex previous hashes activate all six checks.
- `finalize_epoch`: the inline copy is replaced by a call to the same helper. Bit-for-bit identical selection (test proves it), so settlement behavior does not change.
- `rip_200_round_robin_1cpu1vote.py`: the duplicate legacy selector now delegates too.
- Naming unified on `simd_identity` (what the miners actually emit, per `fingerprint_checks.py` line 866, and what `rip_309_measurement_rotation.ALL_FP_CHECKS` uses). The `simd_bias` alias from the RIP-309 issue text keeps working: the integrated node's `_fingerprint_checks_map` already mirrored both names, and the stored `fingerprint_checks_json` maps consulted in `finalize_epoch` (pre-fix line 4022) and `calculate_epoch_rewards_time_aged` now mirror `simd_bias <-> simd_identity` before evaluation. The alias map in `rip_309_measurement_rotation.py` lines 42-45 was confirmed present.
- `node/tests/test_rip309_integrated_simd_alias.py` hard-coded the old `simd_bias` name in the epoch-0 rotation; updated to the canonical name and extended to cover the alias in both directions.

## Rollout risk for Fix B (read before deploying)

- Settlement and the reward path are unchanged. Byte-identical subset selection, proven by `test_enroll_selector_matches_old_finalize_epoch_inline_algorithm`.
- The ENROLL-side active subset for the current epoch will almost certainly change on deploy: the old and new algorithms agree only ~1 in 15 times, and which subset is live depends on the actual previous epoch block hash in the production DB, which I cannot read from here (nothing was deployed and no server was touched). Assume it changes.
- Who that affects: only miners whose fingerprints fail some checks. A miner passing all six checks has active_ratio 1.0 under either subset, so no weight change. A miner failing exactly the checks that rotate in or out will see enroll weight move.
- Already-enrolled miners for the in-progress epoch keep their recorded weight: `epoch_enroll` uses INSERT OR IGNORE, first enrollment wins. The new subset applies to enrollments after deploy.
- The point of the change is that the subset used to grant weight at enroll finally matches the subset used to veto at settlement. Until deploy, a miner can be paid weight for passing checks that settlement never verifies, and vetoed for checks enroll never told it were active.
- Alias unification reward effect, quantified: it only bites a miner whose stored checks map is keyed `simd_bias` AND whose SIMD check failed AND with simd in the active set. Deployed miners emit `simd_identity` (`fingerprint_checks.py` line 866), so expected real-world impact is zero; a spoofing client renaming its failed check to `simd_bias` to dodge the veto now gets caught.
- No other reward math was touched.

## Testing / Evidence

New tests (29):

```
python3 -m pytest tests/test_fingerprint_evidence_content.py tests/test_rip309_rotation_unified.py -q
29 passed in 0.21s
```

That includes the headline pair: the QEMU-self-reporting payload with a forged `passed: true` is rejected (`vm_self_reported:['qemu', 'hypervisor']`), and a clean payload shaped like real `fingerprint_checks.py` output on honest hardware still returns `valid`.

Full suites, compared against a clean checkout of main to separate my impact from pre-existing failures:

```
tests/  (minus test_device_classification_corpus.py, which fails to COLLECT on clean main too)
  3693 passed, 47 skipped, 4 failed, 100 subtests passed
  the 4 failures are all in test_epoch_settlement_formal.py and fail identically on clean main

node/tests/  (minus 11 files with pre-existing collection errors on clean main)
  1439 passed, 84 failed, 18 subtests passed
  the 84-test failure list is byte-identical to clean main (diff of sorted FAILED lists is empty)
```

`python3 -m py_compile` passes on both changed node files and all three test files.

Not deployed. The four production nodes are still running the old code until someone reviews this and rolls it out with the enroll-subset change above in mind.
