### PR TITLE
fix: consistent error handling and exit codes in wallet balance script with full test coverage

### DIFF
--- a/tests/test_wallet_cli_39.py
+++ b/tests/test_wallet_cli_39.py
@@ -92,7 +92,7 @@ def test_safe_json_object_rejects_array_payload(capsys):
     data, rc = cli._safe_json_object(FakeResponse([{"amount_rtc": 1.0}]))
 
     assert data is None
-    assert rc == 1
+    assert rc == cli.EXIT_BAD_RESPONSE
     assert "not an object" in capsys.readouterr().err
 
 
@@ -101,7 +101,116 @@ def test_cmd_balance_rejects_non_object_json(monkeypatch, capsys):
 
     rc = cli.cmd_balance(SimpleNamespace(wallet_id="RTCabc"))
 
-    assert rc == 1
+    assert rc == cli.EXIT_BAD_RESPONSE
     captured = capsys.readouterr()
     assert captured.out == ""
     assert "not an object" in captured.err
+
+
+# ─────────────────────────────────────────────────────────────────
+# Comprehensive cmd_balance failure-path tests
+# ─────────────────────────────────────────────────────────────────
+
+def test_cmd_balance_happy_path(monkeypatch, capsys):
+    """Happy path: valid response with amount_rtc."""
+
+    def fake_get(url, **kwargs):
+        return FakeResponse({"amount_rtc": 42.5, "nonce": 7})
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+
+    rc = cli.cmd_balance(SimpleNamespace(wallet_id="RTCtest"))
+
+    assert rc == cli.EXIT_SUCCESS
+    out = capsys.readouterr().out
+    assert "42.5" in out
+    assert "RTCtest" in out
+
+
+def test_cmd_balance_network_error(monkeypatch, capsys):
+    """Network error → exit code 2, clear stderr."""
+
+    def fake_get(url, **kwargs):
+        raise cli.requests.exceptions.ConnectionError("Connection refused")
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+
+    rc = cli.cmd_balance(SimpleNamespace(wallet_id="RTCnet"))
+
+    assert rc == cli.EXIT_NETWORK_ERROR
+    assert "Network error" in capsys.readouterr().err
+
+
+def test_cmd_balance_not_found(monkeypatch, capsys):
+    """404 response → exit code 4, clear stderr."""
+
+    def fake_get(url, **kwargs):
+        return FakeResponse({"error": "not found"}, ok=False, status_code=404)
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+
+    rc = cli.cmd_balance(SimpleNamespace(wallet_id="RTCunknown"))
+
+    assert rc == cli.EXIT_WALLET_NOT_FOUND
+    assert "not found" in capsys.readouterr().err.lower()
+
+
+def test_cmd_balance_server_error(monkeypatch, capsys):
+    """Non-200, non-404 response → exit code 3 (bad response)."""
+
+    def fake_get(url, **kwargs):
+        return FakeResponse({"error": "internal"}, ok=False, status_code=500)
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+
+    rc = cli.cmd_balance(SimpleNamespace(wallet_id="RTCerr"))
+
+    assert rc == cli.EXIT_BAD_RESPONSE
+    assert "HTTP 500" in capsys.readouterr().err
+
+
+def test_cmd_balance_malformed_json(monkeypatch, capsys):
+    """Non-JSON response body → exit code 3."""
+
+    class RawResponse:
+        status_code = 200
+        ok = True
+
+        def json(self):
+            raise ValueError("Expecting value")
+
+    monkeypatch.setattr(cli.requests, "get", lambda *a, **kw: RawResponse())
+
+    rc = cli.cmd_balance(SimpleNamespace(wallet_id="RTCbadjson"))
+
+    assert rc == cli.EXIT_BAD_RESPONSE
+    err = capsys.readouterr().err
+    assert "non-JSON body" in err
+
+
+def test_cmd_balance_missing_amount_rtc(monkeypatch, capsys):
+    """Response lacks amount_rtc → exit code 3."""
+
+    def fake_get(url, **kwargs):
+        return FakeResponse({"nonce": 0})  # no amount_rtc
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+
+    rc = cli.cmd_balance(SimpleNamespace(wallet_id="RTCmissing"))
+
+    assert rc == cli.EXIT_BAD_RESPONSE
+    assert "amount_rtc" in capsys.readouterr().err
+
+
+def test_cmd_balance_timeout(monkeypatch, capsys):
+    """Timeout → exit code 2."""
+
+    def fake_get(url, **kwargs):
+        raise cli.requests.exceptions.Timeout("timed out")
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+
+    rc = cli.cmd_balance(SimpleNamespace(wallet_id="RTCtimeout"))
+
+    assert rc == cli.EXIT_NETWORK_ERROR
+    assert "Network error" in capsys.readouterr().err

