### PR TITLE
fix: normalize error message prefix to ERROR: for consistency [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/tools/rustchain_wallet_cli.py
+++ b/tools/rustchain_wallet_cli.py
@@ -210,14 +210,14 @@ def _sign_transfer(
 
 def cmd_create(args):
     if Mnemonic is None:
-        print("Error: missing dependency 'mnemonic'. Install: python3 -m pip install mnemonic", file=sys.stderr)
+        print("ERROR: missing dependency 'mnemonic'. Install: python3 -m pip install mnemonic", file=sys.stderr)
         return EXIT_USAGE_ERROR
 
     wallet_name = args.name or f"wallet-{int(time.time())}"
     password = _read_password("Set wallet password: ", "RUSTCHAIN_WALLET_PASSWORD")
     confirm = _read_password("Confirm password: ", "RUSTCHAIN_WALLET_PASSWORD_CONFIRM")
     if password != confirm:
-        print("Error: password mismatch", file=sys.stderr)
+        print("ERROR: password mismatch", file=sys.stderr)
         return EXIT_USAGE_ERROR
 
     m = Mnemonic("english")
@@ -246,7 +246,7 @@ def cmd_create(args):
 
 def cmd_import(args):
     if Mnemonic is None:
-        print("Error: missing dependency 'mnemonic'. Install: python3 -m pip install mnemonic", file=sys.stderr)
+        print("ERROR: missing dependency 'mnemonic'. Install: python3 -m pip install mnemonic", file=sys.stderr)
         return EXIT_USAGE_ERROR
 
     phrase = args.mnemonic.strip().lower()
@@ -254,7 +254,7 @@ def cmd_import(args):
     password = _read_password("Set wallet password: ", "RUSTCHAIN_WALLET_PASSWORD")
     confirm = _read_password("Confirm password: ", "RUSTCHAIN_WALLET_PASSWORD_CONFIRM")
     if password != confirm:
-        print("Error: password mismatch", file=sys.stderr)
+        print("ERROR: password mismatch", file=sys.stderr)
         return EXIT_USAGE_ERROR
 
     priv_hex, pub_hex = _derive_ed25519_from_mnemonic(phrase)
@@ -292,7 +292,7 @@ def _safe_json(r: "requests.Response") -> "tuple[dict | list | None, int]":
         return r.json(), EXIT_SUCCESS if r.ok else EXIT_BAD_RESPONSE
     except Exception:
         print(
-            f"Error: Server returned HTTP {r.status_code} with non-JSON body"
+            f"ERROR: Server returned HTTP {r.status_code} with non-JSON body"
             f" (check node URL / connectivity)",
             file=sys.stderr,
         )
@@ -304,7 +304,7 @@ def _safe_json_object(r: "requests.Response") -> "tuple[dict | None, int]":
     if data is None:
         return None, rc
     if not isinstance(data, dict):
-        print("Error: Server returned JSON but not an object", file=sys.stderr)
+        print("ERROR: Server returned JSON but not an object", file=sys.stderr)
         return None, EXIT_BAD_RESPONSE
     return data, rc
 
@@ -478,7 +478,7 @@ def main():
     try:
         return args.func(args)
     except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
+        print(f"ERROR: {e}", file=sys.stderr)
         return EXIT_UNKNOWN_ERROR
 
 


### PR DESCRIPTION
## Summary

Fixes inconsistent error message formatting in `tools/rustchain_wallet_cli.py` per [RustChain bounty #16253](https://github.com/Scottcjn/rustchain-bounties/issues/16253) / [issue #7889](https://github.com/Scottcjn/Rustchain/issues/7889).

### Changes

**Normalized error message prefix** — all error messages now use `ERROR:` (uppercase) consistently instead of a mix of `Error:` and `ERROR:`:

| File | Line | Before | After |
|------|------|--------|-------|
| `tools/rustchain_wallet_cli.py` | 213 | `Error: missing dependency` | `ERROR: missing dependency` |
| `tools/rustchain_wallet_cli.py` | 220 | `Error: password mismatch` | `ERROR: password mismatch` |
| `tools/rustchain_wallet_cli.py` | 249 | `Error: missing dependency` | `ERROR: missing dependency` |
| `tools/rustchain_wallet_cli.py` | 257 | `Error: password mismatch` | `ERROR: password mismatch` |
| `tools/rustchain_wallet_cli.py` | 295 | `Error: Server returned HTTP` | `ERROR: Server returned HTTP` |
| `tools/rustchain_wallet_cli.py` | 307 | `Error: Server returned JSON but not an object` | `ERROR: Server returned JSON but not an object` |
| `tools/rustchain_wallet_cli.py` | 481 | `Error: {e}` | `ERROR: {e}` |

### Exit code scheme (unchanged, already documented in `--help`)

```
Exit codes:
  0  success
  1  usage / input error
  2  network / connectivity error
  3  bad / unexpected response from server
  4  wallet not found
  5  authentication / decryption failure
  6  unexpected internal error
```

### Verification

The `cmd_balance` function already handles all expected failure paths correctly:
- Network error → `EXIT_NETWORK_ERROR` (2) with `ERROR:` on stderr ✅
- HTTP 404 → `EXIT_WALLET_NOT_FOUND` (4) with `ERROR:` on stderr ✅
- HTTP non-200 → `EXIT_BAD_RESPONSE` (3) with `ERROR:` on stderr ✅
- Non-JSON response → `EXIT_BAD_RESPONSE` (3) with `ERROR:` on stderr ✅
- Missing field in response → `EXIT_BAD_RESPONSE` (3) with `ERROR:` on stderr ✅
- Success → `EXIT_SUCCESS` (0) with JSON on stdout ✅
- Unknown exception → `EXIT_UNKNOWN_ERROR` (6) with `ERROR:` on stderr ✅

Closes: https://github.com/Scottcjn/Rustchain/issues/7889
