### PR TITLE
fix(installer): resolve macOS crashes, missing variables, and sha256 fallback in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,6 +57,7 @@ if [ "$(uname -s)" = "Darwin" ]; then
     MINER_FILENAME="rustchain_mac_miner_v2.5.py"
     MINER_URL="${REPO_RAW}/miners/macos/${MINER_FILENAME}"
     FINGERPRINT_URL="${REPO_RAW}/miners/macos/fingerprint_checks.py"
+    MINER_CRYPTO_URL="${REPO_RAW}/miners/macos/miner_crypto.py"
 else
     MINER_FILENAME="rustchain_linux_miner.py"
     MINER_URL="${REPO_RAW}/miners/linux/rustchain_linux_miner.py"
@@ -602,7 +603,15 @@ CFGEOF
 
     # --- Generate miner ID ---
     local miner_id
-    miner_id=$(echo -n "${wallet}-${arch}-$(hostname)" | sha256sum 2>/dev/null | cut -c1-16 || echo "${wallet}")
+    if command -v sha256sum &>/dev/null; then
+        miner_id=$(echo -n "${wallet}-${arch}-$(hostname)" | sha256sum | cut -c1-16)
+    elif command -v shasum &>/dev/null; then
+        miner_id=$(echo -n "${wallet}-${arch}-$(hostname)" | shasum -a 256 | cut -c1-16)
+    elif command -v python3 &>/dev/null; then
+        miner_id=$(python3 -c "import hashlib; print(hashlib.sha256(b'${wallet}-${arch}-' + b'$(hostname)').hexdigest()[:16])" 2>/dev/null || echo "${wallet}")
+    else
+        miner_id="${wallet}"
+    fi
 
     # --- Create service ---
     echo ""

--- a/tests/test_macos_installer_compatibility.py
+++ b/tests/test_macos_installer_compatibility.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "scripts" / "install.sh"
+
+
+def test_installer_defines_miner_crypto_url_for_macos():
+    script = INSTALLER.read_text(encoding="utf-8")
+    darwin_block = script.split('if [ "$(uname -s)" = "Darwin" ]; then')[1].split("else")[0]
+    assert "MINER_CRYPTO_URL=" in darwin_block
+
+
+def test_installer_uses_portable_sha256_for_miner_id():
+    script = INSTALLER.read_text(encoding="utf-8")
+    assert "shasum -a 256" in script
+    assert "hashlib.sha256" in script


### PR DESCRIPTION
Fixes #7975 where install script failed on macOS.

## Summary of Fixes
1. **Defined Missing `MINER_CRYPTO_URL`:** Added `MINER_CRYPTO_URL` in Darwin branch to avoid unassigned variable errors during download.
2. **Added Portable SHA256 Fallback:** Updated `miner_id` calculation to check for `sha256sum` (GNU), `shasum -a 256` (BSD/macOS), and `python3` fallback instead of failing when GNU `sha256sum` is missing.
3. **Unit Test Coverage:** Added `tests/test_macos_installer_compatibility.py` asserting variable definitions and fallback presence.

Closes #7975
Bounty claim: Scottcjn/rustchain-bounties#16251 (10 RTC)

Wallet: RTCfe13452d122263caf633ab1876bd9631133b68b1