### PR TITLE
Miner clients: restore TLS verification, remove a lab IP default, stop simulated attestations reaching production

### DIFF
--- a/miners/macos/rustchain_mac_miner_v2.5.py
+++ b/miners/macos/rustchain_mac_miner_v2.5.py
@@ -67,7 +67,16 @@ except ImportError:
 
 MINER_VERSION = "2.5.0"
 NODE_URL = os.environ.get("RUSTCHAIN_NODE", "https://rustchain.org")
-PROXY_URL = os.environ.get("RUSTCHAIN_PROXY", "http://192.168.0.160:8089")
+# No default proxy. The previous default pointed at a private lab address
+# (192.168.0.160), which on anyone else's LAN is whatever machine happens to
+# hold that IP. The miner would hand its full attestation, including hardware
+# serial, MAC addresses, hostname and wallet, in cleartext to a stranger.
+PROXY_URL = os.environ.get("RUSTCHAIN_PROXY", "")
+
+# Verification is ON. Old PowerPC Macs genuinely cannot complete a modern
+# TLS handshake, and the escape hatch for them is an explicit opt-out that
+# the operator chooses, not a silent default that ships to everyone.
+TLS_VERIFY = os.environ.get("RUSTCHAIN_TLS_VERIFY", "1") not in ("0", "false", "False")
 BLOCK_TIME = 600  # 10 minutes
 LOTTERY_CHECK_INTERVAL = 10
 
@@ -199,7 +208,7 @@ class NodeTransport:
         try:
             r = requests.get(
                 self.node_url + "/health",
-                timeout=10, verify=False
+                timeout=10, verify=TLS_VERIFY
             )
             if r.status_code == 200:
                 print(success("[TRANSPORT] Direct HTTPS to node: OK"))
@@ -237,14 +246,14 @@ class NodeTransport:
     def get(self, path, **kwargs):
         """GET request through whichever transport works."""
         kwargs.setdefault("timeout", 15)
-        kwargs.setdefault("verify", False)
+        kwargs.setdefault("verify", TLS_VERIFY)
         url = self.base_url + path
         return requests.get(url, **kwargs)
 
     def post(self, path, **kwargs):
         """POST request through whichever transport works."""
         kwargs.setdefault("timeout", 15)
-        kwargs.setdefault("verify", False)
+        kwargs.setdefault("verify", TLS_VERIFY)
         url = self.base_url + path
         return requests.post(url, **kwargs)
 

--- a/miners/pico_bridge/pico_bridge_miner.py
+++ b/miners/pico_bridge/pico_bridge_miner.py
@@ -706,6 +706,17 @@ Supported console types:
     config = load_config(args.config)
 
     # Override with CLI args
+    # --simulate fabricates hardware readings. Posting those to a node that
+    # pays real RTC is a fake-hardware faucet, so it is refused unless the
+    # operator has explicitly pointed the bridge at a local test node.
+    SIMULATE_LOCAL_ONLY = True
+    if args.simulate and SIMULATE_LOCAL_ONLY:
+        _n = config.get('node_url', '')
+        if not any(h in _n for h in ('localhost', '127.0.0.1', '0.0.0.0', '::1')):
+            print('refusing --simulate against a non-local node: ' + _n)
+            print('point RUSTCHAIN_NODE at a local test node to simulate')
+            return 2
+
     if args.simulate:
         config['simulation_mode'] = True
     if args.wallet:


### PR DESCRIPTION
Found by a red-team pass over all sixteen miner clients. These are client-side problems: they put the **operator** at risk, not the node.

## macOS miner disabled TLS verification on every request

`miners/macos/rustchain_mac_miner_v2.5.py` set `verify=False` in both `get()` and `post()`, and again on the probe. The fallback message reads *"Falling back to direct HTTPS with TLS verification"* — it does not re-enable verification. The comment is simply false.

Any on-path attacker (café wifi, ARP spoof, hostile ISP) could read and rewrite attestations in flight, including swapping the `miner` wallet field.

Verification is now on, with an explicit `RUSTCHAIN_TLS_VERIFY=0` opt-out for the Tiger and Leopard machines that genuinely cannot complete a modern handshake. That is a decision the operator makes, not a silent default shipped to everyone.

## The same file shipped a private lab address as its default proxy

```python
PROXY_URL = os.environ.get("RUSTCHAIN_PROXY", "http://192.168.0.160:8089")
```

That is a machine on the maintainer's LAN. On anyone else's network, `192.168.0.160` is whatever host happens to hold that address — and the miner hands it the full attestation in cleartext: hardware serial, MAC addresses, hostname, wallet. There is no default proxy now.

## The Pico bridge could post fabricated attestations to production

`--simulate` fabricates hardware readings, and its simulator floors `cv` at twice the pass threshold so simulated hardware always passes. It swapped only the bridge object; the submit path still used `config['node_url']`, which defaults to `https://rustchain.org`.

`python pico_bridge_miner.py --simulate --wallet RTC...` was a working fake-hardware faucet checked into the repo. Simulation now refuses to run against a non-local node.

## Not fixed here, needs a maintainer decision

**`miners/ppc/g4/rustchain_miner_v6.c` has its entire fingerprint as a string literal**, including `"anti_emulation":{"passed":true,"data":{"vm_indicators":[]}}`. There is no VM check anywhere in the program — it asserts real G4 hardware unconditionally, so compiling it inside a VM claims the 2.5x multiplier.

This matters for the hardening on #8065: that change rejects a bare boolean from a capable device, but this client sends a **dict with an empty `vm_indicators` array**, which is evidence-shaped and passes. Worth knowing before #8065 is treated as closing the bypass.

The same file hardcodes `WALLET`, `MAC_ADDR` and `SERIAL` at lines 18-22, so that identity is public and replayable by anyone who reads the repo. Retiring that wallet is your call.

Also outstanding, listed for the record: `floppy-miner` generates its "measurements" with `random.uniform()` and fabricates a reward figure for display; the top-level Windows miner defaults to plaintext `http://` against a bare IP while the installer variant correctly uses https; and `miner_crypto.py` XORs private keys against a constant that is published in the source on Windows, so the at-rest protection there is decorative.