--- a/tools/rustchain_wallet_cli.py
+++ b/tools/rustchain_wallet_cli.py
@@ -37,10 +37,19 @@ except Exception:  # pragma: no cover
     Mnemonic = None
 
 # Exit codes for consistent error handling
+#
+# Scheme (documented for --help):
+#   0 = success (EXIT_SUCCESS)
+#   1 = usage / input error (EXIT_USAGE_ERROR)
+#   2 = network / connectivity error (EXIT_NETWORK_ERROR)
+#   3 = bad / unexpected response from server (EXIT_BAD_RESPONSE)
+#   4 = wallet not found (EXIT_WALLET_NOT_FOUND)
+#   5 = authentication / decryption failure (EXIT_AUTH_ERROR)
+#   6 = unexpected internal error (EXIT_UNKNOWN_ERROR)
 EXIT_SUCCESS = 0
 EXIT_USAGE_ERROR = 1
 EXIT_NETWORK_ERROR = 2
-EXIT_BAD_RESPONSE = 1
+EXIT_BAD_RESPONSE = 3
 EXIT_WALLET_NOT_FOUND = 4
 EXIT_AUTH_ERROR = 5
 EXIT_UNKNOWN_ERROR = 6
@@ -330,11 +339,12 @@ def cmd_balance(args):
         return rc
 
     if "amount_rtc" not in data:
-        print("ERROR: Response missing 'amount_rtc' field", file=sys.stderr)
-        return EXIT_BAD_RESPONSE
-
-    if "amount_rtc" not in data and "balance_rtc" in data:
-        data["amount_rtc"] = data.get("balance_rtc")
+        # Fallback: accept "balance_rtc" as an alias
+        if "balance_rtc" in data:
+            data["amount_rtc"] = data["balance_rtc"]
+        else:
+            print("ERROR: Response missing 'amount_rtc' field", file=sys.stderr)
+            return EXIT_BAD_RESPONSE
     data["wallet_id"] = args.wallet_id
     print(json.dumps(data, indent=2))
     return EXIT_SUCCESS
@@ -431,7 +441,21 @@ def cmd_epoch(args):
 
 
 def build_parser():
-    p = argparse.ArgumentParser(prog="rustchain-wallet", description="RustChain Wallet CLI")
+    p = argparse.ArgumentParser(
+        prog="rustchain-wallet",
+        description="RustChain Wallet CLI",
+        epilog=(
+            "Exit codes:\n"
+            "  0  success\n"
+            "  1  usage / input error\n"
+            "  2  network / connectivity error\n"
+            "  3  bad / unexpected response from server\n"
+            "  4  wallet not found\n"
+            "  5  authentication / decryption failure\n"
+            "  6  unexpected internal error\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     sub = p.add_subparsers(dest="cmd", required=True)
 
     p_create = sub.add_parser("create", help="Generate new wallet (24-word mnemonic + encrypted keystore)")


### PR DESCRIPTION
## Summary

Fixes inconsistent error handling in the wallet balance check script (`tools/rustchain_wallet_cli.py`).

## Changes

1. **Fixed exit code scheme**: `EXIT_BAD_RESPONSE` changed from `1` to `3` (was conflicting with `EXIT_USAGE_ERROR`).
   - 0 = success
   - 1 = usage / input error
   - 2 = network / connectivity error
   - 3 = bad / unexpected response from server
   - 4 = wallet not found
   - 5 = authentication / decryption failure
   - 6 = unexpected internal error

2. **Fixed dead code in cmd_balance()**: The `balance_rtc` fallback was unreachable after the early return when `amount_rtc` was missing. Reordered logic so the alias is checked before returning the error.

3. **Documented exit codes**: Added in source comments and in `--help` output via argparse epilog.

4. **Full test coverage** (7 new tests in `tests/test_wallet_cli_39.py`):
   - Happy path (valid response)
   - Network error (ConnectionError)
   - Wallet not found (HTTP 404)
   - Server error (HTTP 500)
   - Malformed JSON (non-JSON body)
   - Missing amount_rtc field
   - Timeout error
   - Existing tests updated to use symbolic constants

## Testing

All 22 related tests pass:
- 16 tests in test_wallet_cli_39.py (9 original + 7 new)
- 3 tests in test_wallet_balance_query_validation_7117.py
- 3 tests in test_miner_balance_endpoints.py

Pre-existing test suite: 3672 passed, 4 failed (all in test_epoch_settlement_formal.py — unrelated multiplier ratio tests)

Closes #7889
Closes bounty #16253