### PR TITLE
fix(p2p): require auth on /p2p/gossip POST + correct state root endianness

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -1818,6 +1818,12 @@ def register_p2p_endpoints(app, p2p_node: RustChainP2PNode):
     @app.route('/p2p/gossip', methods=['POST'])
     def receive_gossip():
         """Receive and process gossip message"""
+        # Auth: every other P2P endpoint requires X-P2P-Key. The gossip
+        # POST feeds CRDT merges, so it needs the same gate.
+        auth_error = _require_p2p_read_auth()
+        if auth_error:
+            return auth_error
+
         # FIX(#2867 M5): per-IP rate limit BEFORE expensive verify+CRDT work.
         remote_ip = request.headers.get('X-Forwarded-For', request.remote_addr or 'unknown').split(',')[0].strip()
         if not _gossip_rate_check(remote_ip):

--- a/node/tests/test_p2p_gossip_routes.py
+++ b/node/tests/test_p2p_gossip_routes.py
@@ -54,7 +54,7 @@ def test_p2p_gossip_requires_json_object():
     app, node = _app_and_node()
 
     with app.test_client() as client:
-        resp = client.post("/p2p/gossip", json=["not", "an", "object"])
+        resp = client.post("/p2p/gossip", json=["not", "an", "object"], headers={"X-P2P-Key": "a" * 64})
 
     assert resp.status_code == 400
     assert resp.get_json()["error"] == "JSON object required"
@@ -66,7 +66,7 @@ def test_p2p_gossip_forwards_valid_object_body():
     payload = {"msg_type": "ping"}
 
     with app.test_client() as client:
-        resp = client.post("/p2p/gossip", json=payload)
+        resp = client.post("/p2p/gossip", json=payload, headers={"X-P2P-Key": "a" * 64})
 
     assert resp.status_code == 200
     assert resp.get_json()["status"] == "ok"
@@ -89,7 +89,7 @@ def test_p2p_gossip_rejects_oversized_payload_before_handler():
     }
 
     with app.test_client() as client:
-        resp = client.post("/p2p/gossip", json=payload)
+        resp = client.post("/p2p/gossip", json=payload, headers={"X-P2P-Key": "a" * 64})
 
     assert resp.status_code == 400
     assert "too many keys" in resp.get_json()["error"]
@@ -112,3 +112,24 @@ def test_gossip_message_rejects_payload_that_exceeds_serialized_cap():
 
     with pytest.raises(ValueError, match="maximum serialized size"):
         GossipMessage.from_dict(payload)
+
+
+def test_p2p_gossip_requires_auth_header():
+    """Without X-P2P-Key the gossip POST should be rejected."""
+    app, node = _app_and_node()
+    with app.test_client() as client:
+        resp = client.post("/p2p/gossip", json={"msg_type": "ping"})
+    assert resp.status_code == 401
+    assert node.handled == []
+
+
+def test_p2p_gossip_accepts_valid_auth():
+    """With the correct X-P2P-Key the gossip POST should succeed."""
+    app, node = _app_and_node()
+    payload = {"msg_type": "ping"}
+    with app.test_client() as client:
+        resp = client.post(
+            "/p2p/gossip", json=payload, headers={"X-P2P-Key": "a" * 64}
+        )
+    assert resp.status_code == 200
+    assert node.handled == [payload]

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -943,7 +943,7 @@ class UtxoDB:
                 return hashlib.sha256(b"empty").hexdigest()
 
             # Mix element count into leaf hashes to bind tree to cardinality
-            count_bytes = len(rows).to_bytes(8, 'little')
+            count_bytes = len(rows).to_bytes(8, 'big')
             hashes = []
             for row in rows:
                 leaf = {


### PR DESCRIPTION
## Summary

Fixes #8177 — two findings addressed.

### Finding 1: /p2p/gossip POST has no auth

Every P2P read endpoint (`/p2p/state`, `/p2p/attestation_state`, `/p2p/peers`) calls `_require_p2p_read_auth()` to validate the `X-P2P-Key` header. The gossip POST — the write endpoint that feeds CRDT merges via `p2p_node.handle_gossip()` — had only per-IP rate limiting, no auth.

That meant any network-accessible attacker could POST gossip messages without knowing the P2P secret, potentially injecting fake attestation records or corrupting epoch state.

**Fix:** Added `_require_p2p_read_auth()` at the top of the `receive_gossip` handler, before the rate limit check.

### Finding 2: State root endianness mismatch

`compute_box_id()` uses `to_bytes(8, "big")` and `to_bytes(2, "big")` for all integer encoding. The state root merkle tree leaf computation used `len(rows).to_bytes(8, "little")` for the count prefix — inconsistent with the rest of the hashing code.

**Fix:** Changed to `to_bytes(8, "big")` so the state root is deterministically reproducible across implementations assuming uniform big-endian encoding.

## Testing

- Added two tests: `test_p2p_gossip_requires_auth_header` (verifies 401 without key) and `test_p2p_gossip_accepts_valid_auth` (verifies 200 with valid key)
- Updated existing gossip tests to include the `X-P2P-Key` header
- `pytest node/tests/test_p2p_gossip_routes.py` — 6/6 pass

```
test_p2p_gossip_requires_json_object PASSED
test_p2p_gossip_forwards_valid_object_body PASSED
test_p2p_gossip_rejects_oversized_payload_before_handler PASSED
test_gossip_message_rejects_payload_that_exceeds_serialized_cap PASSED
test_p2p_gossip_requires_auth_header PASSED
test_p2p_gossip_accepts_valid_auth PASSED
```