### PR TITLE
fix: include chain tip in overall health calculation and exit code [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/tools/rustchain-health.py
+++ b/tools/rustchain-health.py
@@ -275,7 +275,8 @@ def render(snapshot: Dict[str, Any]) -> str:
     # ── Overall ───
     all_ok = (h.get("ok", False) and h["reachable"]
               and e["reachable"]
-              and m["reachable"])
+              and m["reachable"]
+              and t["reachable"])
     lines.append(dim("  " + "─" * w))
     if all_ok:
         lines.append(f"  {green(bold('STATUS: ALL SYSTEMS OPERATIONAL'))}")
@@ -358,7 +359,8 @@ def main() -> int:
         all_ok = (snapshot["health"].get("ok", False)
                   and snapshot["health"]["reachable"]
                   and snapshot["epoch"]["reachable"]
-                  and snapshot["miners"]["reachable"])
+                  and snapshot["miners"]["reachable"]
+                  and snapshot["tip"]["reachable"])
         return 0 if all_ok else 1
 
     if args.watch > 0:


### PR DESCRIPTION
## Summary

Adds `tip.reachable` to both `all_ok` predicates used for overall health status rendering and process exit code, so a failed chain-tip check correctly produces an unhealthy status and non-zero exit code.

### Changes

- `render()` (line 276-279): Added `t["reachable"]` to the `all_ok` predicate
- `run_once()` (line 358-363): Added `snapshot["tip"]["reachable"]` to the `all_ok` predicate

This ensures that when the chain tip endpoint is unavailable (HTTP 404, timeout, etc.), the overall status shows `ISSUES DETECTED` and the process exits with code 1, instead of falsely reporting `ALL SYSTEMS OPERATIONAL` with exit code 0.

Closes #8055