### PR TITLE
fix(utxo): clear pending intent on genesis rollback, bound transfer coin selection (#2819)

### DIFF
--- a/node/test_utxo_2819_rollback_mempool_and_bounded_select.py
+++ b/node/test_utxo_2819_rollback_mempool_and_bounded_select.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for two findings on bounty #2819.
+
+Reported by @AInoAKARI.
+
+1. rollback_genesis() left mempool claims behind. Genesis box ids are
+   deterministic, so re-running the migration recreated the exact box a stale
+   pending transaction still claimed, and it came back already reserved.
+
+2. utxo_transfer() coin selection fetched every unspent box for the sender.
+   Anyone can send dust to any address, so a third party could fragment a
+   wallet and inflate the cost of its owner's transfers.
+"""
+
+import hashlib
+import os
+import sqlite3
+import sys
+import tempfile
+import shutil
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from utxo_genesis_migration import migrate, rollback_genesis
+from utxo_db import (
+    UtxoDB,
+    UNIT,
+    MAX_COINBASE_OUTPUT_NRTC,
+    COIN_SELECT_MAX_INPUTS,
+    coin_select,
+)
+
+
+class TestRollbackEvictsMempoolClaims(unittest.TestCase):
+    """Finding 1: rollback must clear pending intent, not just state."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "rollback_mempool.db")
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS balances (
+                   miner_id TEXT PRIMARY KEY,
+                   amount_i64 INTEGER NOT NULL DEFAULT 0
+               )"""
+        )
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64) VALUES (?,?)",
+            ("wallet_a", 100 * UNIT),
+        )
+        conn.commit()
+        conn.close()
+        self.db = UtxoDB(self.db_path)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _genesis_box_id(self):
+        boxes = self.db.get_unspent_for_address("wallet_a")
+        self.assertEqual(len(boxes), 1, "expected exactly one genesis box")
+        return boxes[0]["box_id"]
+
+    def test_stale_claim_does_not_survive_rollback_and_remigrate(self):
+        migrate(self.db_path, dry_run=False)
+        box_id = self._genesis_box_id()
+        box_value = self.db.get_unspent_for_address("wallet_a")[0]["value_nrtc"]
+
+        ok = self.db.mempool_add(
+            {
+                "tx_id": "pending_before_rollback",
+                "tx_type": "transfer",
+                "inputs": [{"box_id": box_id, "spending_proof": "sig"}],
+                "outputs": [{"address": "wallet_b", "value_nrtc": box_value}],
+                "fee_nrtc": 0,
+            }
+        )
+        self.assertTrue(ok, "mempool should accept a spend of the genesis box")
+        self.assertTrue(
+            self.db.mempool_check_double_spend(box_id),
+            "precondition: the box is claimed while the tx is pending",
+        )
+
+        rollback_genesis(self.db_path)
+
+        self.assertFalse(
+            self.db.mempool_check_double_spend(box_id),
+            "rollback must not leave a claim on a box it deleted",
+        )
+
+        # Same balances in, so the migration is expected to rebuild the very
+        # same box id. That determinism is what made the stale claim dangerous.
+        migrate(self.db_path, dry_run=False)
+        self.assertEqual(
+            self._genesis_box_id(),
+            box_id,
+            "precondition: genesis box ids are deterministic",
+        )
+        self.assertFalse(
+            self.db.mempool_check_double_spend(box_id),
+            "a freshly migrated box must not be born already reserved",
+        )
+
+    def test_rollback_leaves_unrelated_mempool_entries_alone(self):
+        """Eviction must be scoped to genesis boxes, not the whole mempool."""
+        migrate(self.db_path, dry_run=False)
+        genesis_box = self._genesis_box_id()
+        genesis_value = self.db.get_unspent_for_address("wallet_a")[0]["value_nrtc"]
+
+        self.db.apply_transaction(
+            {
+                "tx_id": "coinbase_for_carol",
+                "tx_type": "mining_reward",
+                "inputs": [],
+                "outputs": [{"address": "carol", "value_nrtc": 50 * UNIT}],
+                "fee_nrtc": 0,
+                "_allow_minting": True,
+            },
+            block_height=1,
+        )
+        carol_box = self.db.get_unspent_for_address("carol")[0]["box_id"]
+
+        self.db.mempool_add(
+            {
+                "tx_id": "genesis_spender",
+                "tx_type": "transfer",
+                "inputs": [{"box_id": genesis_box, "spending_proof": "sig"}],
+                "outputs": [{"address": "wallet_b", "value_nrtc": genesis_value}],
+                "fee_nrtc": 0,
+            }
+        )
+        self.db.mempool_add(
+            {
+                "tx_id": "unrelated_spender",
+                "tx_type": "transfer",
+                "inputs": [{"box_id": carol_box, "spending_proof": "sig"}],
+                "outputs": [{"address": "dave", "value_nrtc": 50 * UNIT}],
+                "fee_nrtc": 0,
+            }
+        )
+
+        # Non-genesis UTXO state exists, so rollback is expected to refuse.
+        with self.assertRaises(RuntimeError):
+            rollback_genesis(self.db_path)
+
+        # And having refused, it must not have evicted anything.
+        self.assertTrue(self.db.mempool_check_double_spend(genesis_box))
+        self.assertTrue(self.db.mempool_check_double_spend(carol_box))
+
+
+class TestBoundedCoinSelectCandidates(unittest.TestCase):
+    """Finding 2: coin selection must not scale with wallet fragmentation."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "bounded_select.db")
+        self.db = UtxoDB(self.db_path)
+        self.db.init_tables()
+        self._next_block = 1
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _fragment(self, address, count, value_nrtc):
+        """Give `address` `count` boxes, the way a dust sender would.
+
+        Uses the real minting path in batches, since MAX_OUTPUTS caps how many
+        boxes one transaction may create.
+        """
+        # A minting tx may not exceed MAX_COINBASE_OUTPUT_NRTC in total, and
+        # MAX_OUTPUTS caps how many boxes one tx may create, so size batches to
+        # respect both.
+        per_batch = min(100, max(1, MAX_COINBASE_OUTPUT_NRTC // value_nrtc))
+        remaining = count
+        batch = 0
+        while remaining > 0:
+            n = min(remaining, per_batch)
+            tx_id = hashlib.sha256(
+                f"frag:{address}:{batch}".encode()
+            ).hexdigest()
+            ok = self.db.apply_transaction(
+                {
+                    "tx_id": tx_id,
+                    "tx_type": "mining_reward",
+                    "inputs": [],
+                    "outputs": [
+                        {"address": address, "value_nrtc": value_nrtc}
+                        for _ in range(n)
+                    ],
+                    "fee_nrtc": 0,
+                    "_allow_minting": True,
+                },
+                block_height=self._next_block,
+            )
+            self.assertTrue(ok, f"failed to mint fragment batch {batch}")
+            self._next_block += 1
+            remaining -= n
+            batch += 1
+
+    def test_candidate_set_is_bounded(self):
+        self._fragment("victim", 500, 1000)
+        candidates = self.db.get_coin_select_candidates("victim")
+        self.assertLessEqual(
+            len(candidates),
+            2 * COIN_SELECT_MAX_INPUTS + 1,
+            "candidate set must not grow with the size of the wallet",
+        )
+        self.assertEqual(
+            len(self.db.get_unspent_for_address("victim")),
+            500,
+            "precondition: the wallet really is fragmented",
+        )
+
+    def test_candidates_are_deduplicated(self):
+        """The two slices overlap on small wallets and must not double up."""
+        self._fragment("small", 5, 1000)
+        candidates = self.db.get_coin_select_candidates("small")
+        ids = [c["box_id"] for c in candidates]
+        self.assertEqual(len(ids), len(set(ids)), "duplicate boxes returned")
+        self.assertEqual(len(ids), 5, "a small wallet returns every box once")
+
+    def test_selection_matches_unbounded_input(self):
+        """Bounded candidates must not change what coin_select() picks."""
+        cases = [
+            ("dusty", 300, 1000, 5000),          # many tiny boxes
+            ("mixed", 60, 1 * UNIT, 15 * UNIT),   # comfortably covered
+            ("tight", 40, 1000, 39_000),          # needs most of the wallet
+        ]
+        for address, count, value, target in cases:
+            with self.subTest(address=address):
+                self._fragment(address, count, value)
+                full = self.db.get_unspent_for_address(address)
+                bounded = self.db.get_coin_select_candidates(address)
+
+                sel_full, change_full = coin_select(full, target)
+                sel_bounded, change_bounded = coin_select(bounded, target)
+
+                self.assertEqual(
+                    sorted(b["box_id"] for b in sel_full),
+                    sorted(b["box_id"] for b in sel_bounded),
+                    f"{address}: bounded selection diverged from unbounded",
+                )
+                self.assertEqual(change_full, change_bounded)
+
+    def test_insufficient_funds_still_reported(self):
+        """A bounded fetch must not turn 'too poor' into a wrong selection."""
+        self._fragment("poor", 100, 1000)  # 100_000 nrtc total
+        bounded = self.db.get_coin_select_candidates("poor")
+        selected, change = coin_select(bounded, 10 * UNIT)
+        self.assertEqual(selected, [])
+        self.assertEqual(change, 0)
+
+    def test_rejects_bad_max_inputs(self):
+        for bad in (0, -1, True, "20", None):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    self.db.get_coin_select_candidates("anyone", max_inputs=bad)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -44,6 +44,11 @@ MAX_POOL_SIZE = 10_000
 # Without this, a single tx creates unlimited outputs, bloating the UTXO set.
 MAX_INPUTS = 100
 MAX_OUTPUTS = 100
+
+# coin_select() never returns more than this many inputs: smallest-first is
+# abandoned above it, and largest-first is hard-capped at it. Coin selection
+# therefore only ever needs a bounded slice of a wallet, never all of it.
+COIN_SELECT_MAX_INPUTS = 20
 MAX_DATA_INPUTS = 100
 MAX_UTXO_ADDRESS_BYTES = 256
 MAX_UTXO_METADATA_BYTES = 8_192
@@ -447,6 +452,58 @@ class UtxoDB:
             return [dict(r) for r in rows]
         finally:
             conn.close()
+
+    def get_coin_select_candidates(
+        self, address: str, max_inputs: int = COIN_SELECT_MAX_INPUTS
+    ) -> List[dict]:
+        """Bounded candidate set for coin selection over *address*.
+
+        `coin_select()` reads a wallet in only two orders: smallest-first, which
+        it abandons once the selection exceeds COIN_SELECT_MAX_INPUTS, and
+        largest-first, which it caps at that same bound. So it can never look
+        past the cheapest `max_inputs + 1` boxes or the dearest `max_inputs`,
+        and loading the rest is wasted work.
+
+        That waste is attacker-controlled: anyone may send minimum-value boxes
+        to any address, so an unbounded fetch lets a third party fragment a
+        wallet and make each of the owner's later transfers materialize the
+        whole thing. Fetching a bounded slice keeps the cost of a transfer
+        independent of how fragmented the wallet is.
+
+        Returns the union of both slices, deduplicated by box_id. Feeding this
+        to coin_select() yields the same selection as feeding it every unspent
+        box, because both of its passes see an identical prefix.
+        """
+        if not isinstance(max_inputs, int) or isinstance(max_inputs, bool) or max_inputs < 1:
+            raise ValueError("max_inputs must be a positive integer")
+
+        base = """SELECT * FROM utxo_boxes
+                  WHERE owner_address = ? AND spent_at IS NULL"""
+        conn = self._conn()
+        try:
+            # Smallest-first needs one extra row: it is the row that proves the
+            # selection would have exceeded the cap, sending coin_select() down
+            # its largest-first path.
+            cheapest = conn.execute(
+                base + " ORDER BY value_nrtc ASC, box_id ASC LIMIT ?",
+                (address, max_inputs + 1),
+            ).fetchall()
+            dearest = conn.execute(
+                base + " ORDER BY value_nrtc DESC, box_id DESC LIMIT ?",
+                (address, max_inputs),
+            ).fetchall()
+        finally:
+            conn.close()
+
+        merged: List[dict] = []
+        seen = set()
+        for row in list(cheapest) + list(dearest):
+            box = dict(row)
+            if box["box_id"] in seen:
+                continue
+            seen.add(box["box_id"])
+            merged.append(box)
+        return merged
 
     def count_unspent_for_address(self, address: str) -> int:
         """Count unspent boxes for an address without materializing them."""

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -487,11 +487,11 @@ class UtxoDB:
             cheapest = conn.execute(
                 base + " ORDER BY value_nrtc ASC, box_id ASC LIMIT ?",
                 (address, max_inputs + 1),
-            ).fetchall()
+            ).fetchall()  # fetchall-ok: already-paginated (LIMIT max_inputs + 1)
             dearest = conn.execute(
                 base + " ORDER BY value_nrtc DESC, box_id DESC LIMIT ?",
                 (address, max_inputs),
-            ).fetchall()
+            ).fetchall()  # fetchall-ok: already-paginated (LIMIT max_inputs)
         finally:
             conn.close()
 

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -687,8 +687,11 @@ def utxo_transfer():
     # 28999999.999... → 28999999 lost-rtc bug).
     target_nrtc = amount_nrtc + fee_nrtc
 
-    # Select UTXOs
-    utxos = _utxo_db.get_unspent_for_address(from_address)
+    # Select UTXOs.
+    # Bounded fetch: coin_select() only ever reads the cheapest or the dearest
+    # slice of a wallet, so loading every unspent box let a third party inflate
+    # the cost of this call by sending dust to the sender's address.
+    utxos = _utxo_db.get_coin_select_candidates(from_address)
     selected, change_nrtc = coin_select(utxos, target_nrtc)
 
     if not selected:

--- a/node/utxo_genesis_migration.py
+++ b/node/utxo_genesis_migration.py
@@ -334,6 +334,15 @@ def rollback_genesis(db_path: str) -> int:
     Wrapped in a single BEGIN IMMEDIATE transaction so no partial
     deletion state is possible. Idempotent: safe to call when no
     genesis data exists (returns 0).
+
+    Mempool transactions depending on a genesis box are evicted in the same
+    transaction. They cannot be left behind: genesis box ids are deterministic
+    (see compute_genesis_tx_id / compute_box_id), so re-running the migration
+    over unchanged balances recreates the very same box the stale mempool entry
+    still claims. That box would come back already reserved by a transaction
+    from before the rollback, blocking fresh spends and leaving the old
+    transaction eligible for inclusion. Rolling back has to clear pending
+    intent as well as state, or it is not a rollback.
     """
     utxo_db = UtxoDB(db_path)
     conn = utxo_db._conn()
@@ -349,6 +358,22 @@ def rollback_genesis(db_path: str) -> int:
             raise RuntimeError(
                 "refusing to rollback genesis while non-genesis UTXO state exists"
             )
+
+        # Identify genesis boxes before deleting them, so any mempool
+        # transaction spending or referencing one can be evicted below.
+        genesis_box_ids = [
+            row["box_id"]
+            for row in conn.execute(
+                """SELECT box_id FROM utxo_boxes
+                   WHERE transaction_id IN (
+                       SELECT tx_id FROM utxo_transactions WHERE tx_type = 'genesis'
+                   )"""
+            )
+        ]
+
+        # Drop mempool txs claiming those boxes as inputs or data_inputs.
+        # Same connection, so this is inside the BEGIN IMMEDIATE above.
+        utxo_db._evict_stale_data_input_txs(genesis_box_ids, conn=conn)
 
         # Delete only boxes produced by genesis transactions. A non-genesis
         # box can legitimately have creation_height=0.


### PR DESCRIPTION
Fixes two findings on bounty #2819, reported by **@AInoAKARI**.

Both arrived by email rather than through this repo, because the reporter's agent harness returned `403 Resource not accessible by integration` and Private Vulnerability Reporting was disabled at the time. Both have been verified against `main` before writing any code. PVR is now enabled, and the findings are tracked as private draft advisories.

## 1. `rollback_genesis()` left pending intent behind

`node/utxo_genesis_migration.py`

The rollback deleted genesis boxes and transactions, but its guard `check_existing_non_genesis_utxo_state()` counted only `utxo_boxes` and `utxo_transactions`. The word `mempool` did not appear anywhere in the module, so a pending `utxo_mempool` / `utxo_mempool_inputs` claim neither blocked the rollback nor was cleared by it.

Genesis box ids are deterministic:

```python
compute_box_id(amount_nrtc, prop, GENESIS_HEIGHT, compute_genesis_tx_id(miner_id), 0)
```

No random or time derived input, so re-running the migration over unchanged balances rebuilds the identical box. The sequence:

1. migrate, producing genesis box `G`
2. a pending transfer claims `G`
3. rollback deletes `G`, the claim survives
4. re-migrate recreates the same `G`
5. `G` is born already reserved by a transaction from before the rollback

Fresh spends get rejected by the mempool claim guard, and the stale transaction stays eligible for inclusion, for the mempool lifetime.

**Fix:** collect the genesis box ids before deleting, then evict dependent mempool entries on the same connection, inside the existing `BEGIN IMMEDIATE`. This reuses `_evict_stale_data_input_txs()`, which already handles both regular inputs and `data_inputs` and already accepts an external connection, rather than adding a second purge path that could drift from it.

## 2. `utxo_transfer()` coin selection was unbounded

`node/utxo_endpoints.py`, `node/utxo_db.py`

The public read at `utxo_endpoints.py:368` was bounded by the earlier hardening (#13975 / #7399), using `limit` plus a keyset cursor. The transfer path was missed:

```python
utxos = _utxo_db.get_unspent_for_address(from_address)   # no limit
selected, change_nrtc = coin_select(utxos, target_nrtc)
```

`get_unspent_for_address()` appends its `LIMIT` clause only when `limit is not None`, then does `.fetchall()` and materializes every row as a dict. `MAX_INPUTS = 100` bounds validation, not the query.

The waste is attacker controlled. Anyone can send minimum value boxes to any address, so a third party can fragment a wallet and make each of the owner's later transfers materialize the whole thing.

**Fix:** `get_coin_select_candidates()` fetches only the slices `coin_select()` can actually read. It abandons smallest-first once a selection exceeds `COIN_SELECT_MAX_INPUTS` and hard caps largest-first at the same bound, so it never looks past the cheapest `max_inputs + 1` boxes or the dearest `max_inputs`. The extra cheap row is the one that proves the selection would have exceeded the cap, which is what sends `coin_select()` down its largest-first path.

Feeding the union of those two slices to `coin_select()` produces the same selection as feeding it every unspent box, because both passes see an identical prefix. `coin_select()` itself is unchanged, so there is no second copy of the selection rules to drift.

This is a residual path from the earlier public read hardening rather than a new class, exactly as the reporter framed it.

## Call site sweep

`get_unspent_for_address` has only two non test call sites in the repo. Line 368 was already bounded; line 691 was this bug. Every other hit is a test.

## Verification

Seven new cases in `node/test_utxo_2819_rollback_mempool_and_bounded_select.py`:

- stale claim does not survive rollback then re-migrate, asserting the recreated box id is genuinely identical
- eviction stays scoped: with unrelated mempool entries and non genesis state present, rollback refuses and evicts nothing
- candidate set stays bounded on a 500 box wallet
- candidates are deduplicated where the two slices overlap
- bounded selection matches unbounded selection across dusty, comfortably covered, and insufficient wallets
- insufficient funds still reported rather than silently mis-selected
- `max_inputs` validation rejects `0`, negatives, `True`, strings, and `None`

**Mutation check.** Reverting either fix while keeping the tests fails exactly the two cases targeting it, and no others.

**Regression.** No new failures. `test_utxo_db` 103 passed, `test_utxo_endpoints` + `test_rollback_atomicity` 48 passed, `test_utxo_security_audit` 24 passed, `test_utxo_mint_state_root_determinism` 4 passed, transfer suites 17 passed. Fourteen red team PoC scripts under `node/` fail on this branch and fail identically on `main`; the before and after failure sets are the same, and the only difference is the new file moving from failing to passing.

`ruff` is clean on all changed files. The three findings it reports in `utxo_db.py` are pre-existing and unchanged in count.

## Note on severity

No fund theft is claimed for either path. Finding 1 is state integrity and availability. Finding 2 is a residual resource path. Severity and payout are for the maintainer to decide, not settled by this PR.
