### PR TITLE
[UTXO-BUG] Reject non-finite JSON output metadata

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -1800,6 +1800,63 @@ class TestUtxoDB(unittest.TestCase):
                 self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
                 self.assertEqual(self.db.get_balance('bob'), 0)
 
+    def test_mempool_rejects_nonfinite_json_metadata_without_locking_input(self):
+        """NaN and Infinity are not valid JSON and must not enter the mempool."""
+        cases = [
+            {'tokens_json': '[NaN]'},
+            {'tokens_json': '[Infinity]'},
+            {'registers_json': '{"R4": -Infinity}'},
+        ]
+
+        for idx, metadata in enumerate(cases):
+            with self.subTest(metadata=metadata):
+                address = f'alice_nonfinite_{idx}'
+                self.assertTrue(self.db.apply_transaction({
+                    'tx_type': 'mining_reward',
+                    'inputs': [],
+                    'outputs': [{'address': address, 'value_nrtc': UNIT}],
+                    'fee_nrtc': 0,
+                    'timestamp': 1000 + idx,
+                    '_allow_minting': True,
+                }, block_height=1000 + idx))
+                box = self.db.get_unspent_for_address(address)[0]
+
+                ok = self.db.mempool_add({
+                    'tx_id': f'nonfinite{idx}',
+                    'tx_type': 'transfer',
+                    'inputs': [{'box_id': box['box_id']}],
+                    'outputs': [{
+                        'address': 'bob',
+                        'value_nrtc': UNIT,
+                        **metadata,
+                    }],
+                    'fee_nrtc': 0,
+                })
+
+                self.assertFalse(ok)
+                self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
+
+    def test_apply_transaction_rejects_nonfinite_json_metadata(self):
+        """Direct application must reject non-standard JSON constants."""
+        self._apply_coinbase('alice_nonfinite_apply', UNIT, block_height=2000)
+        box = self.db.get_unspent_for_address('alice_nonfinite_apply')[0]
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': box['box_id']}],
+            'outputs': [{
+                'address': 'bob',
+                'value_nrtc': UNIT,
+                'tokens_json': '[NaN]',
+                'registers_json': '{"R4": Infinity}',
+            }],
+            'fee_nrtc': 0,
+        }, block_height=2001)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice_nonfinite_apply'), UNIT)
+        self.assertEqual(self.db.get_balance('bob'), 0)
+
     def test_mempool_rejects_oversized_tx_id_without_locking_input(self):
         """Public mempool tx ids must be bounded before persistence."""
         self._apply_coinbase('alice', 100 * UNIT)

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -121,6 +121,11 @@ def _json_max_depth(text: str) -> int:
     return max_depth
 
 
+def _reject_nonstandard_json_constant(value: str):
+    """Reject Python's non-standard NaN/Infinity JSON extensions."""
+    raise ValueError(f"non-standard JSON constant: {value}")
+
+
 # ---------------------------------------------------------------------------
 # Box / Transaction helpers (dict-based, not dataclass — keeps it simple)
 # ---------------------------------------------------------------------------
@@ -578,9 +583,13 @@ class UtxoDB:
             if _json_max_depth(registers_json) > MAX_UTXO_JSON_DEPTH:
                 return None
             try:
-                tokens = json.loads(tokens_json)
-                registers = json.loads(registers_json)
-            except (TypeError, json.JSONDecodeError):
+                tokens = json.loads(
+                    tokens_json, parse_constant=_reject_nonstandard_json_constant
+                )
+                registers = json.loads(
+                    registers_json, parse_constant=_reject_nonstandard_json_constant
+                )
+            except (TypeError, ValueError):
                 return None
             if not isinstance(tokens, list):
                 return None


### PR DESCRIPTION
## Summary

- reject Python's non-standard `NaN`, `Infinity`, and `-Infinity` JSON constants in UTXO `tokens_json` and `registers_json`
- enforce the same strict metadata validation in direct transaction application and mempool admission through the shared output normalizer
- add regressions proving malformed metadata cannot mutate balances or reserve an input

## Finding

Python's `json.loads()` accepts non-standard numeric constants by default. Before this change, output metadata such as `tokens_json='[NaN]'` or `registers_json='{"R4": Infinity}'` passed `_normalize_outputs()`. Such transactions could enter the mempool, reserve inputs, be returned as block candidates, and then be persisted in the UTXO set.

These values are not valid RFC 8259 JSON. Persisting them in consensus-visible metadata creates an interoperability hazard for strict JSON consumers and non-Python validators, which reject the same transaction/box data. The state root also commits to this invalid raw metadata.

Pre-fix reproduction on current `main`:

```text
pre_fix_mempool_accepted= True
candidate_count= 1
pre_fix_apply_accepted= True
```

The fix uses `parse_constant` to fail closed while preserving valid token arrays and register objects.

Bounty: Scottcjn/rustchain-bounties#2819

## Verification

- `PYTHONPATH=node python3 -m pytest node/test_utxo_db.py -q -k 'nonfinite_json_metadata'` -> 2 passed, 3 subtests passed
- `PYTHONPATH=node python3 -m pytest node/test_utxo_db.py -q` -> 105 passed, 34 subtests passed
- `python3 -m py_compile node/utxo_db.py node/test_utxo_db.py` -> passed
- `git diff --check` -> passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
