### PR TITLE
fix(verifier): validate compensated review comments

### DIFF
--- a/tests/test_star_checker.py
+++ b/tests/test_star_checker.py
@@ -153,6 +153,57 @@ def test_count_user_stars_uses_supplied_repos_without_fetching_owner_repos(monke
     assert star_checker.count_user_stars("targetuser", "owner", "secret", repos=["alpha", "beta"]) == 1
 
 
+def test_validate_star_review_comment_accepts_ftc_compliant_comment():
+    body = (
+        "I reviewed the Proof of Antiquity docs at "
+        "https://github.com/Scottcjn/Rustchain/blob/main/docs/MECHANISM_SPEC_AND_FALSIFICATION_MATRIX.md. "
+        "The vintage-hardware reward model is a clever way to keep mining accessible to retro collectors. "
+        "I received RTC compensation for this review."
+    )
+
+    valid, errors = star_checker.validate_star_review_comment(body)
+
+    assert valid is True
+    assert errors == []
+
+
+def test_validate_star_review_comment_rejects_missing_disclosure():
+    body = (
+        "I reviewed https://github.com/Scottcjn/Rustchain/blob/main/README.md. "
+        "The project ties real hardware scarcity to consensus in a way I have not seen elsewhere."
+    )
+
+    valid, errors = star_checker.validate_star_review_comment(body)
+
+    assert valid is False
+    assert any("FTC disclosure" in error for error in errors)
+
+
+def test_validate_star_review_comment_rejects_missing_link():
+    body = (
+        "I read the README and liked the Proof of Antiquity design. "
+        "It rewards collectors instead of only the newest GPUs. "
+        "I received RTC compensation for this review."
+    )
+
+    valid, errors = star_checker.validate_star_review_comment(body)
+
+    assert valid is False
+    assert any("review link" in error for error in errors)
+
+
+def test_validate_star_review_comment_rejects_single_sentence():
+    body = (
+        "Great project at https://github.com/Scottcjn/Rustchain. "
+        "I received RTC compensation for this review."
+    )
+
+    valid, errors = star_checker.validate_star_review_comment(body)
+
+    assert valid is False
+    assert any("substantive sentences" in error for error in errors)
+
+
 def test_check_wallet_exists_uses_public_wallet_balance_endpoint(monkeypatch, tmp_path):
     cert = tmp_path / ".rustchain" / "node_cert.pem"
     cert.parent.mkdir()

--- a/tools/bounty_verifier/star_checker.py
+++ b/tools/bounty_verifier/star_checker.py
@@ -18,8 +18,6 @@ import requests
 logger = logging.getLogger(__name__)
 
 RUSTCHAIN_NODE_URL = "https://50.28.86.131"
-RUSTCHAIN_REPO_OWNER = "Scottcjn"
-RUSTCHAIN_REPO_NAME = "Rustchain"
 FTC_DISCLOSURE_PHRASE = "i received rtc compensation for this review"
 URL_PATTERN = re.compile(r"https?://[^\s<>\[\]\"')]+", re.IGNORECASE)
 MIN_REVIEW_SENTENCES = 2
@@ -39,8 +37,19 @@ def _response_json_list(resp) -> list:
 
 
 def _count_review_sentences(body: str) -> int:
-    """Count substantive sentences, ignoring URL fragments."""
-    stripped = URL_PATTERN.sub(" ", body)
+    """Count substantive review sentences, ignoring links and disclosure."""
+    stripped = URL_PATTERN.sub(
+        lambda match: match.group(0)[-1]
+        if match.group(0)[-1] in ".!?"
+        else " ",
+        body,
+    )
+    stripped = re.sub(
+        re.escape(FTC_DISCLOSURE_PHRASE),
+        " ",
+        stripped,
+        flags=re.IGNORECASE,
+    )
     return sum(
         1
         for sentence in re.split(r"[.!?]+", stripped)
@@ -49,7 +58,7 @@ def _count_review_sentences(body: str) -> int:
 
 
 def validate_star_review_comment(body: str) -> Tuple[bool, List[str]]:
-    """Validate FTC-compliant star-bounty review comments (issue #773).
+    """Validate compensated review comments for star-based bounties.
 
     Requires:
     - Disclosure: "I received RTC compensation for this review."

--- a/tools/bounty_verifier/star_checker.py
+++ b/tools/bounty_verifier/star_checker.py
@@ -10,13 +10,20 @@ Cherry-picked from LaphoqueRC PR #1712 with fixes:
 """
 
 import logging
-from typing import List, Optional
+import re
+from typing import List, Optional, Tuple
 
 import requests
 
 logger = logging.getLogger(__name__)
 
 RUSTCHAIN_NODE_URL = "https://50.28.86.131"
+RUSTCHAIN_REPO_OWNER = "Scottcjn"
+RUSTCHAIN_REPO_NAME = "Rustchain"
+FTC_DISCLOSURE_PHRASE = "i received rtc compensation for this review"
+URL_PATTERN = re.compile(r"https?://[^\s<>\[\]\"')]+", re.IGNORECASE)
+MIN_REVIEW_SENTENCES = 2
+MIN_REVIEW_SENTENCE_WORDS = 3
 
 
 def _response_json_list(resp) -> list:
@@ -29,6 +36,42 @@ def _response_json_list(resp) -> list:
         logger.warning("GitHub API returned %s JSON, expected list", type(body).__name__)
         return []
     return [item for item in body if isinstance(item, dict)]
+
+
+def _count_review_sentences(body: str) -> int:
+    """Count substantive sentences, ignoring URL fragments."""
+    stripped = URL_PATTERN.sub(" ", body)
+    return sum(
+        1
+        for sentence in re.split(r"[.!?]+", stripped)
+        if len(sentence.split()) >= MIN_REVIEW_SENTENCE_WORDS
+    )
+
+
+def validate_star_review_comment(body: str) -> Tuple[bool, List[str]]:
+    """Validate FTC-compliant star-bounty review comments (issue #773).
+
+    Requires:
+    - Disclosure: "I received RTC compensation for this review."
+    - At least one review link (URL)
+    - At least two substantive sentences
+    """
+    errors: List[str] = []
+
+    if FTC_DISCLOSURE_PHRASE not in body.lower():
+        errors.append(
+            "Missing FTC disclosure: 'I received RTC compensation for this review.'"
+        )
+
+    if not URL_PATTERN.search(body):
+        errors.append("Missing review link (at least one URL required)")
+
+    if _count_review_sentences(body) < MIN_REVIEW_SENTENCES:
+        errors.append(
+            f"Comment must contain at least {MIN_REVIEW_SENTENCES} substantive sentences"
+        )
+
+    return len(errors) == 0, errors
 
 
 def check_user_starred_repo(


### PR DESCRIPTION
## Summary

Adds `validate_star_review_comment()` to the existing star-checker tool so compensated review comments can be checked for the required disclosure, a review link, and two substantive review sentences.

This is a normal verifier contribution. It does not claim or complete a bounty and is not linked to issue #773.

## Correctness

- Excludes the FTC disclosure from the substantive-sentence count.
- Preserves sentence-ending punctuation when removing URLs before counting.
- Removes unused repository constants.

## Verification

- Focused and related verifier suites: 60 passed.
- Repository-wide pytest collection was attempted, but unrelated subprojects currently fail collection because of missing optional dependencies, duplicate test-module names, and existing import/schema errors.

No live-node behavior is changed.

---
This change was prepared with AI assistance under human direction and review.