### PR TITLE
fix(installer): resolve macOS crashes, missing variables, and safe sys.argv sha256 fallback in install.sh (closes #16251)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -604,11 +604,11 @@ CFGEOF
     # --- Generate miner ID ---
     local miner_id
     if command -v sha256sum &>/dev/null; then
-        miner_id=$(echo -n "${wallet}-${arch}-$(hostname)" | sha256sum | cut -c1-16)
+        miner_id=$(printf '%s-%s-%s' "$wallet" "$arch" "$(hostname)" | sha256sum | cut -c1-16)
     elif command -v shasum &>/dev/null; then
-        miner_id=$(echo -n "${wallet}-${arch}-$(hostname)" | shasum -a 256 | cut -c1-16)
+        miner_id=$(printf '%s-%s-%s' "$wallet" "$arch" "$(hostname)" | shasum -a 256 | cut -c1-16)
     elif command -v python3 &>/dev/null; then
-        miner_id=$(python3 -c "import hashlib; print(hashlib.sha256(b'${wallet}-${arch}-' + b'$(hostname)').hexdigest()[:16])" 2>/dev/null || echo "${wallet}")
+        miner_id=$(python3 -c 'import sys, hashlib; print(hashlib.sha256(f"{sys.argv[1]}-{sys.argv[2]}-{sys.argv[3]}".encode()).hexdigest()[:16])' "$wallet" "$arch" "$(hostname)" 2>/dev/null || echo "$wallet")
     else
         miner_id="${wallet}"
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,6 +57,7 @@ if [ "$(uname -s)" = "Darwin" ]; then
     MINER_FILENAME="rustchain_mac_miner_v2.5.py"
     MINER_URL="${REPO_RAW}/miners/macos/${MINER_FILENAME}"
     FINGERPRINT_URL="${REPO_RAW}/miners/macos/fingerprint_checks.py"
+    MINER_CRYPTO_URL="${REPO_RAW}/miners/macos/miner_crypto.py"
 else
     MINER_FILENAME="rustchain_linux_miner.py"
     MINER_URL="${REPO_RAW}/miners/linux/rustchain_linux_miner.py"
@@ -602,7 +603,15 @@ CFGEOF
 
     # --- Generate miner ID ---
     local miner_id
-    miner_id=$(echo -n "${wallet}-${arch}-$(hostname)" | sha256sum 2>/dev/null | cut -c1-16 || echo "${wallet}")
+    if command -v sha256sum &>/dev/null; then
+        miner_id=$(echo -n "${wallet}-${arch}-$(hostname)" | sha256sum | cut -c1-16)
+    elif command -v shasum &>/dev/null; then
+        miner_id=$(echo -n "${wallet}-${arch}-$(hostname)" | shasum -a 256 | cut -c1-16)
+    elif command -v python3 &>/dev/null; then
+        miner_id=$(python3 -c "import hashlib; print(hashlib.sha256(b'${wallet}-${arch}-' + b'$(hostname)').hexdigest()[:16])" 2>/dev/null || echo "${wallet}")
+    else
+        miner_id="${wallet}"
+    fi
 
     # --- Create service ---
     echo ""

--- a/tests/test_macos_installer_compatibility.py
+++ b/tests/test_macos_installer_compatibility.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "scripts" / "install.sh"
+
+
+def test_installer_defines_miner_crypto_url_for_macos():
+    script = INSTALLER.read_text(encoding="utf-8")
+    darwin_block = script.split('if [ "$(uname -s)" = "Darwin" ]; then')[1].split("else")[0]
+    assert "MINER_CRYPTO_URL=" in darwin_block
+
+
+def test_installer_uses_portable_sha256_for_miner_id():
+    script = INSTALLER.read_text(encoding="utf-8")
+    assert "shasum -a 256" in script
+    assert "hashlib.sha256" in script


### PR DESCRIPTION
Resubmitting PR per @Scottcjn review:

## Security Hardening
- Replaced inline string interpolation in `python3 -c` fallback with safe positional arguments (`sys.argv[1]`, `sys.argv[2]`, `sys.argv[3]`), eliminating potential arbitrary code injection via `--wallet`.
- Replaced `echo -n` with `printf '%s-%s-%s'` for clean POSIX execution.

## Fixes & Compatibility
1. **Darwin/macOS Support:** Correctly defines `MINER_CRYPTO_URL` in Darwin branch and uses portable `shasum -a 256` / `python3 sys.argv` fallbacks when `sha256sum` is missing.
2. **Test Suite:** Passes `tests/test_macos_installer_compatibility.py` 100%.

Closes #16251
Bounty claim: Scottcjn/rustchain-bounties#16251 (10 RTC)

Wallet: RTCfe13452d122263caf633ab1876bd9631133b68b1