### PR TITLE
fix: stop stale bot from auto-closing issues [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,19 +17,18 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: |
-            This issue has been inactive for 30 days. It will be closed in 7 days unless there's new activity.
+            This issue has been inactive for 45 days. It will be marked as stale.
             If this is still relevant, please comment to keep it open.
           stale-pr-message: |
-            This PR has been inactive for 14 days. It will be closed in 7 days unless updated.
+            This PR has been inactive for 21 days. It will be closed in 14 days unless updated.
             Need help finishing? Ask in the PR comments — we're happy to assist!
-          close-issue-message: 'Closed due to inactivity. Feel free to reopen if still needed.'
           close-pr-message: 'Closed due to inactivity. Feel free to reopen with updates.'
-          days-before-stale: 30
-          days-before-close: 7
-          days-before-pr-stale: 14
-          days-before-pr-close: 7
+          days-before-stale: 45
+          days-before-close: -1
+          days-before-pr-stale: 21
+          days-before-pr-close: 14
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          exempt-issue-labels: 'bounty,security,pinned,critical'
+          exempt-issue-labels: 'bounty,security,pinned,critical,consensus,tracking,operations'
           exempt-pr-labels: 'security,critical,WIP'
-          operations-per-run: 50
+          operations-per-run: 300


### PR DESCRIPTION
Fixes #8076

Changes:
- **`days-before-issue-close: -1`** — Issues are marked stale but never auto-closed. Marking is informational; closing is destructive, and it hits hardest on the hardest bugs (consensus races, security issues) that naturally go quiet.
- **`days-before-stale: 45`** (up from 30) — More time before marking stale.
- **`days-before-pr-stale: 21`** (up from 14) and **`days-before-pr-close: 14`** (up from 7) — Longer leash for PRs.
- **`operations-per-run: 300`** (up from 50) — The old limit never drained the queue on a repo this size.
- **Exempt labels widened** — Added `consensus`, `tracking`, `operations` to exempt-issue-labels.
- **Removed `close-issue-message`** — No longer needed since issues are never auto-closed.