### PR TITLE
docs: repair broken RustChain links and enforce CI checks

### DIFF
--- a/.github/actions/bcos-action/README.md
+++ b/.github/actions/bcos-action/README.md
@@ -1,6 +1,6 @@
 # BCOS v2 GitHub Action
 
-[![BCOS](https://img.shields.io/badge/BCOS-v2-blue)](https://rustchain.org/bcos/)
+[![BCOS](https://img.shields.io/badge/BCOS-v2-blue)](https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Reusable GitHub Action that any repo can use to run **BCOS v2** (Beacon Certified Open Source) scans.
@@ -175,7 +175,7 @@ Missing tools result in partial credit for affected checks.
 
 ## Verification
 
-Verify attestations at: https://rustchain.org/bcos/
+Verify the BCOS methodology at: https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md
 
 ## License
 
@@ -190,6 +190,6 @@ MIT License - see [LICENSE](LICENSE) file.
 
 ## Support
 
-- Documentation: https://rustchain.org/bcos/
+- Documentation: https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md
 - Issues: https://github.com/Scottcjn/Rustchain/issues
 - Spec: https://github.com/Scottcjn/Rustchain/blob/main/docs/BEACON_CERTIFIED_OPEN_SOURCE.md

--- a/.github/actions/bcos-scan/README.md
+++ b/.github/actions/bcos-scan/README.md
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 # BCOS v2 GitHub Action
 
-> Reusable GitHub Action for [Beacon Certified Open Source](https://rustchain.org/bcos/) trust scans.
+> Reusable GitHub Action for [Beacon Certified Open Source](https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md) trust scans.
 
 Run BCOS v2 scans on any repository. Get a trust score (0–100), certificate ID, and automatic PR comments with badge.
 

--- a/.github/actions/bcos-scan/action.yml
+++ b/.github/actions/bcos-scan/action.yml
@@ -148,7 +148,7 @@ runs:
             ``,
             `<details><summary>What is BCOS?</summary>`,
             ``,
-            `[Beacon Certified Open Source](https://rustchain.org/bcos/) is a transparent`,
+            `[Beacon Certified Open Source](https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md) is a transparent`,
             `trust scoring system for open-source repositories. Scores are anchored on`,
             `RustChain for tamper-proof verification.`,
             ``,

--- a/.github/workflows/bcos.yml
+++ b/.github/workflows/bcos.yml
@@ -146,7 +146,7 @@ jobs:
               '- Test infrastructure evidence',
               '- Review attestation tier',
               '',
-              `[Full report](https://rustchain.org/bcos/verify/${certId}) | [What is BCOS?](https://github.com/Scottcjn/Rustchain/blob/main/docs/BEACON_CERTIFIED_OPEN_SOURCE.md)`,
+              `[BCOS methodology](https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md) | [What is BCOS?](https://github.com/Scottcjn/Rustchain/blob/main/docs/BEACON_CERTIFIED_OPEN_SOURCE.md)`,
               '</details>',
               '',
               '---',

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Check relative repository links
+        run: python tools/check_relative_links.py README.md docs
       - name: Check relative links
         uses: lycheeverse/lychee-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 [![Nodes](https://img.shields.io/badge/Nodes-5%20Active-brightgreen)](https://rustchain.org/explorer/)
 [![DePIN](https://img.shields.io/badge/DePIN-Vintage%20Hardware-8B4513)](https://rustchain.org)
 [![Proof of Antiquity](https://img.shields.io/badge/Consensus-Proof%20of%20Antiquity-DAA520)](docs/WHITEPAPER.md)
-[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.19442753-blue)](https://doi.org/10.5281/zenodo.19442753)
 
 A PowerBook G4 from 2003 earns **2.5x** more than a modern Threadripper.
 A Power Mac G5 earns **2.0x**. A 486 with rusty serial ports earns the most respect of all.
@@ -426,7 +425,7 @@ Emission is a fixed 1.5 RTC per epoch and does not halve. It continues at that r
 
 ### Reference rate climbs as holder count grows
 
-The published USD-equivalent reference rate for RTC moves up as the network gains wallet holders. **Per-bounty RTC awards scale DOWN inversely**, so the *USD value paid per finding* stays stable as the token appreciates. The live rate is always at [`/api/tokenomics`](https://rustchain.org/api/tokenomics).
+The published USD-equivalent reference rate for RTC moves up as the network gains wallet holders. **Per-bounty RTC awards scale DOWN inversely**, so the *USD value paid per finding* stays stable as the token appreciates. The live rate is always in the [tokenomics section of the RustChain homepage](https://rustchain.org/#tokenomics).
 
 | Holder count | Reference rate | Bounty rate scale |
 |--------------|----------------|-------------------|

--- a/docs/GPU_FINGERPRINTING.md
+++ b/docs/GPU_FINGERPRINTING.md
@@ -96,5 +96,4 @@ Minimum 3 violations even for same-architecture spoofs.
 ## Reference
 
 - [RIP-0308: Proof of Physical AI](../rips/docs/RIP-0308-proof-of-physical-ai.md)
-- [DOI: 10.5281/zenodo.19442753](https://doi.org/10.5281/zenodo.19442753)
 - Khattak & Mikaitis, "Accurate Models of NVIDIA Tensor Cores" (arXiv:2512.07004)

--- a/docs/bcos/compare.html
+++ b/docs/bcos/compare.html
@@ -553,7 +553,7 @@
 
   <nav class="nav">
     <a href="../index.html">← Back to Docs</a>
-    <a href="https://rustchain.org/bcos/">BCOS Directory</a>
+    <a href="https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md">BCOS Methodology</a>
     <a href="https://github.com/Scottcjn/rustchain-bounties/issues/2294">Bounty #2294</a>
   </nav>
 
@@ -909,14 +909,14 @@ clawrtc bcos verify BCOS-xxxxxxxx
       <h2>🔍 How to Verify a BCOS-Certified Project</h2>
 
       <div class="cta-buttons">
-        <a href="https://rustchain.org/bcos/" class="btn btn-primary">Visit BCOS Directory</a>
+        <a href="https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md" class="btn btn-primary">Read BCOS Methodology</a>
         <a href="https://github.com/Scottcjn/rustchain-bounties" class="btn btn-secondary">Browse Bounties</a>
       </div>
 
       <h3>Step 1: Check the Badge</h3>
       <p>BCOS-certified repositories display a verification badge:</p>
       <pre><code>&lt;!-- Embed this badge in your README --&gt;
-[![BCOS Certified](https://img.shields.io/badge/BCOS-Certified-brightgreen?style=flat)](https://rustchain.org/bcos/)</code></pre>
+[![BCOS Certified](https://img.shields.io/badge/BCOS-Certified-brightgreen?style=flat)](https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md)</code></pre>
 
       <h3>Step 2: Scan the Repository</h3>
       <pre><code># Install the BCOS CLI tool
@@ -973,7 +973,7 @@ clawrtc bcos verify BCOS-xxxxxxxx</code></pre>
         <div class="screenshot-card">
           <div class="screenshot-placeholder">
             <p>🏆 Directory Listing</p>
-            <p style="font-size: 0.85em; margin-top: 8px;">rustchain.org/bcos/ project grid</p>
+            <p style="font-size: 0.85em; margin-top: 8px;">BCOS methodology and certification workflow</p>
           </div>
           <p><strong>Figure 4:</strong> BCOS certified projects directory</p>
         </div>
@@ -987,7 +987,7 @@ clawrtc bcos scan . | tee scan_output.txt
 clawrtc bcos attest --output bcos-attestation.json
 
 # 3. View in browser
-open https://rustchain.org/bcos/
+open https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md
 
 # 4. Export verification report
 clawrtc bcos report --format html --output report.html</code></pre>
@@ -1001,7 +1001,7 @@ clawrtc bcos report --format html --output report.html</code></pre>
       <ul>
         <li><a href="https://github.com/Scottcjn/rustchain-bounties/issues/2294" target="_blank">Bounty #2294 Specification</a></li>
         <li><a href="../BEACON_CERTIFIED_OPEN_SOURCE.md" target="_blank">BCOS Methodology Spec</a></li>
-        <li><a href="https://rustchain.org/bcos/" target="_blank">BCOS Project Directory</a></li>
+        <li><a href="https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md" target="_blank">BCOS Methodology</a></li>
         <li><a href="https://github.com/Scottcjn/rustchain-bounties" target="_blank">RustChain Bounties</a></li>
       </ul>
 
@@ -1051,7 +1051,7 @@ clawrtc bcos report --format html --output report.html</code></pre>
       <h2 style="color: var(--accent);">🚀 Ready to Get Certified?</h2>
       <p style="margin: 20px 0;">Join 183+ projects using BCOS v2 for AI-assisted code verification</p>
       <div class="cta-buttons">
-        <a href="https://rustchain.org/bcos/" class="btn btn-primary">Verify Your Project</a>
+        <a href="https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md" class="btn btn-primary">Read Verification Methodology</a>
         <a href="https://github.com/Scottcjn/rustchain-bounties" class="btn btn-secondary">Claim a Bounty</a>
       </div>
       <pre><code># Get started in 30 seconds
@@ -1083,7 +1083,7 @@ clawrtc bcos verify</code></pre>
 
   <footer>
     <p>BCOS v2 — Beacon Certified Open Source</p>
-    <p>Free & Open Source (MIT) • On-Chain Verification • rustchain.org/bcos/</p>
+    <p>Free & Open Source (MIT) • On-Chain Verification • BCOS methodology</p>
     <p style="margin-top: 12px; font-size: 0.85em;">
       <a href="../index.html">Documentation</a> •
       <a href="https://github.com/Scottcjn/rustchain-bounties/issues/2294">Bounty #2294</a> •

--- a/docs/blog/rustchain-utility-coin-not-security.md
+++ b/docs/blog/rustchain-utility-coin-not-security.md
@@ -171,7 +171,7 @@ RTC is earned through work, spent on services, and anchored to physical reality.
 
 *RustChain is MIT-licensed open source. Star the repo: github.com/Scottcjn/Rustchain*
 *Block Explorer: rustchain.org/explorer*
-*BCOS Certification: rustchain.org/bcos*
+*BCOS Certification: https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md*
 
 ---
 

--- a/docs/mining.md
+++ b/docs/mining.md
@@ -1,0 +1,7 @@
+# RustChain Mining Guide
+
+The maintained mining documentation is [`MINING_GUIDE.md`](MINING_GUIDE.md).
+
+This compatibility page keeps the historical `docs/mining.md` link working and
+points readers to the current guide, which documents hardware requirements,
+installation, and reward mechanics.

--- a/tools/check_relative_links.py
+++ b/tools/check_relative_links.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Validate local Markdown and HTML links without making network requests."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+
+MARKDOWN_LINK = re.compile(r"(?<!!)\[[^\]]*\]\(([^)\s]+)")
+HTML_LINK = re.compile(r"(?:href|src)=[\"']([^\"']+)[\"']", re.IGNORECASE)
+SKIPPED_SCHEMES = ("http:", "https:", "mailto:", "tel:", "data:", "javascript:")
+
+
+def files_under(root: Path, inputs: list[str]) -> list[Path]:
+    files: set[Path] = set()
+    for raw in inputs:
+        path = (root / raw).resolve()
+        if path.is_file():
+            files.add(path)
+        elif path.is_dir():
+            files.update(path.rglob("*.md"))
+            files.update(path.rglob("*.html"))
+    return sorted(files)
+
+
+def local_targets(document: Path) -> set[str]:
+    text = document.read_text(encoding="utf-8")
+    # HTML-looking snippets inside Markdown code fences are examples, not
+    # links in the document itself. Only parse HTML attributes in real HTML.
+    targets = set(MARKDOWN_LINK.findall(text))
+    if document.suffix.lower() == ".html":
+        targets |= set(HTML_LINK.findall(text))
+    return targets
+
+
+def check(root: Path, documents: list[Path]) -> list[str]:
+    failures: list[str] = []
+    root = root.resolve()
+    for document in documents:
+        for raw in local_targets(document):
+            parsed = urlsplit(unquote(raw))
+            if parsed.scheme or raw.startswith("#") or raw.startswith("/"):
+                continue
+            target = (document.parent / parsed.path).resolve()
+            try:
+                target.relative_to(root)
+            except ValueError:
+                failures.append(f"{document}: link escapes repository: {raw}")
+                continue
+            if not target.exists():
+                failures.append(f"{document}: missing target: {raw}")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", help="Files or directories to inspect")
+    args = parser.parse_args()
+    root = Path.cwd()
+    documents = files_under(root, args.paths)
+    failures = check(root, documents)
+    if failures:
+        print("Relative link check failed:", file=sys.stderr)
+        print("\n".join(f"- {failure}" for failure in failures), file=sys.stderr)
+        return 1
+    print(f"Checked {len(documents)} Markdown/HTML files; all local targets exist.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #16248
Closes #7910
Closes #7908
Closes #7886
Closes #7885
Closes #7792

## Summary
- repair dead BCOS, tokenomics, mining, and stale DOI references across README and top-level docs
- add a compatibility page for the documented mining entry point
- add a dependency-free Python checker for relative Markdown and HTML links
- run the checker in the existing link-check workflow

## Verification
- `python tools/check_relative_links.py README.md docs` — Checked 177 Markdown/HTML files; all local targets exist.
- `python -m py_compile tools/check_relative_links.py`
- `git diff --check`
