### PR TITLE
fix: wrap mempool_clear_expired() in BEGIN IMMEDIATE to prevent concurrent mempool corruption (fixes #8176) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -1535,9 +1535,16 @@ class UtxoDB:
             conn.close()
 
     def mempool_clear_expired(self) -> int:
-        """Remove expired transactions from mempool. Returns count removed."""
+        """Remove expired transactions from mempool. Returns count removed.
+
+        Uses BEGIN IMMEDIATE to ensure the SELECT-then-DELETE sequence is
+        atomic. Without it, a concurrent mempool_add() or apply_transaction()
+        can interleave between the SELECT and the DELETEs, causing mempool
+        state corruption / double-spend (B2, issue #8176).
+        """
         conn = self._conn()
         try:
+            conn.execute("BEGIN IMMEDIATE")
             now = int(time.time())
             try:
                 expired = conn.execute(
@@ -1546,22 +1553,29 @@ class UtxoDB:
                 ).fetchall()
             except sqlite3.OperationalError as exc:
                 if "no such table" in str(exc).lower():
+                    conn.execute("ROLLBACK")
                     return 0
+                conn.execute("ROLLBACK")
                 raise
-            else:
-                count = 0
-                for row in expired:
-                    conn.execute(
-                        "DELETE FROM utxo_mempool_inputs WHERE tx_id = ?",
-                        (row['tx_id'],),
-                    )
-                    conn.execute(
-                        "DELETE FROM utxo_mempool WHERE tx_id = ?",
-                        (row['tx_id'],),
-                    )
-                    count += 1
-                conn.commit()
-                return count
+            count = 0
+            for row in expired:
+                conn.execute(
+                    "DELETE FROM utxo_mempool_inputs WHERE tx_id = ?",
+                    (row['tx_id'],),
+                )
+                conn.execute(
+                    "DELETE FROM utxo_mempool WHERE tx_id = ?",
+                    (row['tx_id'],),
+                )
+                count += 1
+            conn.commit()
+            return count
+        except Exception:
+            try:
+                conn.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
         finally:
             conn.close()
 


### PR DESCRIPTION
## Fix #8176: mempool_clear_expired() missing BEGIN IMMEDIATE

### Problem
`mempool_clear_expired()` (in `node/utxo_db.py`) performs a SELECT to find expired transactions, then loops through doing two DELETE operations per row, then calls `conn.commit()` — all **without wrapping the operation in `BEGIN IMMEDIATE`**.

This means a concurrent `mempool_add()` or `apply_transaction()` can interleave between the SELECT and the DELETEs, causing:
- Mempool state corruption
- Double-spend on UTXO boxes
- Concurrent mempool corruption (B2)

### Fix
Follow the same pattern used by `mempool_remove()` (line 1342-1367): wrap the entire SELECT → DELETE → COMMIT sequence in `BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK`, so SQLite's internal write-lock guarantees no other writer can interleave.

### Changes
- Added `conn.execute("BEGIN IMMEDIATE")` before the SELECT
- Added `conn.execute("ROLLBACK")` in the `OperationalError` (no-such-table) catch
- Added outer `except Exception` to rollback and re-raise on any unexpected error
- The `else` branch was removed; the normal path now runs at the outer level (still inside the transaction)

### Testing
- ✅ Python syntax check passed
- ✅ Python compile check passed
- Follows the same proven pattern as `mempool_remove()` (which already uses BEGIN IMMEDIATE)