### PR TITLE
fix: compute actual tip age in _tip_age_slots() instead of always returning 0 [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -9005,7 +9005,12 @@ def _tip_age_slots():
     try:
         with sqlite3.connect(DB_PATH, timeout=3) as db:
             row = db.execute("SELECT slot FROM headers ORDER BY slot DESC LIMIT 1").fetchone()
-        return 0 if row else None
+        if row is None:
+            return None
+        latest_slot = row[0]
+        now_slot = current_slot()
+        age = now_slot - latest_slot
+        return max(0, age)
     except Exception:
         return None
 


### PR DESCRIPTION
## Summary

Fixes #8057

The `_tip_age_slots()` function was selecting the newest header slot from the database but discarding the value, returning a hardcoded `0` if any row existed. This caused `/health` to report `tip_age_slots: 0` even when the chain tip was months old.

## Fix

Compute the actual tip age by:
1. Getting the latest slot from the headers table
2. Getting the current slot via `current_slot()`
3. Computing `age = now_slot - latest_slot`
4. Returning `max(0, age)` to handle edge cases
5. Empty headers table still returns `None`

## Test

Verified it works correctly by reasoning through the code:
- Empty table → None (unchanged)
- Fresh tip (same slot as current) → 0
- Tip 100 slots behind → 100
- Tip 10,000 slots behind → 10,000