### PR TITLE
fix(security): vouch for claimed reward tiers instead of echoing them back (ARM/console spoofing)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2115,6 +2115,18 @@ STREAK_BONUS_PER_DAY = 0.02      # Additional multiplier per consecutive day (ca
 STREAK_MAX_DAYS = 30             # Max streak bonus cap
 STREAK_GRACE_HOURS = 26          # Hours before streak resets (gives timezone flexibility)
 
+# Console arch strings the Pico bridge is allowed to attest for (RIP-304).
+# Deliberately WIDER than the HARDWARE_WEIGHTS["console"] keys: an Apple II
+# reports the bare CPU ("6502"), not a console model, and falls to the console
+# default tier. Keeping one list means the vouching check and the fingerprint
+# relaxation cannot drift apart and quietly cap honest retro hardware.
+CONSOLE_ARCHES = {
+    "nes_6502", "snes_65c816", "n64_mips", "gba_arm7",
+    "genesis_68000", "sms_z80", "saturn_sh2",
+    "gameboy_z80", "gameboy_color_z80", "ps1_mips",
+    "6502", "65c816", "z80", "sh2",
+}
+
 POWERPC_ARCHES = {"g3", "g4", "g5", "power8", "power9", "powerpc", "power macintosh"}
 X86_CPU_BRANDS = {"intel", "xeon", "core", "celeron", "pentium", "amd", "ryzen", "epyc", "athlon", "threadripper"}
 ARM_CPU_BRANDS = {
@@ -2925,6 +2937,129 @@ def _classify_validated_x86_brand(cpu_brand: str):
     return None
 
 
+# === RIP-201: server-side vouching for claimed reward tiers ===
+#
+# derive_verified_device() used to end by handing the miner's own
+# device_family/device_arch straight back. Both reward tables are keyed off
+# whatever it returns. HARDWARE_WEIGHTS on the enrolment path, and
+# ANTIQUITY_MULTIPLIERS (via get_time_aged_multiplier on the stored
+# miner_attest_recent.device_arch) on the settlement path, so a claim that
+# reached the tail collected its tier for free. family="ARM"/arch="arm2" paid
+# 4.0 and family="console"/arch="nes_6502" paid 2.8 against an honest modern
+# x86_64 at 0.8, on plain bare-metal, with no corroborating evidence at all.
+#
+# The rule below is deliberately not an enumeration of good arch strings,
+# because that list rots the moment somebody adds a tier. It is: if the claim
+# would pay MORE than the modern rate and no detection branch above vouched
+# for it, cap it at the modern rate. Being unable to prove you are vintage
+# costs you the bonus, never your participation. An unvouched miner keeps
+# attesting, keeps enrolling and keeps earning, just at 0.8 like any other
+# modern box.
+UNVOUCHED_DEVICE = {"device_family": "x86_64", "device_arch": "modern"}
+
+# The neutral rate both reward tables agree on for a modern machine.
+# HARDWARE_WEIGHTS["x86_64"]["modern"] == 0.8 and
+# get_time_aged_multiplier("modern") == 0.8.
+_NEUTRAL_DEVICE_WEIGHT = 0.8
+
+
+def _console_bridge_evidence(device: dict, fingerprint: dict) -> bool:
+    """True when the payload carries the RIP-304 Pico bridge shape.
+
+    A real console miner cannot run a Python agent on the console itself; it
+    attests through a Pi Pico wired to the controller port, and
+    miners/pico_bridge/pico_bridge_miner.py always stamps bridge_type on both
+    the device and the fingerprint and always emits a ctrl_port_timing check
+    (see check_pico_bridge_attestation in node/fingerprint_checks.py). Asking
+    for that shape is asking for what the honest client already sends.
+
+    This does not make the console tier unforgeable. A determined spoofer can
+    synthesise the bridge fields too, and check_pico_bridge_attestation still
+    has to do the real work of judging cv/samples and ROM timing. It does stop
+    the two-string version, where an ordinary x86 box types "console" and
+    "nes_6502" into its payload and walks off with 2.8.
+    """
+    if not isinstance(device, dict):
+        device = {}
+    if str(device.get("bridge_type") or "").strip().lower() == "pico_serial":
+        return True
+    if isinstance(fingerprint, dict):
+        if str(fingerprint.get("bridge_type") or "").strip().lower() == "pico_serial":
+            return True
+        entry = _fingerprint_checks_map(fingerprint).get("ctrl_port_timing")
+        if isinstance(entry, dict) and entry.get("data"):
+            return True
+        if entry is True:
+            return True
+    return False
+
+
+def _claim_pays_above_neutral(family: str, arch: str) -> bool:
+    """Would honouring this family/arch pay more than a modern machine?
+
+    Checks both reward tables, because they disagree and both are live.
+    HARDWARE_WEIGHTS decides the enrolment weight snapshot; ANTIQUITY_MULTIPLIERS
+    decides the settlement multiplier when calculate_epoch_rewards_time_aged
+    falls back to miner_attest_recent. x86 arch="486" is 2.0 in the first and
+    2.9 in the second, so consulting only one of them would miss half the money.
+    """
+    bucket = HARDWARE_WEIGHTS.get(family, {})
+    if isinstance(bucket, dict):
+        weight = bucket.get(arch)
+        if weight is None:
+            weight = bucket.get("default")
+        if weight is not None and float(weight) > _NEUTRAL_DEVICE_WEIGHT:
+            return True
+    try:
+        from rip_200_round_robin_1cpu1vote import get_time_aged_multiplier
+        if float(get_time_aged_multiplier(arch, 0.0)) > _NEUTRAL_DEVICE_WEIGHT:
+            return True
+    except Exception:
+        # If the antiquity table cannot be consulted, fall back to the
+        # HARDWARE_WEIGHTS answer above rather than failing the attestation.
+        pass
+    return False
+
+
+def _vouch_claimed_device(family: str, arch: str, device: dict, fingerprint: dict) -> dict:
+    """Decide whether the server is willing to stand behind a claimed tier.
+
+    Only reached from the tail of derive_verified_device, i.e. only for claims
+    that no detection branch above recognised. Everything the server derived
+    itself has already returned by this point and never gets here.
+    """
+    family_lower = str(family or "").strip().lower()
+    arch_lower = str(arch or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+    # x86 keeps the path it already has: _detect_x86_vintage above, plus the
+    # _derive_enroll_weight_device clamp added by #8022. Left alone on purpose
+    # so this change stays complementary to PR #8087 instead of colliding with
+    # it in the same function. See the PR body for the gap that leaves.
+    if family_lower in ("x86", "x86_64", "windows", ""):
+        return {"device_family": family, "device_arch": arch}
+
+    # Console: honour the retro tier only with the Pico bridge shape behind it.
+    if family_lower == "console":
+        if arch_lower in CONSOLE_ARCHES and _console_bridge_evidence(device, fingerprint):
+            return {"device_family": "console", "device_arch": arch_lower}
+        print(f"[VOUCH] REJECT console claim {arch!r}: no pico bridge evidence -> x86_64/modern")
+        return dict(UNVOUCHED_DEVICE)
+
+    # ARM reaching the tail means _detect_arm_evidence found nothing ARM about
+    # this machine while the payload insists it is ARM. Honest vintage ARM goes
+    # through the vintage_arm_arches branch above and never lands here.
+    if family_lower == "arm":
+        print(f"[VOUCH] REJECT ARM claim {arch!r}: no ARM evidence in payload -> x86_64/modern")
+        return dict(UNVOUCHED_DEVICE)
+
+    if _claim_pays_above_neutral(family, arch_lower):
+        print(f"[VOUCH] REJECT unvouched tier {family}/{arch} -> x86_64/modern")
+        return dict(UNVOUCHED_DEVICE)
+
+    # Pays neutral or less. Nothing to steal, so keep the miner's own label.
+    return {"device_family": family, "device_arch": arch}
+
+
 def _derive_enroll_weight_device(
     verified_device: dict, fingerprint: dict, fingerprint_passed: bool = True,
     measurement_report_verified: bool = False,
@@ -3207,8 +3342,11 @@ def derive_verified_device(device: dict, fingerprint: dict, fingerprint_passed: 
         if x86_vintage:
             return x86_vintage
 
-    # Non-PowerPC, non-ARM, non-exotic — return claimed values
-    return {"device_family": family, "device_arch": arch}
+    # Nothing above recognised this device, so family/arch are still the
+    # miner's own words. Vouch for the claim or cap it at the modern rate;
+    # see _vouch_claimed_device. Returning the claim verbatim here is what
+    # handed out ARM/arm2 at 4.0 and console/nes_6502 at 2.8 for free.
+    return _vouch_claimed_device(family, arch, device, fingerprint)
 
 # RIP-0146b: Enrollment enforcement config
 ENROLL_REQUIRE_TICKET = os.getenv("ENROLL_REQUIRE_TICKET", "1") == "1"
@@ -3888,16 +4026,22 @@ def validate_fingerprint_data(
                              "powerpc g4", "powerpc g5", "powerpc g3",
                              "power8", "power9", "68k", "m68k"}
     # RIP-304: Console miners via Pico bridge have their own fingerprint checks
-    console_archs = {"nes_6502", "snes_65c816", "n64_mips", "gba_arm7",
-                     "genesis_68000", "sms_z80", "saturn_sh2",
-                     "gameboy_z80", "gameboy_color_z80", "ps1_mips",
-                     "6502", "65c816", "z80", "sh2"}
+    console_archs = CONSOLE_ARCHES
     # 386/486 predate RDTSC. Relax their clock requirement only for the
     # attestation reward path; other validator consumers keep the strict rule.
     is_vintage = claimed_arch_lower in vintage_relaxed_archs or (
         allow_tscless_x86_reward and claimed_arch_lower in {"386", "486"}
     )
-    is_console = claimed_arch_lower in console_archs
+    # The console relaxation drops clock_drift from the required set, so keying
+    # it off the claimed arch string alone meant one word in the request body
+    # skipped a required hardware check: the same payload with no clock_drift
+    # at all returned missing_required_check:clock_drift as "modern" and valid
+    # as "nes_6502". Require the RIP-304 bridge shape the honest Pico client
+    # actually sends before relaxing anything.
+    is_console = (
+        claimed_arch_lower in console_archs
+        and _console_bridge_evidence(claimed_device, fingerprint)
+    )
 
     # RIP-304: Console miners use Pico bridge fingerprinting (ctrl_port_timing
     # replaces clock_drift; anti_emulation still required via timing CV)

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2283,6 +2283,18 @@ STREAK_BONUS_PER_DAY = 0.02      # Additional multiplier per consecutive day (ca
 STREAK_MAX_DAYS = 30             # Max streak bonus cap
 STREAK_GRACE_HOURS = 26          # Hours before streak resets (gives timezone flexibility)
 
+# Console arch strings the Pico bridge is allowed to attest for (RIP-304).
+# Deliberately WIDER than the HARDWARE_WEIGHTS["console"] keys: an Apple II
+# reports the bare CPU ("6502"), not a console model, and falls to the console
+# default tier. Keeping one list means the vouching check and the fingerprint
+# relaxation cannot drift apart and quietly cap honest retro hardware.
+CONSOLE_ARCHES = {
+    "nes_6502", "snes_65c816", "n64_mips", "gba_arm7",
+    "genesis_68000", "sms_z80", "saturn_sh2",
+    "gameboy_z80", "gameboy_color_z80", "ps1_mips",
+    "6502", "65c816", "z80", "sh2",
+}
+
 POWERPC_ARCHES = {"g3", "g4", "g5", "power8", "power9", "powerpc", "power macintosh"}
 
 
@@ -3333,6 +3345,129 @@ def _classify_validated_x86_brand(cpu_brand: str):
     return None
 
 
+# === RIP-201: server-side vouching for claimed reward tiers ===
+#
+# derive_verified_device() used to end by handing the miner's own
+# device_family/device_arch straight back. Both reward tables are keyed off
+# whatever it returns. HARDWARE_WEIGHTS on the enrolment path, and
+# ANTIQUITY_MULTIPLIERS (via get_time_aged_multiplier on the stored
+# miner_attest_recent.device_arch) on the settlement path, so a claim that
+# reached the tail collected its tier for free. family="ARM"/arch="arm2" paid
+# 4.0 and family="console"/arch="nes_6502" paid 2.8 against an honest modern
+# x86_64 at 0.8, on plain bare-metal, with no corroborating evidence at all.
+#
+# The rule below is deliberately not an enumeration of good arch strings,
+# because that list rots the moment somebody adds a tier. It is: if the claim
+# would pay MORE than the modern rate and no detection branch above vouched
+# for it, cap it at the modern rate. Being unable to prove you are vintage
+# costs you the bonus, never your participation. An unvouched miner keeps
+# attesting, keeps enrolling and keeps earning, just at 0.8 like any other
+# modern box.
+UNVOUCHED_DEVICE = {"device_family": "x86_64", "device_arch": "modern"}
+
+# The neutral rate both reward tables agree on for a modern machine.
+# HARDWARE_WEIGHTS["x86_64"]["modern"] == 0.8 and
+# get_time_aged_multiplier("modern") == 0.8.
+_NEUTRAL_DEVICE_WEIGHT = 0.8
+
+
+def _console_bridge_evidence(device: dict, fingerprint: dict) -> bool:
+    """True when the payload carries the RIP-304 Pico bridge shape.
+
+    A real console miner cannot run a Python agent on the console itself; it
+    attests through a Pi Pico wired to the controller port, and
+    miners/pico_bridge/pico_bridge_miner.py always stamps bridge_type on both
+    the device and the fingerprint and always emits a ctrl_port_timing check
+    (see check_pico_bridge_attestation in node/fingerprint_checks.py). Asking
+    for that shape is asking for what the honest client already sends.
+
+    This does not make the console tier unforgeable. A determined spoofer can
+    synthesise the bridge fields too, and check_pico_bridge_attestation still
+    has to do the real work of judging cv/samples and ROM timing. It does stop
+    the two-string version, where an ordinary x86 box types "console" and
+    "nes_6502" into its payload and walks off with 2.8.
+    """
+    if not isinstance(device, dict):
+        device = {}
+    if str(device.get("bridge_type") or "").strip().lower() == "pico_serial":
+        return True
+    if isinstance(fingerprint, dict):
+        if str(fingerprint.get("bridge_type") or "").strip().lower() == "pico_serial":
+            return True
+        entry = _fingerprint_checks_map(fingerprint).get("ctrl_port_timing")
+        if isinstance(entry, dict) and entry.get("data"):
+            return True
+        if entry is True:
+            return True
+    return False
+
+
+def _claim_pays_above_neutral(family: str, arch: str) -> bool:
+    """Would honouring this family/arch pay more than a modern machine?
+
+    Checks both reward tables, because they disagree and both are live.
+    HARDWARE_WEIGHTS decides the enrolment weight snapshot; ANTIQUITY_MULTIPLIERS
+    decides the settlement multiplier when calculate_epoch_rewards_time_aged
+    falls back to miner_attest_recent. x86 arch="486" is 2.0 in the first and
+    2.9 in the second, so consulting only one of them would miss half the money.
+    """
+    bucket = HARDWARE_WEIGHTS.get(family, {})
+    if isinstance(bucket, dict):
+        weight = bucket.get(arch)
+        if weight is None:
+            weight = bucket.get("default")
+        if weight is not None and float(weight) > _NEUTRAL_DEVICE_WEIGHT:
+            return True
+    try:
+        from rip_200_round_robin_1cpu1vote import get_time_aged_multiplier
+        if float(get_time_aged_multiplier(arch, 0.0)) > _NEUTRAL_DEVICE_WEIGHT:
+            return True
+    except Exception:
+        # If the antiquity table cannot be consulted, fall back to the
+        # HARDWARE_WEIGHTS answer above rather than failing the attestation.
+        pass
+    return False
+
+
+def _vouch_claimed_device(family: str, arch: str, device: dict, fingerprint: dict) -> dict:
+    """Decide whether the server is willing to stand behind a claimed tier.
+
+    Only reached from the tail of derive_verified_device, i.e. only for claims
+    that no detection branch above recognised. Everything the server derived
+    itself has already returned by this point and never gets here.
+    """
+    family_lower = str(family or "").strip().lower()
+    arch_lower = str(arch or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+    # x86 keeps the path it already has: _detect_x86_vintage above, plus the
+    # _derive_enroll_weight_device clamp added by #8022. Left alone on purpose
+    # so this change stays complementary to PR #8087 instead of colliding with
+    # it in the same function. See the PR body for the gap that leaves.
+    if family_lower in ("x86", "x86_64", "windows", ""):
+        return {"device_family": family, "device_arch": arch}
+
+    # Console: honour the retro tier only with the Pico bridge shape behind it.
+    if family_lower == "console":
+        if arch_lower in CONSOLE_ARCHES and _console_bridge_evidence(device, fingerprint):
+            return {"device_family": "console", "device_arch": arch_lower}
+        print(f"[VOUCH] REJECT console claim {arch!r}: no pico bridge evidence -> x86_64/modern")
+        return dict(UNVOUCHED_DEVICE)
+
+    # ARM reaching the tail means _detect_arm_evidence found nothing ARM about
+    # this machine while the payload insists it is ARM. Honest vintage ARM goes
+    # through the vintage_arm_arches branch above and never lands here.
+    if family_lower == "arm":
+        print(f"[VOUCH] REJECT ARM claim {arch!r}: no ARM evidence in payload -> x86_64/modern")
+        return dict(UNVOUCHED_DEVICE)
+
+    if _claim_pays_above_neutral(family, arch_lower):
+        print(f"[VOUCH] REJECT unvouched tier {family}/{arch} -> x86_64/modern")
+        return dict(UNVOUCHED_DEVICE)
+
+    # Pays neutral or less. Nothing to steal, so keep the miner's own label.
+    return {"device_family": family, "device_arch": arch}
+
+
 def _derive_enroll_weight_device(
     verified_device: dict, fingerprint: dict, fingerprint_passed: bool = True,
     measurement_report_verified: bool = False,
@@ -3615,8 +3750,11 @@ def derive_verified_device(device: dict, fingerprint: dict, fingerprint_passed: 
         if x86_vintage:
             return x86_vintage
 
-    # Non-PowerPC, non-ARM, non-exotic — return claimed values
-    return {"device_family": family, "device_arch": arch}
+    # Nothing above recognised this device, so family/arch are still the
+    # miner's own words. Vouch for the claim or cap it at the modern rate;
+    # see _vouch_claimed_device. Returning the claim verbatim here is what
+    # handed out ARM/arm2 at 4.0 and console/nes_6502 at 2.8 for free.
+    return _vouch_claimed_device(family, arch, device, fingerprint)
 
 # RIP-0146b: Enrollment enforcement config
 ENROLL_REQUIRE_TICKET = os.getenv("ENROLL_REQUIRE_TICKET", "1") == "1"
@@ -4695,7 +4833,16 @@ def validate_fingerprint_data(
     is_vintage = claimed_arch_lower in vintage_relaxed_archs or (
         claimed_arch_lower in {"386", "486"}
     )
-    is_console = claimed_arch_lower in console_archs
+    # The console relaxation drops clock_drift from the required set, so keying
+    # it off the claimed arch string alone meant one word in the request body
+    # skipped a required hardware check: the same payload with no clock_drift
+    # at all returned missing_required_check:clock_drift as "modern" and valid
+    # as "nes_6502". Require the RIP-304 bridge shape the honest Pico client
+    # actually sends before relaxing anything.
+    is_console = (
+        claimed_arch_lower in console_archs
+        and _console_bridge_evidence(claimed_device, fingerprint)
+    )
 
     # RIP-304: Console miners use Pico bridge fingerprinting (ctrl_port_timing
     # replaces clock_drift; anti_emulation still required via timing CV)

--- a/tests/test_vintage_arch_vouching.py
+++ b/tests/test_vintage_arch_vouching.py
@@ -1,0 +1,249 @@
+"""Regression tests for server-side vouching of claimed reward tiers.
+
+Encodes the defect found 2026-07-31: derive_verified_device() ended by
+returning the miner's own device_family/device_arch verbatim for any family it
+did not specifically handle, and there was no allowlist of arch values
+anywhere. Both reward tables key off what it returns, so a plain bare-metal
+x86 box that put two extra strings in its attestation payload collected a
+vintage tier for free:
+
+    {"family": "ARM",     "arch": "arm2"}      -> 4.0x
+    {"family": "console", "arch": "nes_6502"}  -> 2.8x
+
+against an honest modern x86_64 at 0.8x. The epoch pot is fixed at 1.5 RTC and
+split by weight, so every fraudulent multiplier came straight out of the
+honest miners' share.
+
+The second half of the same defect: the console clock_drift relaxation in
+validate_fingerprint_data() keyed off the *claimed* arch string, so the same
+payload with no clock_drift measurement at all was rejected as "modern" and
+accepted as "nes_6502".
+
+The hard constraint on any fix here is that the fleet contains hardware which
+genuinely cannot produce the usual evidence. An unvouchable claim must be
+capped at the modern rate, never zeroed. Losing the bonus is correct; losing
+the ability to mine is not.
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+
+import pytest
+
+NODE_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "node")
+NODE_FILE = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+@pytest.fixture(scope="module")
+def node():
+    os.environ.setdefault("RC_ADMIN_KEY", "0" * 32)
+    os.environ.setdefault("RC_P2P_SECRET", "c" * 40)
+    os.environ.setdefault("DB_PATH", tempfile.mktemp(suffix=".db"))
+    if NODE_DIR not in sys.path:
+        sys.path.insert(0, NODE_DIR)
+    spec = importlib.util.spec_from_file_location("rcnode_vouch", NODE_FILE)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["rcnode_vouch"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def weight_of(node, verified):
+    """Enrolment-path weight, mirroring the lookup in enroll_epoch()."""
+    bucket = node.HARDWARE_WEIGHTS.get(verified["device_family"], {})
+    return bucket.get(verified["device_arch"], bucket.get("default", 1.0))
+
+
+def antiquity_of(arch):
+    """Settlement-path multiplier, mirroring calculate_epoch_rewards_time_aged()."""
+    from rip_200_round_robin_1cpu1vote import get_time_aged_multiplier
+    return get_time_aged_multiplier(arch, 0.0)
+
+
+MODERN_FP = {
+    "all_passed": True,
+    "checks": {
+        "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
+        "clock_drift": {"passed": True, "data": {"cv": 0.09, "samples": 500}},
+        "simd_identity": {"passed": True, "data": {"has_sse": True, "has_sse2": True, "has_avx": True}},
+    },
+}
+
+# A real Pico bridge attestation (RIP-304). miners/pico_bridge/pico_bridge_miner.py
+# stamps bridge_type on both the device and the fingerprint and always emits
+# ctrl_port_timing.
+PICO_FP = {
+    "bridge_type": "pico_serial",
+    "all_passed": True,
+    "checks": {
+        "ctrl_port_timing": {"passed": True, "data": {"cv": 0.005, "samples": 500}},
+        "rom_execution_timing": {"passed": True, "data": {"hash_time_us": 847000}},
+        "bus_jitter": {"passed": True, "data": {"jitter_stdev_ns": 1250}},
+        "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
+    },
+}
+
+# A genuine 486: no SIMD, and clock_drift FAILS because there is no usable TSC.
+FP_486 = {
+    "all_passed": False,
+    "checks": {
+        "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
+        "cache_timing": {"passed": True, "data": {"latencies": {"4KB": {"random_ns": 180.0}}}},
+        "simd_identity": {"passed": True, "data": {"has_sse": False}},
+    },
+}
+
+MODERN_X86_BOX = {"cpu": "Intel(R) Core(TM) i9-13900K", "machine": "x86_64"}
+
+
+# --- the hole itself -------------------------------------------------------
+
+@pytest.mark.parametrize("family,arch", [
+    ("ARM", "arm2"),
+    ("ARM", "arm3"),
+    ("ARM", "strongarm"),
+    ("console", "nes_6502"),
+    ("console", "ps1_mips"),
+    ("console", "snes_65c816"),
+])
+def test_claimed_vintage_tier_on_a_modern_box_is_capped(node, family, arch):
+    """A bare-metal x86 box cannot type its way into a vintage tier."""
+    device = dict(MODERN_X86_BOX, family=family, arch=arch)
+    verified = node.derive_verified_device(device, MODERN_FP, True)
+
+    assert weight_of(node, verified) <= 0.8, (
+        f"{family}/{arch} still pays {weight_of(node, verified)} on the enrolment path"
+    )
+    assert antiquity_of(verified["device_arch"]) <= 0.8, (
+        f"{family}/{arch} still pays {antiquity_of(verified['device_arch'])} at settlement"
+    )
+
+
+def test_capped_claim_is_not_zeroed(node):
+    """Losing the bonus is correct. Losing the ability to earn is not."""
+    device = dict(MODERN_X86_BOX, family="console", arch="nes_6502")
+    verified = node.derive_verified_device(device, MODERN_FP, True)
+
+    assert weight_of(node, verified) > 0, "an unvouched miner must still earn"
+    assert weight_of(node, verified) == 0.8, "cap is the modern rate, not a penalty"
+
+
+def test_console_arch_no_longer_skips_clock_drift(node):
+    """The relaxation must not be reachable by typing a console arch string."""
+    no_clock = {"all_passed": True, "checks": {
+        "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
+    }}
+
+    ok_modern, reason_modern = node.validate_fingerprint_data(
+        no_clock, claimed_device={"family": "x86_64", "arch": "modern"},
+        allow_tscless_x86_reward=True,
+    )
+    ok_console, reason_console = node.validate_fingerprint_data(
+        no_clock, claimed_device={"family": "console", "arch": "nes_6502"},
+        allow_tscless_x86_reward=True,
+    )
+
+    assert ok_modern is False and reason_modern == "missing_required_check:clock_drift"
+    assert ok_console is False, "claiming a console arch skipped a required check"
+    assert reason_console == reason_modern, "same payload, same verdict"
+
+
+# --- honest hardware must not regress --------------------------------------
+
+def test_honest_console_via_pico_bridge_keeps_its_tier(node):
+    device = {"family": "console", "arch": "nes_6502", "model": "NES",
+              "cpu": "Ricoh 2A03", "bridge_type": "pico_serial"}
+    verified = node.derive_verified_device(device, PICO_FP, True)
+
+    assert verified == {"device_family": "console", "device_arch": "nes_6502"}
+    assert weight_of(node, verified) == 2.8
+
+
+def test_honest_apple_ii_reports_a_bare_cpu_and_keeps_its_tier(node):
+    """An Apple II reports "6502", not a console model name.
+
+    HARDWARE_WEIGHTS["console"] has no "6502" key, so it lands on the console
+    default tier. Any vouching check built from the weight-table keys alone
+    would cap this machine, which is worse than the bug it fixes.
+    """
+    device = {"family": "console", "arch": "6502", "model": "Apple II",
+              "cpu": "MOS 6502", "bridge_type": "pico_serial"}
+    verified = node.derive_verified_device(device, PICO_FP, True)
+
+    assert verified == {"device_family": "console", "device_arch": "6502"}
+    assert weight_of(node, verified) == 2.5
+    assert antiquity_of("6502") > 0.8
+
+
+def test_honest_tscless_486_is_untouched(node):
+    """A real 486 legitimately fails clock_drift. It keeps its tier.
+
+    x86 is deliberately left on its existing path here (_detect_x86_vintage
+    plus the _derive_enroll_weight_device clamp from #8022) so this change
+    stays complementary to PR #8087 rather than colliding with it.
+    """
+    device = {"family": "x86", "arch": "486", "cpu": "Intel 486DX2-66", "machine": "i486"}
+    verified = node.derive_verified_device(device, FP_486, False)
+
+    assert verified == {"device_family": "x86", "device_arch": "486"}
+    assert weight_of(node, verified) == 2.0
+
+
+def test_honest_vintage_arm_with_arm_evidence_keeps_its_tier(node):
+    """Real vintage ARM resolves in the ARM-evidence branch, not at the tail."""
+    device = {"family": "ARM", "arch": "strongarm",
+              "cpu": "DEC StrongARM SA-110", "machine": "arm"}
+    verified = node.derive_verified_device(device, MODERN_FP, True)
+
+    assert verified == {"device_family": "ARM", "device_arch": "strongarm"}
+    assert weight_of(node, verified) == 2.8
+
+
+def test_honest_g4_and_apple_silicon_unaffected(node):
+    g4 = node.derive_verified_device(
+        {"family": "PowerPC", "arch": "g4", "cpu": "PowerPC 7455 AltiVec", "machine": "ppc"},
+        MODERN_FP, True)
+    assert g4 == {"device_family": "PowerPC", "device_arch": "G4"}
+
+    m2 = node.derive_verified_device(
+        {"family": "ARM", "arch": "m2", "cpu": "Apple M2", "machine": "arm64",
+         "platform_system": "Darwin"}, MODERN_FP, True)
+    assert m2["device_family"] == "Apple Silicon"
+
+
+def test_honest_modern_x86_unchanged(node):
+    device = dict(MODERN_X86_BOX, family="x86_64", arch="modern")
+    verified = node.derive_verified_device(device, MODERN_FP, True)
+
+    assert verified == {"device_family": "x86_64", "device_arch": "modern"}
+    assert weight_of(node, verified) == 0.8
+
+
+def test_missing_device_object_does_not_crash(node):
+    """An i386 client may send no device object at all."""
+    verified = node.derive_verified_device({}, FP_486, False)
+
+    assert isinstance(verified, dict)
+    assert "device_family" in verified and "device_arch" in verified
+
+
+# --- the vouching helper itself --------------------------------------------
+
+def test_claim_pays_above_neutral_consults_both_reward_tables(node):
+    """x86 486 is 2.0 in HARDWARE_WEIGHTS and 2.9 in ANTIQUITY_MULTIPLIERS.
+
+    Consulting only one table would miss half the money, so the helper has to
+    read both.
+    """
+    assert node._claim_pays_above_neutral("ARM", "arm2") is True
+    assert node._claim_pays_above_neutral("console", "nes_6502") is True
+    assert node._claim_pays_above_neutral("x86_64", "modern") is False
+
+
+def test_console_bridge_evidence_requires_the_pico_shape(node):
+    assert node._console_bridge_evidence({"bridge_type": "pico_serial"}, {}) is True
+    assert node._console_bridge_evidence({}, PICO_FP) is True
+    assert node._console_bridge_evidence({}, MODERN_FP) is False
+    assert node._console_bridge_evidence({}, {}) is False

--- a/tests/test_vintage_arch_vouching.py
+++ b/tests/test_vintage_arch_vouching.py
@@ -40,7 +40,9 @@ NODE_FILE = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
 def node():
     os.environ.setdefault("RC_ADMIN_KEY", "0" * 32)
     os.environ.setdefault("RC_P2P_SECRET", "c" * 40)
-    os.environ.setdefault("DB_PATH", tempfile.mktemp(suffix=".db"))
+    _db_fd, _db_path = tempfile.mkstemp(suffix=".db")
+    os.close(_db_fd)
+    os.environ.setdefault("DB_PATH", _db_path)
     if NODE_DIR not in sys.path:
         sys.path.insert(0, NODE_DIR)
     spec = importlib.util.spec_from_file_location("rcnode_vouch", NODE_FILE)

--- a/tests/test_vintage_arch_vouching.py
+++ b/tests/test_vintage_arch_vouching.py
@@ -138,11 +138,9 @@ def test_console_arch_no_longer_skips_clock_drift(node):
 
     ok_modern, reason_modern = node.validate_fingerprint_data(
         no_clock, claimed_device={"family": "x86_64", "arch": "modern"},
-        allow_tscless_x86_reward=True,
     )
     ok_console, reason_console = node.validate_fingerprint_data(
         no_clock, claimed_device={"family": "console", "arch": "nes_6502"},
-        allow_tscless_x86_reward=True,
     )
 
     assert ok_modern is False and reason_modern == "missing_required_check:clock_drift"


### PR DESCRIPTION
## The hole

`derive_verified_device` ended by returning the miner's own `device_family` and `device_arch` verbatim for any family it did not specifically handle, and there was no allowlist of arch values anywhere. Both reward tables key off what that function returns, so a plain bare-metal x86 box that added two strings to its attestation payload collected a vintage tier for free.

Measured on current main (b634ab01), no fingerprint tricks, just an ordinary modern machine with an ordinary passing fingerprint:

```
case                           derived                      HW_W  ANTIQ
HONEST modern x86_64           x86_64/modern                 0.8    0.8
SPOOF ARM/arm2                 ARM/arm2                      4.0    4.0
SPOOF console/nes_6502         console/nes_6502              2.8    2.8
SPOOF console, no bridge       console/ps1_mips              2.8    2.8
```

5x an honest miner. The epoch pot is fixed at 1.5 RTC and split by weight, so this is strictly zero sum. Every fraudulent multiplier came straight out of the honest miners' share.

Second half of the same defect: the console `clock_drift` relaxation in `validate_fingerprint_data` keyed off the claimed arch string. The same payload, with no clock-drift measurement submitted at all:

```
claims arch=modern    -> passed=False  missing_required_check:clock_drift
claims arch=nes_6502  -> passed=True   valid
```

One word in the request body skipped a required hardware check and unlocked 2.8x.

## The fix

Two changes, both on the live attestation path.

**1. Vouch or cap, at the tail of `derive_verified_device`.** The rule is deliberately not an enumeration of good arch strings, because that list rots the moment somebody adds a tier. It is: if the claim would pay more than the modern rate, and no detection branch above vouched for it, cap it at the modern rate.

`_claim_pays_above_neutral` consults **both** reward tables, because they disagree and both are live. `HARDWARE_WEIGHTS` decides the enrolment weight snapshot; `ANTIQUITY_MULTIPLIERS` (via `get_time_aged_multiplier` on the stored `miner_attest_recent.device_arch`) decides the settlement multiplier when `calculate_epoch_rewards_time_aged` falls back to `miner_attest_recent`. x86 `arch="486"` is 2.0 in the first and 2.9 in the second, so consulting only one of them would miss half the money.

Console keeps its tier only with the RIP-304 Pico bridge shape behind it, which is what `miners/pico_bridge/pico_bridge_miner.py` already sends on every attestation. ARM reaching the tail means `_detect_arm_evidence` found nothing ARM about the machine while the payload insists it is ARM, so that is capped outright. Honest vintage ARM resolves in the ARM-evidence branch above and never reaches the tail.

**2. The console relaxation now keys off bridge evidence, not the claimed string.** Same required-check bar as everyone else unless the Pico bridge shape is actually present.

### Capped, never zeroed

This is the constraint that shaped the whole change. The fleet contains hardware that genuinely cannot produce the usual evidence. An unvouchable claim is capped at the modern rate, not accused and not zeroed. Being unable to prove you are vintage costs you the bonus, never your participation: an unvouched miner keeps attesting, keeps enrolling and keeps earning at 0.8, like any other modern box.

I got this wrong on the first pass and the test battery caught it. `HARDWARE_WEIGHTS["console"]` has no `6502` key, because an Apple II reports the bare CPU rather than a console model. A vouching check built from the weight-table keys alone capped a genuine Apple II from 2.5 to 0.8. That is why `CONSOLE_ARCHES` is now a single shared constant, wider than the weight-table keys, used by both the vouching check and the fingerprint relaxation so the two cannot drift apart again.

## Verification

### Before and after, same battery

```
                               BEFORE (main)                  AFTER (this PR)
case                           derived         HW_W  ANTIQ    derived         HW_W  ANTIQ
HONEST modern x86_64           x86_64/modern    0.8    0.8     x86_64/modern    0.8    0.8
SPOOF ARM/arm2                 ARM/arm2         4.0    4.0     x86_64/modern    0.8    0.8
SPOOF console/nes_6502         console/nes_6502 2.8    2.8     x86_64/modern    0.8    0.8
SPOOF console, no bridge       console/ps1_mips 2.8    2.8     x86_64/modern    0.8    0.8
HONEST NES via Pico bridge     console/nes_6502 2.8    2.8     console/nes_6502 2.8    2.8
HONEST AppleII 6502 bridge     console/6502     2.5    2.8     console/6502     2.5    2.8
HONEST vintage ARM2 (Acorn)    AppleSilicon/M2  1.2   1.15     AppleSilicon/M2  1.2   1.15
HONEST StrongARM               ARM/strongarm    2.8    2.8     ARM/strongarm    2.8    2.8
HONEST modern ARM NAS          ARM/aarch64   0.0005 0.0005     ARM/aarch64   0.0005 0.0005
HONEST real 486 (no TSC)       x86/486          2.0    2.9     x86/486          2.0    2.9
HONEST i386, no device obj     ARM/aarch64   0.0005 0.0005     ARM/aarch64   0.0005 0.0005
HONEST G4 PowerPC              PowerPC/G4       2.5    2.5     PowerPC/G4       2.5    2.5
HONEST Apple Silicon M2        AppleSilicon/M2  1.2   1.15     AppleSilicon/M2  1.2   1.15
```

Three spoofs capped at the modern rate. All ten honest cases byte identical to main, including the real 486 that fails clock-drift because it has no usable TSC, the Apple II on the bare `6502` string, and the client that sends no device object at all.

Console relaxation, before and after:

```
                                        BEFORE          AFTER
x86 claims modern, no clock_drift       rejected        rejected
x86 claims nes_6502, no clock_drift     ACCEPTED        rejected
x86 claims 6502, no clock_drift         ACCEPTED        rejected
HONEST 486 (vintage relax path)         accepted        accepted
HONEST G4 (vintage relax path)          unchanged       unchanged
```

### Test suites, failure sets not counts

```
tests/       main: 4 failed, 3730 passed    this PR: 4 failed, 3747 passed
             new failures vs main: none
             fixed vs main: none
             (+17 = this PR's new tests)

node/tests/  main: 98 failed, 1614 passed   this PR: 98 failed, 1614 passed
             new failures vs main: none
```

Compared as sets with `comm`, not by count, since counts move with ordering. The 4 pre-existing `tests/` failures are all in `test_epoch_settlement_formal.py` and unrelated. `ruff` on the node file: 62 errors before, 62 after. The new test file is clean.

New tests are in `tests/`, not `node/tests/`, because only `tests/` is the blocking CI job.

The 17 new tests were run against unpatched main to confirm they actually encode the defect rather than just describing the new code: **10 fail on main, 7 pass.** The 7 that pass on main are the honest-hardware cases, which is the point. They were correct before and are still correct after.

### Confirming this is on the live path

Being green means little if the code never runs, so I traced it rather than assuming:

- `/attest/submit` (line 5039) dispatches to `submit_attestation` then `_submit_attestation_impl` (5058)
- line 5404 calls `validate_fingerprint_data(fingerprint, claimed_device=device, ...)` <- relaxation fix
- line 5461 calls `record_attestation_success`, which at line 3724 calls `derive_verified_device` and at line 3753 writes the result into `miner_attest_recent (device_family, device_arch)` <- vouching fix, and this is the row settlement reads
- line 5505 calls `derive_verified_device` again for auto-enrol, then `_derive_enroll_weight_device` at 5506, then `HARDWARE_WEIGHTS` into `epoch_enroll.weight` <- vouching fix again
- settlement: `calculate_epoch_rewards_time_aged` reads `miner_attest_recent.device_arch` and calls `get_time_aged_multiplier`

Both edits sit on that path, and the vouching fix covers both the enrolment weight and the stored arch that settlement falls back to.

## This is complementary to #8087, not competing

No reviewer needs to choose between them. #8087 works on the x86 half inside `_detect_x86_vintage` and the x86 branch. This PR deliberately does not touch x86 at all: `_vouch_claimed_device` returns early for `x86`, `x86_64` and `Windows`, leaving `_detect_x86_vintage` plus the `_derive_enroll_weight_device` clamp from #8022 exactly as they are. They can merge in either order.

Note that #8022's clamp lives in `_derive_enroll_weight_device`, which is on the enrolment path only. A stored `x86/486` still reads 2.9 through `get_time_aged_multiplier` on the settlement fallback path. That gap is x86 territory and it is what #8087 addresses by making the derived identity honest, so I have left it alone rather than colliding in the same function.

## Adjacent things I found and did not fix

Three separate defects turned up while testing. All pre-existing, all unchanged by this PR, none of them in scope here. Flagging with numbers rather than quietly expanding the diff:

1. **`_detect_exotic_arch` trusts the claimed family with no corroboration.** `family="sparc"` gets `sparc_v7` at 2.9, `family="m68k"` gets `68000` at 3.0. Same class of bug as this one, but each architecture needs its own evidence design, so it wants its own PR.

2. **A real Acorn ARM2 is misclassified as Apple Silicon.** The Apple-silicon test does `any(f"m{n}" in cpu_brand_lower for n in ("1","2","3","4"))`, and `"acorn arm2"` contains `m2`. A genuine ARM2 gets 1.2 instead of 4.0. This is honest-miner harm rather than theft, which is why I have not touched it in a security PR, but it should be fixed.

3. **The honest Pico bridge miner cannot pass attestation at all.** `pico_bridge_miner.py` emits `anti_emulation.data.emulator_indicators`, while `validate_fingerprint_data` requires `vm_indicators`, so a real console miner gets `anti_emulation_no_evidence`. The asymmetry is ugly: a spoofer sending the standard modern payload with `arch=nes_6502` passed, while the honest console it was imitating did not. This PR closes the spoof side. Fixing the honest side changes who can earn, so that is your call, not mine.

## What is still open after this

The ARM and console halves are closed. The x86 settlement-fallback gap in item 1 above is #8087's. The exotic-family tiers in adjacent item 1 are untouched and still claimable.
