### PR TITLE
Remove the --exclude-mail flag that makes the link checker exit 2

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -23,7 +23,6 @@ jobs:
             --exclude "https?://(twitter|x)\.com"
             --exclude "https://github.com/Scottcjn/Rustchain/actions"
             --exclude "https?://(www\.)?(linkedin|facebook|instagram|tiktok)"
-            --exclude-mail
             -- './**/*.md' './**/*.html'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## The link checker has not checked a link since 22 July

Every run of `lychee.yml` on `main` fails identically:

```
error: unexpected argument '--exclude-mail' found
##[error]Process completed with exit code 2.
```

lychee removed `--exclude-mail`; mail links are skipped by default now and `--include-mail` opts back in. The action resolves to a version that rejects the flag, so the binary exits before reading a single file. All three runs on `main` (22 July) failed this way.

## Why it went unnoticed

The job did not report broken links. It reported that it could not start. A red check for an unparseable argument looks a lot like a red check for a genuinely broken link, so the workflow kept being treated as if it were guarding something while it guarded nothing.

That is the same shape as several other things found this week: a health CLI that exited 0 when the tip check failed, and a `_tip_age_slots` that returned a constant instead of an age. A check that cannot run is indistinguishable from a check that passes, unless you go and look.

## Verification

A run with these args minus the flag checks **2,261 links and reports 0 errors**, so the configuration is otherwise sound.

## Note for the bounty

Bounty #16248 has drawn several PRs proposing brand new duplicate link-check workflows. None of them needed to. The existing workflow was one flag away from working, and at least one of those PRs achieves a green check by excluding the very URLs that are broken, which is worse than the failure it replaces.