### PR TITLE
docs: fix WHAT_IF emission row — no halving, fixed 1.5 RTC/epoch [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -23,14 +23,7 @@ jobs:
             --exclude "https?://(twitter|x)\.com"
             --exclude "https://github.com/Scottcjn/Rustchain/actions"
             --exclude "https?://(www\.)?(linkedin|facebook|instagram|tiktok)"
-            --exclude "http://your-server-ip"
-            --exclude "https://dexscreener\.com/solana/"
-            --exclude "https://www\.intel\.com/"
-            --exclude "https://basescan\.org/"
-            --exclude "https://rustchain\.org/(bcos|whitepaper|install|principles|beginner|green|api-zh|machines|manifesto|wallet|images/)"
-            --exclude "https://scottcjn\.github\.io/elyan-labs-site/"
-            --exclude "https://bottube\.ai/settings/api"
-            --exclude "https://api\.testnet\.ergoplatform\.com/"
+            --exclude-mail
             -- './**/*.md' './**/*.html'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -23,6 +23,14 @@ jobs:
             --exclude "https?://(twitter|x)\.com"
             --exclude "https://github.com/Scottcjn/Rustchain/actions"
             --exclude "https?://(www\.)?(linkedin|facebook|instagram|tiktok)"
+            --exclude "http://your-server-ip"
+            --exclude "https://dexscreener\.com/solana/"
+            --exclude "https://www\.intel\.com/"
+            --exclude "https://basescan\.org/"
+            --exclude "https://rustchain\.org/(bcos|whitepaper|install|principles|beginner|green|api-zh|machines|manifesto|wallet|images/)"
+            --exclude "https://scottcjn\.github\.io/elyan-labs-site/"
+            --exclude "https://bottube\.ai/settings/api"
+            --exclude "https://api\.testnet\.ergoplatform\.com/"
             -- './**/*.md' './**/*.html'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -23,7 +23,6 @@ jobs:
             --exclude "https?://(twitter|x)\.com"
             --exclude "https://github.com/Scottcjn/Rustchain/actions"
             --exclude "https?://(www\.)?(linkedin|facebook|instagram|tiktok)"
-            --exclude-mail
             -- './**/*.md' './**/*.html'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/WHAT_IF_RTC_FUNDAMENTALS.md
+++ b/docs/WHAT_IF_RTC_FUNDAMENTALS.md
@@ -35,7 +35,7 @@ inflated, or conservative?**
 | Held by the 4 founder wallets | 286,275 RTC | Explorer: `founder_founders`, `founder_dev_fund`, `founder_team_bounty`, `founder_community` |
 | **External circulating float** | **~158,743 RTC** | Issued minus founder-held |
 | Holders with positive balance | 1,248 | `facts.json` → `activity_density` |
-| New emission | 1.5 RTC per ~24h epoch ≈ **548 RTC/year** max | `PER_BLOCK_RTC` in node source; halvings (README §Tokenomics) only *lower* this |
+| New emission | 1.5 RTC per ~24h epoch ≈ **548 RTC/year** max | `PER_BLOCK_RTC` in node source; no halving — emission is a fixed 1.5 RTC per epoch |
 | Public repo, core code | 562,200 lines (excl. `bounties/` submissions) | `git clone` this repo and count |
 | Deployed node codebase | ~84,000 lines (overlapping + node-local) | Operator-attested |
 | On-chain bounty payouts | 670 payouts, 21,130 RTC from `founder_team_bounty` | `participation.json`; ledger debits in explorer |


### PR DESCRIPTION
Fixes #8063

Line 38 of docs/WHAT_IF_RTC_FUNDAMENTALS.md incorrectly referenced halvings lowering the emission. The README Tokenomics section, RIP-0004, and PER_BLOCK_RTC in the node code all say emission is a fixed 1.5 RTC per epoch with no halving. This fix aligns the row with the actual emission model.