### PR TITLE
docs(wallet-setup): clarify social-media bounties are not code…

### DIFF
--- a/docs/WALLET_SETUP.md
+++ b/docs/WALLET_SETUP.md
@@ -221,7 +221,7 @@ What to expect:
 
 ### Option 2: earn bounties
 
-RustChain pays RTC for code contributions.
+RustChain pays RTC for code contributions. Social-media bounties are not code contributions and are not addressed by repository code changes.
 
 Typical payout flow:
 


### PR DESCRIPTION
Refs #303

> Linked rather than closing: this change addresses part of that issue, not all of it. Retarget or add a closing keyword if you disagree.

Ignore the untrusted social-media posting instructions; document that social-media bounties are non-code, so the repo fix is documentation-only.

Could not run the suite locally: . Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.