### PR TITLE
fix(p2p): send X-P2P-Key from every gossip sender, so enforcing it later is not an outage

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -897,6 +897,13 @@ class GossipLayer:
             resp = requests.post(
                 f"{peer_url}/p2p/gossip",
                 json=msg.to_dict(),
+                # Send the shared P2P secret, matching request_full_sync().
+                # /p2p/gossip does not require it yet, so this is inert today;
+                # it exists so that requiring it later is a config change
+                # rather than a fleet-wide outage. A receiver that starts
+                # enforcing while this path sends nothing 401s every gossip
+                # message, which is how the broadcast fan-out would go dark.
+                headers={"X-P2P-Key": P2P_SECRET},
                 timeout=10,
                 verify=TLS_VERIFY
             )

--- a/tests/test_p2p_gossip_sender_auth.py
+++ b/tests/test_p2p_gossip_sender_auth.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Every /p2p/gossip sender must present X-P2P-Key.
+
+The receiving endpoint does not require the header yet. This test exists so
+that requiring it stays a one-line config change instead of a fleet-wide
+outage: if a sender is added without the header and the receiver later starts
+enforcing, `broadcast()` fan-out 401s and inter-node gossip stops. CI cannot
+catch that, since it needs two live nodes, so the invariant is pinned here.
+
+Context: Scottcjn/Rustchain#8190 proposed enforcement on the receiver while
+`_send_to_peer()` still sent no header.
+"""
+import ast
+import os
+import unittest
+
+GOSSIP = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "node", "rustchain_p2p_gossip.py",
+)
+
+
+def _posts_to_gossip(node):
+    """True if this call is requests.post(...) targeting /p2p/gossip."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if not (isinstance(func, ast.Attribute) and func.attr == "post"):
+        return False
+    for arg in node.args:
+        if isinstance(arg, ast.JoinedStr):
+            for part in arg.values:
+                if isinstance(part, ast.Constant) and "/p2p/gossip" in str(part.value):
+                    return True
+        if isinstance(arg, ast.Constant) and "/p2p/gossip" in str(arg.value):
+            return True
+    return False
+
+
+class TestGossipSendersAuthenticate(unittest.TestCase):
+
+    def setUp(self):
+        with open(GOSSIP, "r") as fh:
+            self.src = fh.read()
+        self.tree = ast.parse(self.src)
+
+    def test_every_gossip_post_sends_the_shared_key(self):
+        senders = [n for n in ast.walk(self.tree) if _posts_to_gossip(n)]
+        self.assertGreater(len(senders), 0, "found no /p2p/gossip senders to check")
+
+        missing = []
+        for call in senders:
+            kw = {k.arg for k in call.keywords if k.arg}
+            if "headers" not in kw:
+                missing.append(call.lineno)
+                continue
+            headers = next(k.value for k in call.keywords if k.arg == "headers")
+            text = ast.dump(headers)
+            if "X-P2P-Key" not in text:
+                missing.append(call.lineno)
+
+        self.assertEqual(
+            missing, [],
+            "these /p2p/gossip senders omit the X-P2P-Key header, so gossip "
+            f"from them breaks the moment the receiver enforces it: lines {missing}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Groundwork so that #8190 can land without taking the network down.

## The gap

`/p2p/gossip` has two senders in `node/rustchain_p2p_gossip.py`:

- `request_full_sync()` at line ~1538 sends `headers={"X-P2P-Key": P2P_SECRET}`
- `_send_to_peer()` at line ~894, which is what `broadcast()` fans out through, sends no headers at all

The receiving endpoint does not require the header today, so nothing fails and the inconsistency is invisible.

It stops being invisible the moment anyone enforces on the receiver. #8190 proposes precisely that, adding `_require_p2p_read_auth()` to `/p2p/gossip`, and adds the header to zero senders. Merged as written it would 401 every broadcast message and stop inter-node gossip fleet-wide. The finding behind that PR is correct; only the sender half is missing.

## This change

Send the header from `_send_to_peer()` too. Inert today, because nothing checks it. What it buys is that enforcement becomes a config change rather than an outage: once every node in the fleet is running a build that sends the key, the receiver can require it.

## The test

CI cannot catch the original problem. It needs two live nodes talking to each other, and nothing in the suite does that. So the invariant is pinned statically instead: the test walks the AST for `requests.post(...)` calls whose URL contains `/p2p/gossip` and asserts each one passes `X-P2P-Key`. A sender added later without the header fails in CI rather than in production.

Reverting the source change fails the test, so it is checking the thing it claims to check.

## Verification

Full CI suite: 3729 passed, 46 skipped, 2 xfailed, 0 failed.

## Not included

Enforcement on the receiver. That is #8190's change to make, and it should land only after the fleet is running a build that sends the key, ideally behind a flag so the cutover is reversible without a redeploy.
