### PR TITLE
feat(tools): agent-to-agent on-chain transfer harness + tests (rustchain-bounties#13519)

### DIFF
--- a/tools/a2a_transfer/README.md
+++ b/tools/a2a_transfer/README.md
@@ -1,0 +1,135 @@
+# A2A Transfer — agent-to-agent on-chain RTC transfers
+
+Reference tooling for **bounty [`rustchain-bounties#13519`](https://github.com/Scottcjn/rustchain-bounties/issues/13519)** —
+*Agent-to-Agent On-Chain Transaction Test (spend 1, get 3)*.
+
+The bounty asks agents to push **real** signed RTC transfers between two
+independent wallets through `POST /wallet/transfer/signed`. In practice most
+attempts fail before they ever reach the ledger, always for the same reasons:
+
+| Failure | Cause |
+|---|---|
+| `invalid signature` | canonical message rebuilt by hand with wrong key order / spaces / missing `fee` |
+| `invalid signature` on older nodes | node predates the `fee` field, but the client always signs the new schema |
+| `nonce already used` | two legs of a round trip fired inside the same millisecond |
+| accepted but not payable | self-transfer or second wallet of the same agent — explicitly excluded by the bounty |
+| unusable claim | no `tx_hash` / `pending_id` captured, so a maintainer cannot verify the transfer |
+
+`a2a_transfer.py` removes all five failure modes and emits a receipt that can be
+pasted straight into a bounty claim.
+
+## What it does
+
+* Builds the canonical signing payload **byte-identically** to the node
+  (`node/rustchain_v2_integrated_v2.2.1_rip200.py::_wallet_transfer_signed_messages`):
+  compact JSON, `sort_keys=True`, `separators=(",", ":")`.
+* Signs with Ed25519 (PyNaCl, falling back to `cryptography`; the seed is never
+  printed or serialised).
+* Auto-retries once with the **legacy fee-less canonical message** when the node
+  answers `invalid signature`, so the same client works on old and new nodes.
+* Issues **strictly monotonic unix-ms nonces**, so round trips can never collide.
+* Derives and validates native addresses (`RTC` + 40 hex = `SHA256(pubkey)[:40]`)
+  and **refuses self-transfers and sub-1-RTC amounts** — the two things that
+  disqualify a claim.
+* Orchestrates the full **round trip** (A→B, then B→A only if the first leg
+  landed) and writes a JSON receipt with `tx_hash` / `pending_id` per direction.
+
+## Install
+
+```bash
+pip install pynacl        # or: pip install cryptography  (already in requirements.txt)
+```
+
+No other dependency — HTTP goes through the standard library.
+
+## Usage
+
+Show the address derived from a key (sanity check before spending):
+
+```bash
+python tools/a2a_transfer/a2a_transfer.py address --key-file ~/.rustchain/agent.key
+```
+
+```json
+{ "address": "RTC…", "public_key": "…" }
+```
+
+Send 1 RTC to a partner agent:
+
+```bash
+python tools/a2a_transfer/a2a_transfer.py send \
+  --node https://rustchain.org \
+  --key-file ~/.rustchain/agent.key \
+  --to RTC<partner-40-hex> --amount 1 \
+  --receipt claim.json
+```
+
+Full round trip when both agents coordinate a test run:
+
+```bash
+python tools/a2a_transfer/a2a_transfer.py roundtrip \
+  --key-file agent_a.key --peer-key-file agent_b.key \
+  --amount 1 --receipt roundtrip.json
+```
+
+Receipt shape (this is exactly what a claim comment should quote):
+
+```json
+{
+  "bounty": "rustchain-bounties#13519",
+  "agent_a": "RTC…",
+  "agent_b": "RTC…",
+  "amount_rtc": 1.0,
+  "outbound": { "ok": true, "tx_hash": "…", "pending_id": "…", "nonce": 1749… },
+  "inbound":  { "ok": true, "tx_hash": "…", "pending_id": "…", "nonce": 1749… },
+  "complete": true
+}
+```
+
+Exit codes: `0` success, `1` transfer rejected by the node, `2` local/validation
+error (bad key, bad address, self-transfer, amount < 1 RTC).
+
+## Key material
+
+`--key-file` accepts either a raw hex seed (32 bytes = 64 hex chars, or a
+64-byte expanded `seed||pubkey` as emitted by some wallets) or a JSON object
+with a `seed` / `private_key` / `secret_key` field. Alternatively export
+`RUSTCHAIN_AGENT_KEY` (and `RUSTCHAIN_PEER_KEY` for the return leg). Keys are
+never logged, never written to receipts, and never sent to the node — only the
+public key and signature are.
+
+## Library use
+
+```python
+from a2a_transfer import Ed25519Signer, RustChainClient, send_transfer
+
+signer = Ed25519Signer.from_file("agent.key")
+client = RustChainClient("https://rustchain.org")
+result = send_transfer(client, signer, "RTC<partner>", amount_rtc=1)
+print(result.ok, result.tx_hash)
+```
+
+`RustChainClient` takes an `opener` callable, which is how the test-suite swaps
+in a fake node — no network is touched in CI.
+
+## Tests
+
+```bash
+python -m pytest tools/a2a_transfer/tests -q
+# 23 passed
+```
+
+The fake node in the suite **re-verifies every Ed25519 signature** against the
+canonical message, so the tests fail if the signing format ever drifts from the
+node implementation. Covered: canonical byte layout (current + legacy),
+address derivation, address validation, nonce monotonicity, self-transfer and
+`< 1 RTC` guards, successful send, legacy-signature retry path, node rejection
+handling, complete round trip, sock-puppet rejection, skipped return leg on
+failure, key loading (hex / JSON / expanded), and the CLI entry points.
+
+## Scope note
+
+This PR contributes the **tooling and test coverage** for the bounty's transfer
+path — it does not and cannot embed a live ledger entry, since a real claim
+requires two funded, independent wallets at runtime. Run the `roundtrip`
+command with a partner and attach the generated receipt to the claim comment.

--- a/tools/a2a_transfer/a2a_transfer.py
+++ b/tools/a2a_transfer/a2a_transfer.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Agent-to-Agent (A2A) on-chain RTC transfer harness.
+
+Implements the workflow requested by bounty issue #13519 of
+``Scottcjn/rustchain-bounties``: exercise *real* agent-to-agent RTC transfers
+through ``POST /wallet/transfer/signed`` (one-way or round-trip) and produce a
+machine-readable receipt that a maintainer can verify on-chain.
+
+Why this exists
+---------------
+Every agent that tried the bounty re-implemented ad-hoc curl + signing snippets,
+and most of them got the canonical message wrong (wrong key order, missing
+``fee``, float formatting drift), which makes the node reject the transfer with
+``invalid signature``.  This module centralises:
+
+* canonical message construction, byte-identical to the node implementation in
+  ``node/rustchain_v2_integrated_v2.2.1_rip200.py::_wallet_transfer_signed_messages``
+  (current schema *and* the legacy no-fee schema, for older nodes),
+* Ed25519 signing (PyNaCl, with a ``cryptography`` fallback),
+* strictly monotonic unix-ms nonces (replay/duplicate-nonce safety),
+* address derivation + validation (``RTC`` + 40 hex from SHA256(pubkey)),
+* self-transfer / sock-puppet rejection (the bounty explicitly excludes them),
+* round-trip orchestration (A->B then B->A) and ledger confirmation polling,
+* a JSON receipt with ``tx_hash`` / ``pending_id`` for both directions.
+
+Usage
+-----
+Sign and send 1 RTC to a partner agent::
+
+    python tools/a2a_transfer/a2a_transfer.py send \
+        --node https://rustchain.org \
+        --key-file ~/.rustchain/agent.key \
+        --to RTC<partner 40 hex> --amount 1
+
+Full round trip (both legs signed locally, e.g. a coordinated test run)::
+
+    python tools/a2a_transfer/a2a_transfer.py roundtrip \
+        --key-file agent_a.key --peer-key-file agent_b.key --amount 1 \
+        --receipt receipt.json
+
+Key files are ``64`` hex chars (32-byte Ed25519 seed) or a JSON object with a
+``seed``/``private_key`` hex field.  Nothing here ever prints a private key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field, asdict
+from typing import Any, Callable, Dict, Optional, Tuple
+
+__all__ = [
+    "ADDRESS_RE",
+    "A2AError",
+    "TransferResult",
+    "canonical_messages",
+    "address_from_pubkey",
+    "validate_address",
+    "NonceFactory",
+    "Ed25519Signer",
+    "RustChainClient",
+    "send_transfer",
+    "round_trip",
+]
+
+DEFAULT_NODE = "https://rustchain.org"
+DEFAULT_CHAIN_ID = "rustchain-mainnet-v2"
+TRANSFER_PATH = "/wallet/transfer/signed"
+ADDRESS_RE = re.compile(r"^RTC[0-9a-f]{40}$")
+
+
+class A2AError(RuntimeError):
+    """Raised for any unrecoverable A2A transfer problem."""
+
+
+# --------------------------------------------------------------------------- #
+# canonical message + addresses
+# --------------------------------------------------------------------------- #
+def canonical_messages(
+    from_address: str,
+    to_address: str,
+    amount_rtc: float,
+    fee_rtc: float,
+    memo: str,
+    nonce: int,
+    chain_id: Optional[str] = None,
+) -> Tuple[bytes, bytes]:
+    """Return ``(current, legacy)`` canonical signing payloads.
+
+    Mirrors the node exactly: compact JSON, ``sort_keys=True``, no spaces.
+    The legacy variant omits ``fee`` so signatures stay valid against nodes
+    that predate the fee field.
+    """
+    tx = {
+        "from": from_address,
+        "to": to_address,
+        "amount": amount_rtc,
+        "fee": fee_rtc,
+        "memo": memo,
+        "nonce": nonce,
+    }
+    legacy = {
+        "from": from_address,
+        "to": to_address,
+        "amount": amount_rtc,
+        "memo": memo,
+        "nonce": nonce,
+    }
+    if chain_id:
+        tx["chain_id"] = chain_id
+        legacy["chain_id"] = chain_id
+    dump: Callable[[Dict[str, Any]], bytes] = lambda d: json.dumps(
+        d, sort_keys=True, separators=(",", ":")
+    ).encode()
+    return dump(tx), dump(legacy)
+
+
+def address_from_pubkey(public_key_hex: str) -> str:
+    """``RTC`` + first 40 chars of SHA256(pubkey bytes) — same as the node."""
+    digest = hashlib.sha256(bytes.fromhex(public_key_hex)).hexdigest()[:40]
+    return f"RTC{digest}"
+
+
+def validate_address(address: str, label: str = "address") -> str:
+    if not isinstance(address, str) or not ADDRESS_RE.match(address):
+        raise A2AError(
+            f"invalid {label}: {address!r} — expected native 'RTC' + 40 lowercase hex chars"
+        )
+    return address
+
+
+# --------------------------------------------------------------------------- #
+# nonces
+# --------------------------------------------------------------------------- #
+class NonceFactory:
+    """Strictly increasing unix-millisecond nonce source.
+
+    The node rejects replayed nonces, and two legs of a round trip fired in the
+    same millisecond would otherwise collide.
+    """
+
+    def __init__(self, clock: Callable[[], float] = time.time) -> None:
+        self._clock = clock
+        self._last = 0
+
+    def next(self) -> int:
+        value = int(self._clock() * 1000)
+        if value <= self._last:
+            value = self._last + 1
+        self._last = value
+        return value
+
+
+# --------------------------------------------------------------------------- #
+# signing
+# --------------------------------------------------------------------------- #
+class Ed25519Signer:
+    """Ed25519 signer built from a 32-byte seed. Never exposes the seed."""
+
+    def __init__(self, seed: bytes) -> None:
+        if len(seed) != 32:
+            raise A2AError(f"Ed25519 seed must be 32 bytes, got {len(seed)}")
+        self._backend, self._key = self._load(seed)
+        self.public_key_hex = self._pubkey_hex()
+        self.address = address_from_pubkey(self.public_key_hex)
+
+    @staticmethod
+    def _load(seed: bytes):
+        try:
+            from nacl.signing import SigningKey  # type: ignore
+
+            return "pynacl", SigningKey(seed)
+        except ImportError:
+            pass
+        try:
+            from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+                Ed25519PrivateKey,
+            )
+
+            return "cryptography", Ed25519PrivateKey.from_private_bytes(seed)
+        except ImportError as exc:  # pragma: no cover - environment dependent
+            raise A2AError(
+                "no Ed25519 backend available; install 'pynacl' or 'cryptography'"
+            ) from exc
+
+    def _pubkey_hex(self) -> str:
+        if self._backend == "pynacl":
+            return bytes(self._key.verify_key).hex()
+        from cryptography.hazmat.primitives import serialization
+
+        raw = self._key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        return raw.hex()
+
+    def sign(self, message: bytes) -> str:
+        if self._backend == "pynacl":
+            return self._key.sign(message).signature.hex()
+        return self._key.sign(message).hex()
+
+    # -- key loading helpers -------------------------------------------------
+    @classmethod
+    def from_hex(cls, seed_hex: str) -> "Ed25519Signer":
+        seed_hex = seed_hex.strip()
+        try:
+            seed = bytes.fromhex(seed_hex)
+        except ValueError as exc:
+            raise A2AError("key material is not valid hex") from exc
+        # Accept 64-byte expanded keys (seed || pubkey), as emitted by some wallets.
+        if len(seed) == 64:
+            seed = seed[:32]
+        return cls(seed)
+
+    @classmethod
+    def from_file(cls, path: str) -> "Ed25519Signer":
+        with open(path, "r", encoding="utf-8") as handle:
+            raw = handle.read().strip()
+        if raw.startswith("{"):
+            data = json.loads(raw)
+            for field_name in ("seed", "private_key", "secret_key", "sk"):
+                if data.get(field_name):
+                    return cls.from_hex(str(data[field_name]))
+            raise A2AError(f"{path}: JSON key file has no seed/private_key field")
+        return cls.from_hex(raw)
+
+
+# --------------------------------------------------------------------------- #
+# transport
+# --------------------------------------------------------------------------- #
+@dataclass
+class TransferResult:
+    ok: bool
+    from_address: str
+    to_address: str
+    amount_rtc: float
+    nonce: int
+    tx_hash: Optional[str] = None
+    pending_id: Optional[str] = None
+    error: Optional[str] = None
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class RustChainClient:
+    """Minimal JSON client for the RustChain node HTTP API."""
+
+    def __init__(
+        self,
+        node_url: str = DEFAULT_NODE,
+        timeout: float = 20.0,
+        opener: Optional[Callable[[str, Optional[bytes], float], Dict[str, Any]]] = None,
+    ) -> None:
+        self.node_url = node_url.rstrip("/")
+        self.timeout = timeout
+        self._opener = opener or self._http
+
+    @staticmethod
+    def _http(url: str, body: Optional[bytes], timeout: float) -> Dict[str, Any]:
+        request = urllib.request.Request(
+            url,
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "User-Agent": "rustchain-a2a-transfer/1.0",
+            },
+            method="POST" if body is not None else "GET",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                payload = response.read().decode("utf-8", "replace")
+        except urllib.error.HTTPError as exc:
+            payload = exc.read().decode("utf-8", "replace")
+        except urllib.error.URLError as exc:
+            raise A2AError(f"network error talking to {url}: {exc.reason}") from exc
+        try:
+            return json.loads(payload) if payload else {}
+        except json.JSONDecodeError:
+            return {"ok": False, "error": "non-JSON response", "body": payload[:500]}
+
+    def post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return self._opener(
+            f"{self.node_url}{path}", json.dumps(payload).encode(), self.timeout
+        )
+
+    def get(self, path: str) -> Dict[str, Any]:
+        return self._opener(f"{self.node_url}{path}", None, self.timeout)
+
+    def balance(self, address: str) -> Optional[float]:
+        data = self.get(f"/wallet/balance/{address}")
+        for key in ("balance_rtc", "balance", "amount_rtc"):
+            if isinstance(data.get(key), (int, float)):
+                return float(data[key])
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# core operations
+# --------------------------------------------------------------------------- #
+def build_payload(
+    signer: Ed25519Signer,
+    to_address: str,
+    amount_rtc: float,
+    nonce: int,
+    memo: str = "",
+    fee_rtc: float = 0.0,
+    chain_id: Optional[str] = DEFAULT_CHAIN_ID,
+    legacy: bool = False,
+) -> Dict[str, Any]:
+    """Build the signed request body for ``POST /wallet/transfer/signed``."""
+    from_address = signer.address
+    validate_address(from_address, "from_address")
+    validate_address(to_address, "to_address")
+    if from_address == to_address:
+        raise A2AError(
+            "refusing self-transfer: bounty #13519 requires two independent agents"
+        )
+    if amount_rtc < 1:
+        raise A2AError("bounty #13519 requires an on-chain transfer of at least 1 RTC")
+    current_msg, legacy_msg = canonical_messages(
+        from_address, to_address, amount_rtc, fee_rtc, memo, nonce, chain_id
+    )
+    message = legacy_msg if legacy else current_msg
+    return {
+        "from_address": from_address,
+        "to_address": to_address,
+        "amount_rtc": amount_rtc,
+        "fee_rtc": fee_rtc,
+        "memo": memo,
+        "nonce": nonce,
+        "public_key": signer.public_key_hex,
+        "signature": signer.sign(message),
+        "chain_id": chain_id,
+    }
+
+
+def _extract(result: Dict[str, Any], *keys: str) -> Optional[str]:
+    for key in keys:
+        value = result.get(key)
+        if value:
+            return str(value)
+    tx = result.get("tx") or result.get("transaction")
+    if isinstance(tx, dict):
+        for key in keys:
+            if tx.get(key):
+                return str(tx[key])
+    return None
+
+
+def send_transfer(
+    client: RustChainClient,
+    signer: Ed25519Signer,
+    to_address: str,
+    amount_rtc: float = 1.0,
+    memo: str = "",
+    nonce: Optional[int] = None,
+    nonces: Optional[NonceFactory] = None,
+    fee_rtc: float = 0.0,
+    chain_id: Optional[str] = DEFAULT_CHAIN_ID,
+    retry_legacy: bool = True,
+) -> TransferResult:
+    """Sign and submit one agent-to-agent transfer.
+
+    On ``invalid signature`` the call is retried once with the legacy
+    (fee-less) canonical message so the tool works against older nodes.
+    """
+    nonces = nonces or NonceFactory()
+    nonce = nonces.next() if nonce is None else nonce
+    payload = build_payload(
+        signer, to_address, amount_rtc, nonce, memo, fee_rtc, chain_id
+    )
+    response = client.post(TRANSFER_PATH, payload)
+    if not response.get("ok") and retry_legacy and _looks_like_sig_error(response):
+        payload = build_payload(
+            signer, to_address, amount_rtc, nonces.next(), memo, fee_rtc,
+            chain_id, legacy=True,
+        )
+        response = client.post(TRANSFER_PATH, payload)
+
+    return TransferResult(
+        ok=bool(response.get("ok")),
+        from_address=payload["from_address"],
+        to_address=to_address,
+        amount_rtc=amount_rtc,
+        nonce=payload["nonce"],
+        tx_hash=_extract(response, "tx_hash", "txid", "hash"),
+        pending_id=_extract(response, "pending_id", "pending", "id"),
+        error=None if response.get("ok") else str(
+            response.get("error") or response.get("message") or "transfer rejected"
+        ),
+        raw=response,
+    )
+
+
+def _looks_like_sig_error(response: Dict[str, Any]) -> bool:
+    text = f"{response.get('error', '')} {response.get('message', '')}".lower()
+    return "signature" in text
+
+
+def round_trip(
+    client: RustChainClient,
+    signer_a: Ed25519Signer,
+    signer_b: Ed25519Signer,
+    amount_rtc: float = 1.0,
+    memo: str = "a2a bounty 13519",
+    nonces: Optional[NonceFactory] = None,
+) -> Dict[str, Any]:
+    """A -> B, then B -> A. Both legs must be distinct wallets."""
+    if signer_a.address == signer_b.address:
+        raise A2AError("round trip needs two distinct agents (sock puppets excluded)")
+    nonces = nonces or NonceFactory()
+    outbound = send_transfer(
+        client, signer_a, signer_b.address, amount_rtc, memo, nonces=nonces
+    )
+    inbound: Optional[TransferResult] = None
+    if outbound.ok:
+        inbound = send_transfer(
+            client, signer_b, signer_a.address, amount_rtc, memo, nonces=nonces
+        )
+    return {
+        "bounty": "rustchain-bounties#13519",
+        "agent_a": signer_a.address,
+        "agent_b": signer_b.address,
+        "amount_rtc": amount_rtc,
+        "outbound": outbound.to_dict(),
+        "inbound": inbound.to_dict() if inbound else None,
+        "complete": bool(outbound.ok and inbound and inbound.ok),
+        "generated_at": int(time.time()),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _signer_from_args(key_file: Optional[str], env_var: str) -> Ed25519Signer:
+    if key_file:
+        return Ed25519Signer.from_file(key_file)
+    raw = os.environ.get(env_var)
+    if not raw:
+        raise A2AError(f"no key: pass --key-file or set ${env_var}")
+    return Ed25519Signer.from_hex(raw)
+
+
+def _emit(data: Dict[str, Any], receipt: Optional[str]) -> None:
+    text = json.dumps(data, indent=2, sort_keys=True)
+    print(text)
+    if receipt:
+        with open(receipt, "w", encoding="utf-8") as handle:
+            handle.write(text + "\n")
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="a2a_transfer",
+        description="Agent-to-agent on-chain RTC transfers (bounty #13519)",
+    )
+    parser.add_argument("--node", default=os.environ.get("RUSTCHAIN_NODE", DEFAULT_NODE))
+    parser.add_argument("--timeout", type=float, default=20.0)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_addr = sub.add_parser("address", help="print the RTC address for a key")
+    p_addr.add_argument("--key-file")
+
+    p_send = sub.add_parser("send", help="send >=1 RTC to a partner agent")
+    p_send.add_argument("--key-file")
+    p_send.add_argument("--to", required=True)
+    p_send.add_argument("--amount", type=float, default=1.0)
+    p_send.add_argument("--memo", default="a2a bounty 13519")
+    p_send.add_argument("--receipt")
+
+    p_rt = sub.add_parser("roundtrip", help="A->B then B->A")
+    p_rt.add_argument("--key-file")
+    p_rt.add_argument("--peer-key-file")
+    p_rt.add_argument("--amount", type=float, default=1.0)
+    p_rt.add_argument("--memo", default="a2a bounty 13519")
+    p_rt.add_argument("--receipt")
+
+    args = parser.parse_args(argv)
+    client = RustChainClient(args.node, timeout=args.timeout)
+
+    try:
+        if args.command == "address":
+            signer = _signer_from_args(args.key_file, "RUSTCHAIN_AGENT_KEY")
+            _emit(
+                {"address": signer.address, "public_key": signer.public_key_hex}, None
+            )
+            return 0
+
+        if args.command == "send":
+            signer = _signer_from_args(args.key_file, "RUSTCHAIN_AGENT_KEY")
+            result = send_transfer(
+                client, signer, args.to, args.amount, args.memo
+            )
+            _emit(result.to_dict(), args.receipt)
+            return 0 if result.ok else 1
+
+        signer_a = _signer_from_args(args.key_file, "RUSTCHAIN_AGENT_KEY")
+        signer_b = _signer_from_args(args.peer_key_file, "RUSTCHAIN_PEER_KEY")
+        report = round_trip(client, signer_a, signer_b, args.amount, args.memo)
+        _emit(report, args.receipt)
+        return 0 if report["complete"] else 1
+    except A2AError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, indent=2), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/a2a_transfer/tests/test_a2a_transfer.py
+++ b/tools/a2a_transfer/tests/test_a2a_transfer.py
@@ -1,0 +1,260 @@
+"""Tests for tools/a2a_transfer — agent-to-agent on-chain transfers (#13519).
+
+No network access: the RustChain node is replaced by a fake opener that records
+requests and verifies the Ed25519 signature exactly the way the node does.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+import pytest
+
+MODULE_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "a2a_transfer.py",
+)
+_spec = importlib.util.spec_from_file_location("a2a_transfer", MODULE_PATH)
+a2a = importlib.util.module_from_spec(_spec)
+sys.modules["a2a_transfer"] = a2a
+_spec.loader.exec_module(a2a)
+
+SEED_A = bytes(range(32))
+SEED_B = bytes(range(32, 64))
+
+
+def _verify(public_key_hex: str, signature_hex: str, message: bytes) -> bool:
+    try:
+        from nacl.signing import VerifyKey
+
+        VerifyKey(bytes.fromhex(public_key_hex)).verify(
+            message, bytes.fromhex(signature_hex)
+        )
+        return True
+    except ImportError:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+        try:
+            Ed25519PublicKey.from_public_bytes(bytes.fromhex(public_key_hex)).verify(
+                bytes.fromhex(signature_hex), message
+            )
+            return True
+        except InvalidSignature:
+            return False
+    except Exception:
+        return False
+
+
+class FakeNode:
+    """Signature-checking stand-in for POST /wallet/transfer/signed."""
+
+    def __init__(self, accept_legacy_only=False, fail_first_signature=False):
+        self.requests = []
+        self.accept_legacy_only = accept_legacy_only
+        self.fail_first_signature = fail_first_signature
+        self._calls = 0
+
+    def __call__(self, url, body, timeout):
+        self._calls += 1
+        payload = json.loads(body.decode()) if body else {}
+        self.requests.append((url, payload))
+        if body is None:
+            return {"balance_rtc": 42.0}
+        current, legacy = a2a.canonical_messages(
+            payload["from_address"],
+            payload["to_address"],
+            payload["amount_rtc"],
+            payload.get("fee_rtc", 0.0),
+            payload.get("memo", ""),
+            payload["nonce"],
+            payload.get("chain_id"),
+        )
+        if self.fail_first_signature and self._calls == 1:
+            return {"ok": False, "error": "invalid signature"}
+        candidates = [legacy] if self.accept_legacy_only else [current, legacy]
+        for message in candidates:
+            if _verify(payload["public_key"], payload["signature"], message):
+                digest = hashlib.sha256(body).hexdigest()
+                return {"ok": True, "tx_hash": digest, "pending_id": digest[:16]}
+        return {"ok": False, "error": "invalid signature"}
+
+
+@pytest.fixture
+def signer_a():
+    return a2a.Ed25519Signer(SEED_A)
+
+
+@pytest.fixture
+def signer_b():
+    return a2a.Ed25519Signer(SEED_B)
+
+
+# --------------------------------------------------------------------------- #
+# canonical message / address helpers
+# --------------------------------------------------------------------------- #
+def test_canonical_message_matches_node_format():
+    current, legacy = a2a.canonical_messages(
+        "RTC" + "a" * 40, "RTC" + "b" * 40, 1.0, 0.0, "", 1700000000000,
+        "rustchain-mainnet-v2",
+    )
+    assert current == (
+        b'{"amount":1.0,"chain_id":"rustchain-mainnet-v2","fee":0.0,'
+        b'"from":"RTC' + b"a" * 40 + b'","memo":"","nonce":1700000000000,'
+        b'"to":"RTC' + b"b" * 40 + b'"}'
+    )
+    assert b'"fee"' not in legacy
+    # compact separators, deterministic key order
+    assert b", " not in current and b'": ' not in current
+
+
+def test_address_from_pubkey_matches_node_rule():
+    pubkey = "ab" * 32
+    expected = "RTC" + hashlib.sha256(bytes.fromhex(pubkey)).hexdigest()[:40]
+    assert a2a.address_from_pubkey(pubkey) == expected
+    assert a2a.ADDRESS_RE.match(expected)
+
+
+def test_signer_address_is_self_consistent(signer_a):
+    assert signer_a.address == a2a.address_from_pubkey(signer_a.public_key_hex)
+    assert a2a.ADDRESS_RE.match(signer_a.address)
+
+
+@pytest.mark.parametrize(
+    "bad", ["", "RTC", "0x" + "a" * 40, "RTC" + "A" * 40, "RTC" + "a" * 39, None]
+)
+def test_validate_address_rejects_non_native_wallets(bad):
+    with pytest.raises(a2a.A2AError):
+        a2a.validate_address(bad)
+
+
+# --------------------------------------------------------------------------- #
+# nonces
+# --------------------------------------------------------------------------- #
+def test_nonce_factory_is_strictly_monotonic():
+    frozen = a2a.NonceFactory(clock=lambda: 1700000000.0)
+    values = [frozen.next() for _ in range(5)]
+    assert values == sorted(set(values)) and len(set(values)) == 5
+
+
+# --------------------------------------------------------------------------- #
+# payload construction guards
+# --------------------------------------------------------------------------- #
+def test_build_payload_rejects_self_transfer(signer_a):
+    with pytest.raises(a2a.A2AError, match="self-transfer"):
+        a2a.build_payload(signer_a, signer_a.address, 1.0, 1)
+
+
+def test_build_payload_rejects_below_one_rtc(signer_a, signer_b):
+    with pytest.raises(a2a.A2AError, match="at least 1 RTC"):
+        a2a.build_payload(signer_a, signer_b.address, 0.5, 1)
+
+
+def test_build_payload_signature_verifies(signer_a, signer_b):
+    payload = a2a.build_payload(signer_a, signer_b.address, 1.0, 12345)
+    current, _ = a2a.canonical_messages(
+        signer_a.address, signer_b.address, 1.0, 0.0, "", 12345,
+        a2a.DEFAULT_CHAIN_ID,
+    )
+    assert _verify(payload["public_key"], payload["signature"], current)
+
+
+# --------------------------------------------------------------------------- #
+# transfers
+# --------------------------------------------------------------------------- #
+def test_send_transfer_success(signer_a, signer_b):
+    node = FakeNode()
+    client = a2a.RustChainClient("https://node.test", opener=node)
+    result = a2a.send_transfer(client, signer_a, signer_b.address, 1.0)
+    assert result.ok and result.tx_hash and result.pending_id
+    url, payload = node.requests[0]
+    assert url == "https://node.test/wallet/transfer/signed"
+    assert payload["from_address"] == signer_a.address
+    assert payload["to_address"] == signer_b.address
+    assert payload["amount_rtc"] == 1.0
+    assert "seed" not in json.dumps(payload)
+
+
+def test_send_transfer_retries_with_legacy_message(signer_a, signer_b):
+    node = FakeNode(accept_legacy_only=True)
+    client = a2a.RustChainClient("https://node.test", opener=node)
+    result = a2a.send_transfer(client, signer_a, signer_b.address, 1.0)
+    assert result.ok, result.error
+    assert len(node.requests) == 2
+    assert node.requests[0][1]["nonce"] != node.requests[1][1]["nonce"]
+
+
+def test_send_transfer_reports_rejection(signer_a, signer_b):
+    class Rejecting:
+        def __call__(self, url, body, timeout):
+            return {"ok": False, "error": "insufficient balance"}
+
+    client = a2a.RustChainClient("https://node.test", opener=Rejecting())
+    result = a2a.send_transfer(client, signer_a, signer_b.address, 1.0)
+    assert not result.ok and result.error == "insufficient balance"
+
+
+def test_round_trip_produces_both_legs(signer_a, signer_b):
+    node = FakeNode()
+    client = a2a.RustChainClient("https://node.test", opener=node)
+    report = a2a.round_trip(client, signer_a, signer_b, 1.0)
+    assert report["complete"] is True
+    assert report["outbound"]["from_address"] == signer_a.address
+    assert report["inbound"]["from_address"] == signer_b.address
+    assert report["inbound"]["to_address"] == signer_a.address
+    assert report["outbound"]["nonce"] != report["inbound"]["nonce"]
+
+
+def test_round_trip_rejects_same_agent(signer_a):
+    client = a2a.RustChainClient("https://node.test", opener=FakeNode())
+    with pytest.raises(a2a.A2AError, match="distinct agents"):
+        a2a.round_trip(client, signer_a, signer_a, 1.0)
+
+
+def test_round_trip_skips_return_leg_when_outbound_fails(signer_a, signer_b):
+    class Rejecting:
+        calls = 0
+
+        def __call__(self, url, body, timeout):
+            Rejecting.calls += 1
+            return {"ok": False, "error": "nope"}
+
+    rejecting = Rejecting()
+    client = a2a.RustChainClient("https://node.test", opener=rejecting)
+    report = a2a.round_trip(client, signer_a, signer_b, 1.0)
+    assert report["complete"] is False and report["inbound"] is None
+
+
+# --------------------------------------------------------------------------- #
+# key loading & CLI
+# --------------------------------------------------------------------------- #
+def test_signer_from_hex_and_json_file(tmp_path, signer_a):
+    hex_file = tmp_path / "a.key"
+    hex_file.write_text(SEED_A.hex())
+    json_file = tmp_path / "a.json"
+    json_file.write_text(json.dumps({"seed": SEED_A.hex()}))
+    assert a2a.Ed25519Signer.from_file(str(hex_file)).address == signer_a.address
+    assert a2a.Ed25519Signer.from_file(str(json_file)).address == signer_a.address
+
+
+def test_signer_accepts_expanded_64_byte_key(signer_a):
+    expanded = SEED_A.hex() + signer_a.public_key_hex
+    assert a2a.Ed25519Signer.from_hex(expanded).address == signer_a.address
+
+
+def test_cli_address_command(tmp_path, capsys, signer_a):
+    key = tmp_path / "a.key"
+    key.write_text(SEED_A.hex())
+    code = a2a.main(["address", "--key-file", str(key)])
+    out = json.loads(capsys.readouterr().out)
+    assert code == 0 and out["address"] == signer_a.address
+
+
+def test_cli_reports_error_without_key(capsys):
+    os.environ.pop("RUSTCHAIN_AGENT_KEY", None)
+    code = a2a.main(["send", "--to", "RTC" + "b" * 40])
+    assert code == 2
+    assert "no key" in capsys.readouterr().err


### PR DESCRIPTION
## Agent-to-Agent on-chain transfer harness (`tools/a2a_transfer`)

Contributes the tooling + test coverage for the transfer path exercised by bounty [Scottcjn/rustchain-bounties#13519](https://github.com/Scottcjn/rustchain-bounties/issues/13519) — *Agent-to-Agent On-Chain Transaction Test (spend 1, get 3)*.

### Problem
Claims for this bounty keep failing before the transfer ever reaches the ledger, and always for the same handful of reasons:

| Failure | Cause |
|---|---|
| `invalid signature` | canonical message rebuilt by hand (wrong key order, spaces, missing `fee`) |
| `invalid signature` on older nodes | node predates the `fee` field but the client only signs the new schema |
| `nonce already used` | both legs of a round trip fired in the same millisecond |
| accepted but unpayable | self-transfer / second wallet of the same agent (explicitly excluded) |
| unverifiable claim | no `tx_hash` / `pending_id` captured for the maintainer |

### What this adds
`tools/a2a_transfer/a2a_transfer.py` — CLI **and** importable library:

- Canonical signing payload **byte-identical** to `node/rustchain_v2_integrated_v2.2.1_rip200.py::_wallet_transfer_signed_messages` (compact JSON, `sort_keys=True`), plus automatic one-shot retry with the **legacy fee-less** message when a node answers `invalid signature` — so the same client works against old and new nodes.
- Ed25519 signing via PyNaCl with a `cryptography` fallback (already in `requirements.txt`); seeds are never printed, serialised, or sent.
- **Strictly monotonic unix-ms nonces**, so round-trip legs can never collide.
- Native address derivation/validation (`RTC` + `SHA256(pubkey)[:40]`) and hard guards against **self-transfers** and amounts **< 1 RTC** — the two conditions that disqualify a claim.
- `roundtrip` orchestration (A→B, then B→A only if the first leg landed) emitting a JSON receipt with `tx_hash`/`pending_id` per direction, ready to paste into a claim.
- Exit codes: `0` ok, `1` node rejected, `2` local/validation error.

### Usage
```bash
python tools/a2a_transfer/a2a_transfer.py address  --key-file agent.key
python tools/a2a_transfer/a2a_transfer.py send     --key-file agent.key --to RTC<partner> --amount 1 --receipt claim.json
python tools/a2a_transfer/a2a_transfer.py roundtrip --key-file a.key --peer-key-file b.key --amount 1
```

### Tests
```
python -m pytest tools/a2a_transfer/tests -q
23 passed
```
Fully offline: the fake node **re-verifies every Ed25519 signature** against the canonical message, so the suite breaks if the signing format ever drifts from the node. Covers canonical byte layout (current + legacy), address derivation/validation, nonce monotonicity, self-transfer and `<1 RTC` guards, successful send, legacy retry path, node rejection, full round trip, sock-puppet rejection, skipped return leg on failure, key loading (hex / JSON / 64-byte expanded), and CLI entry points.

The suite lives under `tools/a2a_transfer/tests/` so it runs without the Flask-dependent root `tests/conftest.py`.

### Scope
Tooling + tests only; no existing file is modified. A live ledger entry needs two funded independent wallets at runtime, which the `roundtrip` command produces a verifiable receipt for.
