### PR TITLE
feat: add mobile touch controls to beacon atlas

### DIFF
--- a/site/beacon/index.html
+++ b/site/beacon/index.html
@@ -71,9 +71,13 @@ function escapeHtml(value) {
   </div>
 
   <!-- Controls hint (bottom-left) -->
-  <div class="controls-hint">
+  <div class="controls-hint desktop-controls">
     DRAG rotate | SCROLL zoom | RIGHT-DRAG pan<br>
     CLICK agent/city for details | ESC close
+  </div>
+  <div class="controls-hint mobile-controls">
+    ONE FINGER rotate | TWO FINGERS zoom/pan<br>
+    TAP agent/city for details | TAP outside to close
   </div>
 
   <!-- Info Panel (right side) -->

--- a/site/beacon/scene.js
+++ b/site/beacon/scene.js
@@ -55,6 +55,15 @@ export function initScene(canvas) {
   controls.minDistance = 30;
   controls.maxDistance = 600;
   controls.maxPolarAngle = Math.PI * 0.48;
+  // Make the gesture contract explicit so touch behavior stays stable when
+  // OrbitControls defaults change between Three.js releases.
+  controls.touches.ONE = THREE.TOUCH.ROTATE;
+  controls.touches.TWO = THREE.TOUCH.DOLLY_PAN;
+  controls.screenSpacePanning = true;
+  if (window.matchMedia?.('(pointer: coarse)').matches) {
+    controls.rotateSpeed = 0.65;
+    controls.panSpeed = 0.8;
+  }
   controls.target.set(0, 0, 0);
 
   controls.addEventListener('start', () => { autoRotate = false; });
@@ -111,9 +120,20 @@ export function setHoverHandler(fn) { onHoverHandler = fn; }
 export function setMissHandler(fn) { onMissHandler = fn; }
 
 export function setupInteraction(canvas) {
-  canvas.addEventListener('click', (e) => {
-    mouse.x = (e.clientX / window.innerWidth) * 2 - 1;
-    mouse.y = -(e.clientY / window.innerHeight) * 2 + 1;
+  // OrbitControls uses Pointer Events for mouse, pen, and touch. Handle taps
+  // on the same event stream so a swipe/drag never opens an agent by accident.
+  canvas.style.touchAction = 'none';
+  const tapDistance = 10;
+  let pointerStart = null;
+
+  const updatePointer = (e) => {
+    const rect = canvas.getBoundingClientRect();
+    mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+    mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+  };
+
+  const selectAt = (e) => {
+    updatePointer(e);
 
     raycaster.setFromCamera(mouse, camera);
     const hits = raycaster.intersectObjects(clickables, false);
@@ -123,11 +143,30 @@ export function setupInteraction(canvas) {
     } else if (onMissHandler) {
       onMissHandler();
     }
+  };
+
+  canvas.addEventListener('pointerdown', (e) => {
+    if (e.isPrimary && e.button === 0) {
+      pointerStart = { x: e.clientX, y: e.clientY };
+    }
   });
 
-  canvas.addEventListener('mousemove', (e) => {
-    mouse.x = (e.clientX / window.innerWidth) * 2 - 1;
-    mouse.y = -(e.clientY / window.innerHeight) * 2 + 1;
+  canvas.addEventListener('pointerup', (e) => {
+    if (!pointerStart || !e.isPrimary || e.button !== 0) return;
+    const distance = Math.hypot(e.clientX - pointerStart.x, e.clientY - pointerStart.y);
+    pointerStart = null;
+    if (distance <= tapDistance) selectAt(e);
+  });
+
+  canvas.addEventListener('pointercancel', () => {
+    pointerStart = null;
+  });
+
+  canvas.addEventListener('pointermove', (e) => {
+    // Touch screens do not have hover; avoiding raycasts while dragging keeps
+    // the gesture responsive and prevents tooltip flicker.
+    if (e.pointerType === 'touch') return;
+    updatePointer(e);
 
     raycaster.setFromCamera(mouse, camera);
     const hits = raycaster.intersectObjects(hoverables, false);

--- a/site/beacon/styles.css
+++ b/site/beacon/styles.css
@@ -30,6 +30,7 @@
 html, body {
   width: 100%; height: 100%;
   overflow: hidden;
+  overscroll-behavior: none;
   background: var(--bg-dark);
   font-family: var(--font-mono);
   color: var(--green);
@@ -41,6 +42,8 @@ html, body {
   top: 0; left: 0;
   width: 100%; height: 100%;
   z-index: 1;
+  touch-action: none;
+  user-select: none;
 }
 
 /* --- CRT Overlay --- */
@@ -102,6 +105,8 @@ html, body {
   line-height: 1.6;
   opacity: 0.7;
 }
+
+.mobile-controls { display: none; }
 
 /* --- Info Panel (right side) --- */
 .info-panel {
@@ -753,7 +758,27 @@ html, body {
   .hud-title { font-size: 22px; }
   .hud-stats { font-size: 14px; }
 
-  .controls-hint { display: none; }
+  .desktop-controls { display: none; }
+
+  .mobile-controls {
+    display: block;
+    right: 10px;
+    bottom: 10px;
+    left: 10px;
+    font-size: 10px;
+    line-height: 1.45;
+    text-align: center;
+    text-shadow: 0 0 6px var(--bg-dark);
+  }
+
+  .panel-titlebar {
+    min-height: 44px;
+  }
+
+  .panel-dot {
+    width: 18px;
+    height: 18px;
+  }
 }
 
 


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)
- [x] Add a tier label: `BCOS-L1` or `BCOS-L2` (the PR changes existing files only)
- [x] No new code files were added, so no SPDX header was required
- [x] Provide test evidence (commands + output below)

## What Changed

Implements Track B — Mobile touch controls from [bounty #1524](https://github.com/Scottcjn/rustchain-bounties/issues/1524) (15 RTC):

- Explicitly configures OrbitControls for one-finger rotation and two-finger dolly/pan gestures.
- Uses pointer events with a movement threshold so swipes do not accidentally select agents or cities.
- Uses canvas-relative raycasting and skips touch hover work to keep gestures responsive.
- Adds mobile-specific gesture guidance and larger touch targets for the info panel.

## Testing / Evidence

- `C:\Users\genar\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --check site\beacon\scene.js` — passed.
- `git diff --check` — passed.