### PR TITLE
attractor: consensus-invariant harness

### DIFF
--- a/testing/attractor/README.md
+++ b/testing/attractor/README.md
@@ -1,0 +1,121 @@
+# Attractor — reusable adversarial test harness for consensus invariants
+
+Bounty: [Scottcjn/rustchain-bounties#12789](https://github.com/Scottcjn/rustchain-bounties/issues/12789)
+
+Attractor gives contributors **one uniform, low-interpretation way** to submit small,
+self-contained adversarial tests that pin a single RustChain consensus invariant.
+Pure stdlib, deterministic, runnable from pytest or standalone.
+
+```bash
+cd testing
+python -m attractor                       # standalone runner (exit 0 = all green)
+python -m pytest attractor/test_attractor.py -v
+```
+
+Current status: **3/3 reference invariants green on main**, 12 harness tests passing.
+
+---
+
+## 1. Submission grammar
+
+Exactly **one invariant per test**, declared with the `@invariant` decorator.
+The decorator mechanically rejects submissions that break the grammar.
+
+```python
+from attractor.harness import Ctx, invariant
+
+@invariant(
+    id="INV-<AREA>-<NNN>",            # unique, uppercase, e.g. INV-EMISSION-001
+    statement="<precise, falsifiable statement of the invariant>",  # >= 15 chars
+    scope="consensus/<subarea>",       # must contain a '/'
+    adversarial=True,                  # the test must include a hostile case
+)
+def test_<name>(ctx: Ctx) -> None:
+    """One sentence naming the adversary (replay, reorder, casing, overflow, ...)."""
+    adv = ctx.adversary("replay-storm")
+    ...
+    ctx.check(<condition>, "<why this check supports the invariant>")  # >= 1 required
+```
+
+Rules enforced in code (`attractor/harness.py`):
+
+| Rule | Enforced by |
+|---|---|
+| `id` matches `INV-<AREA>-<NNN>` and is unique | `ID_RE`, `REGISTRY` duplicate guard |
+| `statement` is descriptive (>= 15 chars) | `invariant()` |
+| `scope` is `area/subarea` | `invariant()` |
+| Test performs at least one `ctx.check()` | wrapper + `run_all()` |
+| Every `ctx.check()` carries a reason (>= 8 chars) | `Ctx.check()` |
+| Failure message names the invariant id and statement | `InvariantViolation` |
+| No wall clock, no network, seeded RNG only | `Ctx.rng = random.Random(seed)` |
+
+Adversary helpers (`ctx.adversary(name)`): `replay(items, times)`,
+`shuffle(items)`, `inject(items, payload, count)` — they make the hostile intent
+of a test explicit and reviewable at a glance.
+
+**File layout for a submission**
+
+```
+testing/attractor/
+  harness.py        # do not modify in a submission PR
+  models.py         # add the rule you are pinning, if not present
+  examples.py       # or contributions/<your_invariant>.py — the new @invariant
+  test_attractor.py # register the new id in the parametrized green-list
+```
+
+---
+
+## 2. Acceptance rubric (objective)
+
+A submission is **ACCEPTED** only if all of A1–A7 hold:
+
+| # | Criterion | How a reviewer checks it |
+|---|---|---|
+| A1 | Grammar-valid | `python -m attractor` imports it without `HarnessUsageError` |
+| A2 | Exactly one invariant per test | one `@invariant` per function; no bundled asserts about unrelated rules |
+| A3 | Green on current `main` | `python -m attractor` exits 0; `pytest attractor/ -q` passes |
+| A4 | Deterministic / non-flaky | 5 repeated runs at the same seed produce identical check lists (covered by `test_reference_invariants_are_deterministic`) |
+| A5 | Genuinely adversarial | the test constructs a hostile input (replay, reorder, casing mutation, boundary/overflow, double-submit) — not a happy path only |
+| A6 | Non-tautological | the test fails if the pinned rule is inverted; the author states in the PR body *which one-line change to `models.py` turns it red* |
+| A7 | Documented invariant | `statement` reads as a falsifiable claim about consensus, and the docstring names the adversary |
+
+**REJECTED** if any of R1–R5 hold:
+
+| # | Reject reason |
+|---|---|
+| R1 | Flaky: differs between runs, uses `time`, `os.urandom`, network, or unseeded randomness |
+| R2 | Tautology: asserts `x == x`, re-asserts a literal, or only checks the code it just called returned what it returned |
+| R3 | Multi-invariant blob: one test pinning several unrelated rules (split it) |
+| R4 | Vague statement/scope that a future reviewer cannot evaluate consistently |
+| R5 | Modifies `harness.py` semantics to make a test pass, or duplicates an existing invariant id |
+
+Scoring is binary per row — no subjective weighting, so two reviewers reach the
+same verdict.
+
+---
+
+## 3. Reference invariants (all green on main)
+
+| id | Invariant pinned | Adversary |
+|---|---|---|
+| `INV-EMISSION-001` | rewards minted per epoch == declared emission for that epoch (across halvings) | skewed share weights that maximise integer-division rounding loss; re-mint of an already-minted epoch |
+| `INV-ENROLL-002` | no miner can be enrolled twice, regardless of address casing or order | 3x replayed + shuffled + case-mutated enrollment stream; malformed address |
+| `INV-SETTLE-003` | settlement is idempotent: replaying a payout id never moves balance twice | 4x replay storm interleaved with unrelated payouts |
+
+Each one satisfies A6: e.g. deleting the remainder-distribution loop in
+`RewardLedger.mint_epoch` turns `INV-EMISSION-001` red; dropping `.lower()` in
+`MinerRegistry.canonical` turns `INV-ENROLL-002` red; removing the `applied`
+set-check in `Settlement.settle` turns `INV-SETTLE-003` red.
+
+`models.py` holds minimal, readable reference implementations of the rules under
+test. As production consensus code is wired in, an invariant test can point at
+the real module instead — the grammar and rubric are unchanged.
+
+---
+
+## 4. Why this grows the regression suite cheaply
+
+* Reviewers apply a 12-row checklist instead of reading each test from scratch.
+* Every accepted test is self-registering: `REGISTRY` is the machine-readable
+  index of everything consensus currently guarantees.
+* A red invariant names the exact rule that broke, in one line, in CI output.

--- a/testing/attractor/__init__.py
+++ b/testing/attractor/__init__.py
@@ -1,0 +1,23 @@
+"""Attractor: reusable adversarial test harness for RustChain consensus invariants."""
+
+from .harness import (  # noqa: F401
+    REGISTRY,
+    Adversary,
+    Ctx,
+    HarnessUsageError,
+    InvariantSpec,
+    InvariantViolation,
+    invariant,
+    run_all,
+)
+
+__all__ = [
+    "REGISTRY",
+    "Adversary",
+    "Ctx",
+    "HarnessUsageError",
+    "InvariantSpec",
+    "InvariantViolation",
+    "invariant",
+    "run_all",
+]

--- a/testing/attractor/__main__.py
+++ b/testing/attractor/__main__.py
@@ -1,0 +1,8 @@
+"""Standalone runner: `python -m attractor` (from the `testing/` directory)."""
+
+import sys
+
+from attractor import examples  # noqa: F401  (registers the reference invariants)
+from attractor.harness import run_all
+
+sys.exit(run_all())

--- a/testing/attractor/examples.py
+++ b/testing/attractor/examples.py
@@ -1,0 +1,108 @@
+"""Reference invariant tests. Each one pins exactly one stated invariant.
+
+Copy any of these as the template for a new attractor submission.
+"""
+
+from __future__ import annotations
+
+from .harness import Ctx, invariant
+from .models import ConsensusError, EmissionSchedule, MinerRegistry, RewardLedger, Settlement
+
+
+@invariant(
+    id="INV-EMISSION-001",
+    statement="rewards minted per epoch == declared emission for that epoch",
+    scope="consensus/emission",
+    adversarial=True,
+)
+def test_emission_conserved(ctx: Ctx) -> None:
+    """Adversary: skewed share distributions that maximise rounding loss."""
+    schedule = EmissionSchedule()
+    adv = ctx.adversary("rounding-skew")
+    for epoch in (0, 1, 99, 100, 250):
+        ledger = RewardLedger(schedule)
+        miners = [f"m{i}" for i in range(7)]
+        shares = {m: adv.rng.choice([1, 1, 1, 2, 9973]) for m in miners}
+        payouts = ledger.mint_epoch(epoch, shares)
+        declared = schedule.declared_for_epoch(epoch)
+        ctx.check(
+            sum(payouts.values()) == declared,
+            f"epoch {epoch}: minted {sum(payouts.values())} must equal declared {declared}",
+        )
+        ctx.check(
+            all(v >= 0 for v in payouts.values()),
+            f"epoch {epoch}: no payout may be negative",
+        )
+    # Hostile: double-minting the same epoch must be rejected, not silently doubled.
+    ledger = RewardLedger(schedule)
+    ledger.mint_epoch(3, {"a": 1})
+    try:
+        ledger.mint_epoch(3, {"a": 1})
+        doubled = True
+    except ConsensusError:
+        doubled = False
+    ctx.check(not doubled, "re-minting an already minted epoch must raise, not inflate supply")
+
+
+@invariant(
+    id="INV-ENROLL-002",
+    statement="no miner can be enrolled twice, regardless of address casing or order",
+    scope="consensus/enrollment",
+    adversarial=True,
+)
+def test_no_double_enrollment(ctx: Ctx) -> None:
+    """Adversary: replayed, reordered and case-mutated enrollment requests."""
+    base = [f"0x{i:040x}" for i in range(1, 13)]
+    adv = ctx.adversary("replay-case")
+    hostile = adv.shuffle(adv.replay(base, times=3))
+    hostile += [a.upper().replace("0X", "0x") for a in base]
+    hostile = adv.shuffle(hostile)
+
+    reg = MinerRegistry()
+    accepted = reg.enroll_many(hostile)
+    ctx.check(
+        len(reg) == len(base),
+        f"registry holds {len(reg)} miners; exactly {len(base)} unique miners were offered",
+    )
+    ctx.check(
+        sum(accepted) == len(base),
+        "exactly one enrollment per unique miner may be accepted",
+    )
+    try:
+        reg.enroll("0xdeadbeef")
+        rejected = False
+    except ConsensusError:
+        rejected = True
+    ctx.check(rejected, "malformed addresses must be rejected instead of enrolled")
+
+
+@invariant(
+    id="INV-SETTLE-003",
+    statement="settlement is idempotent: replaying a payout id never moves balance twice",
+    scope="consensus/settlement",
+    adversarial=True,
+)
+def test_settlement_idempotent(ctx: Ctx) -> None:
+    """Adversary: replay storm interleaved with unrelated payouts."""
+    adv = ctx.adversary("replay-storm")
+    payouts = [(f"p{i}", f"0x{i:040x}", 10 + i) for i in range(1, 9)]
+    stream = adv.shuffle(adv.replay(payouts, times=4))
+
+    s = Settlement()
+    for pid, addr, amt in stream:
+        s.settle(pid, addr, amt)
+
+    expected_total = sum(amt for _, _, amt in payouts)
+    ctx.check(
+        sum(s.balances.values()) == expected_total,
+        f"total settled {sum(s.balances.values())} must equal {expected_total} despite 4x replay",
+    )
+    for pid, addr, amt in payouts:
+        ctx.check(
+            s.balances[addr] == amt,
+            f"{addr} credited exactly once for {pid}",
+        )
+    ctx.check(
+        s.settle("p1", "0x" + "1" * 40, 999) is False,
+        "a re-settled payout id must report False and leave balances untouched",
+    )

--- a/testing/attractor/harness.py
+++ b/testing/attractor/harness.py
@@ -1,0 +1,154 @@
+"""Attractor consensus-invariant harness.
+
+A tiny, dependency-free harness that gives contributors a single, uniform way to
+submit *one invariant per test* against RustChain consensus behaviour.
+
+Grammar (enforced by :func:`invariant` and :func:`check`):
+
+    @invariant(
+        id="INV-EMISSION-001",              # stable, unique, uppercase id
+        statement="rewards minted per epoch == declared emission",
+        scope="consensus/emission",
+        adversarial=True,                   # test must include a hostile case
+    )
+    def test_something(ctx):
+        ctx.check(actual == expected, "why this pins the invariant")
+
+Design goals
+------------
+* Deterministic: the harness seeds its own RNG; no wall-clock, no network.
+* Self-contained: pure stdlib, importable from pytest or run standalone.
+* Objectively reviewable: every registered invariant carries machine-checkable
+  metadata, so the acceptance rubric in README.md can be applied mechanically.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List
+
+ID_RE = re.compile(r"^INV-[A-Z0-9]+(-[A-Z0-9]+)*-\d{3}$")
+
+REGISTRY: Dict[str, "InvariantSpec"] = {}
+
+
+class InvariantViolation(AssertionError):
+    """Raised when an invariant assertion fails."""
+
+
+class HarnessUsageError(ValueError):
+    """Raised when a submission violates the submission grammar."""
+
+
+@dataclass(frozen=True)
+class InvariantSpec:
+    id: str
+    statement: str
+    scope: str
+    adversarial: bool
+    func: Callable[["Ctx"], None]
+
+
+@dataclass
+class Ctx:
+    """Execution context handed to every invariant test."""
+
+    spec: InvariantSpec
+    seed: int = 1337
+    rng: random.Random = field(init=False)
+    checks: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.rng = random.Random(self.seed)
+
+    def check(self, condition: bool, reason: str) -> None:
+        """Assert one fact that supports the invariant."""
+        if not reason or len(reason) < 8:
+            raise HarnessUsageError("ctx.check() requires a descriptive reason")
+        self.checks.append(reason)
+        if not condition:
+            raise InvariantViolation(
+                f"{self.spec.id} violated: {self.spec.statement} :: {reason}"
+            )
+
+    def adversary(self, name: str) -> "Adversary":
+        return Adversary(name, self.rng)
+
+
+@dataclass
+class Adversary:
+    """Small helper to make the hostile intent of a test explicit."""
+
+    name: str
+    rng: random.Random
+
+    def replay(self, items: List[Any], times: int = 2) -> List[Any]:
+        """Duplicate every item `times` times (replay / double-submit attack)."""
+        return [x for x in items for _ in range(times)]
+
+    def shuffle(self, items: List[Any]) -> List[Any]:
+        out = list(items)
+        self.rng.shuffle(out)
+        return out
+
+    def inject(self, items: List[Any], payload: Any, count: int = 1) -> List[Any]:
+        out = list(items)
+        for _ in range(count):
+            out.insert(self.rng.randrange(len(out) + 1), payload)
+        return out
+
+
+def invariant(*, id: str, statement: str, scope: str, adversarial: bool = True):
+    """Register exactly one invariant. Enforces the submission grammar."""
+
+    def deco(func: Callable[[Ctx], None]) -> Callable[..., None]:
+        if not ID_RE.match(id):
+            raise HarnessUsageError(
+                f"invariant id {id!r} must match INV-<AREA>-<NNN> (uppercase)"
+            )
+        if id in REGISTRY:
+            raise HarnessUsageError(f"duplicate invariant id {id!r}")
+        if len(statement) < 15:
+            raise HarnessUsageError("statement must describe the invariant precisely")
+        if "/" not in scope:
+            raise HarnessUsageError("scope must look like 'area/subarea'")
+        spec = InvariantSpec(id, statement, scope, adversarial, func)
+        REGISTRY[id] = spec
+
+        def wrapper(*_args: Any, **_kwargs: Any) -> None:
+            ctx = Ctx(spec)
+            func(ctx)
+            if not ctx.checks:
+                raise HarnessUsageError(f"{id} performed no ctx.check() calls")
+
+        wrapper.__name__ = func.__name__
+        wrapper.__doc__ = f"[{id}] {statement}"
+        wrapper.invariant_spec = spec  # type: ignore[attr-defined]
+        return wrapper
+
+    return deco
+
+
+def run_all() -> int:
+    """Standalone runner: `python -m attractor.harness`. Returns exit code."""
+    failures = 0
+    for spec in REGISTRY.values():
+        ctx = Ctx(spec)
+        try:
+            spec.func(ctx)
+            if not ctx.checks:
+                raise HarnessUsageError(f"{spec.id} performed no ctx.check() calls")
+            print(f"PASS {spec.id}  {spec.statement}")
+        except Exception as exc:  # noqa: BLE001 - report, don't crash the suite
+            failures += 1
+            print(f"FAIL {spec.id}  {exc}")
+    print(f"\n{len(REGISTRY) - failures}/{len(REGISTRY)} invariants green")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print("run the suite with: python -m attractor", file=sys.stderr)
+    sys.exit(2)

--- a/testing/attractor/models.py
+++ b/testing/attractor/models.py
@@ -1,0 +1,109 @@
+"""Minimal reference models of the RustChain consensus rules under test.
+
+These are *pins*: deliberately small, readable re-implementations of the rules
+that the real node must obey. An example invariant test exercises the model
+adversarially; when the production code diverges from a rule, the rule is
+ported here and the corresponding invariant starts failing loudly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Set
+
+
+class ConsensusError(Exception):
+    pass
+
+
+# --- emission -------------------------------------------------------------
+
+@dataclass(frozen=True)
+class EmissionSchedule:
+    """Declared emission: `base` RTC per epoch, halving every `halving` epochs."""
+
+    base: int = 50
+    halving: int = 100
+
+    def declared_for_epoch(self, epoch: int) -> int:
+        if epoch < 0:
+            raise ConsensusError("epoch must be non-negative")
+        return self.base >> (epoch // self.halving)
+
+
+@dataclass
+class RewardLedger:
+    schedule: EmissionSchedule = field(default_factory=EmissionSchedule)
+    minted: Dict[int, int] = field(default_factory=dict)
+
+    def mint_epoch(self, epoch: int, shares: Dict[str, int]) -> Dict[str, int]:
+        """Split the declared emission across miners by share weight.
+
+        Remainder from integer division is assigned deterministically (sorted
+        miner order) so the sum always equals the declared emission exactly.
+        """
+        if epoch in self.minted:
+            raise ConsensusError(f"epoch {epoch} already minted")
+        total = self.schedule.declared_for_epoch(epoch)
+        weight = sum(shares.values())
+        if weight <= 0:
+            raise ConsensusError("no positive shares for epoch")
+        payouts: Dict[str, int] = {}
+        for miner in sorted(shares):
+            payouts[miner] = total * shares[miner] // weight
+        remainder = total - sum(payouts.values())
+        for miner in sorted(shares):
+            if remainder == 0:
+                break
+            payouts[miner] += 1
+            remainder -= 1
+        self.minted[epoch] = sum(payouts.values())
+        return payouts
+
+
+# --- enrollment -----------------------------------------------------------
+
+@dataclass
+class MinerRegistry:
+    """Enrollment set keyed by canonical (lowercased) wallet address."""
+
+    _enrolled: Set[str] = field(default_factory=set)
+
+    @staticmethod
+    def canonical(address: str) -> str:
+        addr = address.strip().lower()
+        if not addr.startswith("0x") or len(addr) != 42:
+            raise ConsensusError(f"malformed address: {address!r}")
+        return addr
+
+    def enroll(self, address: str) -> bool:
+        addr = self.canonical(address)
+        if addr in self._enrolled:
+            return False
+        self._enrolled.add(addr)
+        return True
+
+    def enroll_many(self, addresses: Iterable[str]) -> List[bool]:
+        return [self.enroll(a) for a in addresses]
+
+    def __len__(self) -> int:
+        return len(self._enrolled)
+
+
+# --- settlement -----------------------------------------------------------
+
+@dataclass
+class Settlement:
+    """Idempotent settlement: each payout id may only move balance once."""
+
+    balances: Dict[str, int] = field(default_factory=dict)
+    applied: Set[str] = field(default_factory=set)
+
+    def settle(self, payout_id: str, address: str, amount: int) -> bool:
+        if amount < 0:
+            raise ConsensusError("negative settlement amount")
+        if payout_id in self.applied:
+            return False
+        self.applied.add(payout_id)
+        self.balances[address] = self.balances.get(address, 0) + amount
+        return True

--- a/testing/attractor/test_attractor.py
+++ b/testing/attractor/test_attractor.py
@@ -1,0 +1,117 @@
+"""Tests for the attractor harness itself + the reference invariants.
+
+Run:  pytest testing/attractor/test_attractor.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from attractor import HarnessUsageError, InvariantViolation, invariant  # noqa: E402
+from attractor.harness import REGISTRY, Ctx, InvariantSpec  # noqa: E402
+from attractor import examples  # noqa: E402,F401  (registers reference invariants)
+
+
+# --- the three reference invariants must be green -------------------------
+
+@pytest.mark.parametrize("inv_id", ["INV-EMISSION-001", "INV-ENROLL-002", "INV-SETTLE-003"])
+def test_reference_invariant_is_green(inv_id):
+    spec = REGISTRY[inv_id]
+    ctx = Ctx(spec)
+    spec.func(ctx)
+    assert ctx.checks, "an invariant test must perform at least one ctx.check()"
+
+
+def test_reference_invariants_are_deterministic():
+    """Same seed, same result: no flaky submissions allowed."""
+    for spec in REGISTRY.values():
+        for _ in range(5):
+            ctx = Ctx(spec, seed=1337)
+            spec.func(ctx)
+            first = list(ctx.checks)
+            ctx2 = Ctx(spec, seed=1337)
+            spec.func(ctx2)
+            assert ctx2.checks == first
+
+
+def test_registry_metadata_is_complete():
+    assert len(REGISTRY) >= 3
+    for inv_id, spec in REGISTRY.items():
+        assert isinstance(spec, InvariantSpec)
+        assert spec.id == inv_id
+        assert "/" in spec.scope
+        assert len(spec.statement) >= 15
+        assert spec.adversarial is True
+
+
+# --- grammar enforcement ---------------------------------------------------
+
+def test_rejects_bad_id():
+    with pytest.raises(HarnessUsageError):
+        @invariant(id="bad id", statement="something that is long enough", scope="a/b")
+        def _f(ctx):  # pragma: no cover
+            ctx.check(True, "never runs")
+
+
+def test_rejects_duplicate_id():
+    @invariant(id="INV-DUP-900", statement="a duplicate id must be refused", scope="a/b")
+    def _f(ctx):  # pragma: no cover
+        ctx.check(True, "placeholder check")
+
+    with pytest.raises(HarnessUsageError):
+        @invariant(id="INV-DUP-900", statement="a duplicate id must be refused", scope="a/b")
+        def _g(ctx):  # pragma: no cover
+            ctx.check(True, "placeholder check")
+
+
+def test_rejects_vague_statement_and_scope():
+    with pytest.raises(HarnessUsageError):
+        @invariant(id="INV-VAGUE-901", statement="short", scope="a/b")
+        def _f(ctx):  # pragma: no cover
+            ctx.check(True, "placeholder check")
+
+    with pytest.raises(HarnessUsageError):
+        @invariant(id="INV-VAGUE-902", statement="a sufficiently long statement", scope="noslash")
+        def _g(ctx):  # pragma: no cover
+            ctx.check(True, "placeholder check")
+
+
+def test_rejects_test_without_checks():
+    @invariant(id="INV-EMPTY-903", statement="tests must assert something real", scope="a/b")
+    def _f(ctx):
+        return None
+
+    with pytest.raises(HarnessUsageError):
+        _f()
+
+
+def test_check_requires_reason():
+    spec = REGISTRY["INV-SETTLE-003"]
+    ctx = Ctx(spec)
+    with pytest.raises(HarnessUsageError):
+        ctx.check(True, "x")
+
+
+def test_violation_is_reported():
+    @invariant(id="INV-FAIL-904", statement="a failing invariant must raise", scope="a/b")
+    def _f(ctx):
+        ctx.check(False, "this condition is deliberately false")
+
+    with pytest.raises(InvariantViolation) as exc:
+        _f()
+    assert "INV-FAIL-904" in str(exc.value)
+
+
+# --- adversary helpers -----------------------------------------------------
+
+def test_adversary_helpers():
+    ctx = Ctx(REGISTRY["INV-ENROLL-002"])
+    adv = ctx.adversary("t")
+    assert adv.replay([1, 2], times=3) == [1, 1, 1, 2, 2, 2]
+    assert sorted(adv.shuffle([1, 2, 3, 4])) == [1, 2, 3, 4]
+    assert adv.inject([1, 2, 3], 9, count=2).count(9) == 2


### PR DESCRIPTION
Closes Scottcjn/rustchain-bounties#12789 — *Attractor: design a reusable adversarial test harness for consensus invariants*.

Adds `testing/attractor/`: a dependency-free, deterministic harness that gives future
contributors **one uniform way** to submit small self-contained adversarial tests that
pin a single consensus invariant — plus the submission grammar, an objective accept/reject
rubric, and 3 example invariant tests that are green on `main`.

```
cd testing
python -m attractor                                # 3/3 invariants green, exit 0
python -m pytest attractor/test_attractor.py -q    # 12 passed
```

## 1. Reusable template / submission grammar

One invariant per test, declared with `@invariant`. The decorator *mechanically rejects*
malformed submissions, so review cost is near zero.

```python
from attractor.harness import Ctx, invariant

@invariant(
    id="INV-<AREA>-<NNN>",                                          # unique, uppercase
    statement="<precise, falsifiable statement of the invariant>",  # >= 15 chars
    scope="consensus/<subarea>",                                    # must contain '/'
    adversarial=True,                                               # hostile case required
)
def test_<name>(ctx: Ctx) -> None:
    """One sentence naming the adversary (replay, reorder, casing, boundary, ...)."""
    adv = ctx.adversary("replay-storm")
    ...
    ctx.check(<condition>, "<why this check supports the invariant>")
```

Enforced in code (`attractor/harness.py`), each with a test in `test_attractor.py`:

| Rule | Enforced by |
|---|---|
| `id` matches `INV-<AREA>-<NNN>` and is unique | `ID_RE` + `REGISTRY` duplicate guard |
| `statement` descriptive (>= 15 chars) | `invariant()` |
| `scope` is `area/subarea` | `invariant()` |
| At least one `ctx.check()` per test | wrapper + `run_all()` |
| Every check carries a reason (>= 8 chars) | `Ctx.check()` |
| Failure names the invariant id + statement | `InvariantViolation` |
| No wall clock / network; seeded RNG only | `Ctx.rng = random.Random(seed)` |

Adversary helpers make hostile intent explicit and reviewable: `replay()`, `shuffle()`, `inject()`.

## 2. Acceptance rubric (binary, no subjective weighting)

**ACCEPT** only if all hold:

| # | Criterion | Reviewer check |
|---|---|---|
| A1 | Grammar-valid | imports without `HarnessUsageError` |
| A2 | Exactly one invariant per test | one `@invariant`, no bundled unrelated asserts |
| A3 | Green on current `main` | `python -m attractor` exits 0; `pytest attractor/ -q` passes |
| A4 | Deterministic / non-flaky | 5 runs at same seed give identical check lists (auto-tested) |
| A5 | Genuinely adversarial | constructs replay / reorder / casing / boundary / double-submit input |
| A6 | Non-tautological | PR body states the one-line change to `models.py` that turns it red |
| A7 | Documented invariant | falsifiable `statement`; docstring names the adversary |

**REJECT** if: R1 flaky (`time`, `os.urandom`, network, unseeded RNG) · R2 tautology (`x == x`)
· R3 multi-invariant blob · R4 statement/scope too vague to evaluate consistently
· R5 weakens `harness.py` to pass, or duplicates an existing id.

## 3. Example invariant tests (all green on main)

| id | Invariant pinned | Adversary | Turns red if… (A6) |
|---|---|---|---|
| `INV-EMISSION-001` | rewards minted per epoch == declared emission for that epoch, across halvings | share weights skewed to maximise integer-division rounding loss; re-mint of an already-minted epoch | delete the remainder-distribution loop in `RewardLedger.mint_epoch` |
| `INV-ENROLL-002` | no miner enrolled twice, regardless of address casing or ordering | 3x replayed + shuffled + case-mutated enrollment stream; malformed address | drop `.lower()` in `MinerRegistry.canonical` |
| `INV-SETTLE-003` | settlement is idempotent: replaying a payout id never moves balance twice | 4x replay storm interleaved with unrelated payouts | remove the `applied` set-check in `Settlement.settle` |

`models.py` holds minimal, readable reference implementations of the rules under test; as
production consensus modules are wired in, an invariant can point at the real module —
grammar and rubric are unchanged. `REGISTRY` doubles as a machine-readable index of
everything consensus currently guarantees.

## Files added

- `testing/attractor/harness.py` — grammar enforcement, `Ctx`, `Adversary`, standalone runner
- `testing/attractor/models.py` — reference emission / enrollment / settlement rules
- `testing/attractor/examples.py` — the 3 reference invariants
- `testing/attractor/test_attractor.py` — 12 tests: green-list, determinism, grammar rejection, helpers
- `testing/attractor/README.md` — template + full rubric
- `testing/attractor/__init__.py`, `__main__.py`

Pure stdlib, no new dependencies, nothing outside `testing/attractor/` is touched.
