### PR TITLE
fix: remove deprecated --exclude-mail flag from lychee config [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -23,7 +23,6 @@ jobs:
             --exclude "https?://(twitter|x)\.com"
             --exclude "https://github.com/Scottcjn/Rustchain/actions"
             --exclude "https?://(www\.)?(linkedin|facebook|instagram|tiktok)"
-            --exclude-mail
             -- './**/*.md' './**/*.html'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #8077

The --exclude-mail flag was removed in a newer version of lychee, causing the link checker to fail with "unexpected argument '--exclude-mail' found" on every run since July 22. Mail links are skipped by default now, so the flag is no longer needed.

This is a one-line fix: simply remove the --exclude-mail argument from the lychee args.