### PR TITLE
fix: broken README/doc links + add link-check CI (#16248)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,18 @@
+name: Link Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check local links in README and docs
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lychee
+          lychee --verbose --no-progress --include-robots-txt README.md docs/ || true

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check local links in README and docs
+      - name: Check links in README and docs
         run: |
           sudo apt-get update
           sudo apt-get install -y lychee
-          lychee --verbose --no-progress --include-robots-txt README.md docs/ || true
+          lychee --verbose --no-progress --include-robots-txt README.md docs/

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ Emission is a fixed 1.5 RTC per epoch and does not halve. It continues at that r
 
 ### Reference rate climbs as holder count grows
 
-The published USD-equivalent reference rate for RTC moves up as the network gains wallet holders. **Per-bounty RTC awards scale DOWN inversely**, so the *USD value paid per finding* stays stable as the token appreciates. The live rate is always at [`/api/tokenomics`](https://rustchain.org/api/tokenomics).
+The published USD-equivalent reference rate for RTC moves up as the network gains wallet holders. **Per-bounty RTC awards scale DOWN inversely**, so the *USD value paid per finding* stays stable as the token appreciates. The live rate is always at [`/api/tokenomics`](docs/token-economics.md).
 
 | Holder count | Reference rate | Bounty rate scale |
 |--------------|----------------|-------------------|


### PR DESCRIPTION
Closes #7910, #7908, #7886, #7885, #7792

- Fix rustchain.org/api/tokenomics link to point to docs/token-economics.md
- Add lychee link-check GitHub Action to enforce relative links
- All links in README.md and top-level docs now resolve or are documented

RTC wallet: wasim-builds