### PR TITLE
fix(rip-309b): score unmeasurable hardware as neutral, fail closed on no evidence, reconcile #8064

### DIFF
--- a/node/rip_200_round_robin_1cpu1vote.py
+++ b/node/rip_200_round_robin_1cpu1vote.py
@@ -206,11 +206,18 @@ ANTIQUITY_MULTIPLIERS = {
     # Sony
     "ps1_mips": 2.8,          # PlayStation 1 - MIPS R3000A (1994)
 
-    # Generic CPU families used across consoles and computers
-    "6502": 2.8,              # MOS 6502 (Apple II, Commodore 64, NES, Atari)
-    "65c02": 2.7,             # WDC 65C02 (Apple IIe enhanced, BBC Master)
-    "65c816": 2.7,            # WDC 65C816 (SNES, Apple IIGS)
-    "z80": 2.6,               # Zilog Z80 (Game Boy, SMS, MSX, Spectrum)
+    # Generic CPU families — these bare keys mean a STANDALONE micro (Apple II,
+    # C64, MSX, Spectrum), not a console. Console silicon has its own prefixed
+    # keys above (nes_6502 2.8, snes_65c816 2.7, gameboy_z80 2.6) and keeps the
+    # higher rate, because a Pico-bridged console presents a measured
+    # anti_emulation check while a standalone micro presents an HTTP payload
+    # that cannot be told apart from a forgery. Kept in step with
+    # HARDWARE_WEIGHTS["MOS"] / ["Zilog"] in the node — two tables disagreeing
+    # about the same silicon is how the rotation-selector bug happened.
+    "6502": 2.5,              # MOS 6502 standalone (Apple II, C64, Atari)
+    "65c02": 2.4,             # WDC 65C02 (Apple IIe enhanced, BBC Master)
+    "65c816": 2.4,            # WDC 65C816 standalone (Apple IIGS)
+    "z80": 2.3,               # Zilog Z80 standalone (MSX, Spectrum, CP/M)
     "sh1": 2.7,               # Hitachi SH-1 (1992) - early embedded
     "sh2": 2.6,               # Hitachi SH-2 (Sega Saturn, 32X)
     "sh4": 2.3,               # Hitachi SH-4 (Dreamcast, 1998) - 200MHz superscalar

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3941,6 +3941,113 @@ def fetch_miner_fingerprint_sequence(conn, miner: str) -> list:
     return out
 
 
+# === RIP-309c: measurement freshness binding ===
+# The attestation ENVELOPE is already fresh: /attest/submit requires a live
+# server-issued challenge from /attest/challenge, single-use, 300s expiry. What
+# is not bound is the measurement CONTENT. Nothing stops a client wrapping
+# values measured once, long ago, in a nonce fetched a second ago — and the
+# reference client does exactly that, measuring at startup and caching for the
+# life of the process (miners/linux/rustchain_linux_miner.py: the re-measure is
+# guarded by `not self.fingerprint_data`).
+#
+# The fix is to make the measurement DEPEND on the challenge. The client
+# already holds the nonce before it would measure, so no protocol reordering is
+# needed: derive the size of the timing workload from the nonce, and report
+# what was run. A binding computed for a different nonce carries the wrong
+# iteration count and is detectable by recomputation alone.
+MEASUREMENT_WORKLOAD_MIN = 1000
+MEASUREMENT_WORKLOAD_SPAN = 1000
+
+
+def derive_measurement_workload(nonce: str) -> int:
+    """Iterations the client must run this round, derived from the challenge.
+
+    Deterministic and cheap on both sides: a 6502 or a 386 can take four hex
+    digits and loop. The server recomputes it rather than trusting the client's
+    claim, so a replayed binding built for last round's nonce does not match.
+    """
+    text = str(nonce or "")
+    if len(text) < 4:
+        return MEASUREMENT_WORKLOAD_MIN
+    try:
+        seed = int(text[:4], 16)
+    except ValueError:
+        seed = sum(ord(c) for c in text[:4])
+    return MEASUREMENT_WORKLOAD_MIN + (seed % MEASUREMENT_WORKLOAD_SPAN)
+
+
+def verify_measurement_binding(nonce: str, binding, expected_rate_ns=None,
+                               rate_tolerance: float = 4.0) -> dict:
+    """Check a measurement was produced for THIS challenge.
+
+    Two independent checks:
+
+    1. `iterations` must equal what this nonce implies. Exact, needs no
+       hardware model, and is what kills replay: a binding built for another
+       nonce carries another iteration count.
+    2. If a per-iteration cost is known for this miner from its own history,
+       the reported duration must be within `rate_tolerance` of it. This is
+       what makes fabricating a duration expensive rather than free, and it is
+       the same self-consistency argument as the temporal gate: the forger has
+       to keep reproducing its own claimed hardware's speed.
+
+    Returns a verdict dict; never raises on malformed input. `state` is
+    "absent" when the client sent nothing, which during rollout is normal and
+    must not be treated as failure.
+    """
+    if binding is None:
+        return {"state": "absent", "ok": False, "reason": "no_binding"}
+    if not isinstance(binding, dict):
+        return {"state": "malformed", "ok": False, "reason": "binding_not_dict"}
+
+    claimed_nonce = str(binding.get("nonce") or "")
+    if claimed_nonce and claimed_nonce != str(nonce or ""):
+        return {"state": "mismatch", "ok": False, "reason": "binding_nonce_mismatch"}
+
+    expected_iterations = derive_measurement_workload(nonce)
+    try:
+        iterations = int(binding.get("iterations"))
+    except (TypeError, ValueError):
+        return {"state": "malformed", "ok": False, "reason": "iterations_not_int"}
+    if iterations != expected_iterations:
+        return {
+            "state": "stale",
+            "ok": False,
+            "reason": f"workload_mismatch:expected={expected_iterations}:got={iterations}",
+        }
+
+    try:
+        duration_ns = float(binding.get("duration_ns"))
+    except (TypeError, ValueError):
+        return {"state": "malformed", "ok": False, "reason": "duration_not_numeric"}
+    if duration_ns <= 0:
+        return {"state": "malformed", "ok": False, "reason": "duration_not_positive"}
+
+    rate_ns = duration_ns / max(iterations, 1)
+    verdict = {
+        "state": "bound",
+        "ok": True,
+        "reason": "binding_ok",
+        "iterations": iterations,
+        "rate_ns": rate_ns,
+    }
+    if expected_rate_ns:
+        try:
+            expected = float(expected_rate_ns)
+        except (TypeError, ValueError):
+            expected = 0.0
+        if expected > 0:
+            ratio = rate_ns / expected
+            verdict["rate_ratio"] = ratio
+            if ratio > rate_tolerance or ratio < (1.0 / rate_tolerance):
+                verdict.update({
+                    "state": "rate_implausible",
+                    "ok": False,
+                    "reason": f"rate_deviates:ratio={ratio:.3f}",
+                })
+    return verdict
+
+
 # An identity with too little history to check is not trusted with the full
 # antiquity premium, and is not punished either. Zero would re-implement a
 # tenure gate at full strength and penalise honest newcomers; one would make a
@@ -5634,6 +5741,23 @@ def _submit_attestation_impl():
         # collected the full antiquity premium. Gate the bonus on it.
         hw_weight_raw = hw_weight
         hw_weight = apply_temporal_consistency_to_weight(hw_weight, temporal_review)
+
+        # RIP-309c phase 0: observe only. Record whether this submission bound
+        # its measurement to the challenge, so fleet adoption can be measured
+        # before anything depends on it. Deliberately NOT enforced here: a hard
+        # cutover is what made the unsigned-attestation change unmergeable, and
+        # the fleet includes vintage clients that are slow to update. When
+        # adoption is high enough, an unbound submission should lose part of
+        # the bonus through the temporal gate above, not be rejected.
+        measurement_binding_verdict = verify_measurement_binding(
+            nonce, data.get("measurement_binding")
+        )
+        if measurement_binding_verdict.get("state") not in ("absent", "bound"):
+            app.logger.warning(
+                f"[MEASUREMENT-BINDING] {miner[:20]}... "
+                f"state={measurement_binding_verdict.get('state')} "
+                f"reason={measurement_binding_verdict.get('reason')}"
+            )
         miner_id = _attest_valid_miner(data.get("miner_id")) or miner
 
         with closing(sqlite3.connect(DB_PATH)) as enroll_conn:
@@ -5725,6 +5849,11 @@ def _submit_attestation_impl():
         "device": device,
         "fingerprint_passed": fingerprint_passed,
         "temporal_review_flag": bool(temporal_review.get("review_flag")),
+        # RIP-309c: tells a client whether its measurement was bound to the
+        # challenge, and what workload the NEXT round expects. A client can
+        # adopt binding without a coordinated release by reading this.
+        "measurement_binding_state": measurement_binding_verdict.get("state"),
+        "measurement_workload_next": derive_measurement_workload(nonce),
         "macs_recorded": len(macs) if macs else 0,
         "warthog_bonus": warthog_bonus
     })

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3941,6 +3941,157 @@ def fetch_miner_fingerprint_sequence(conn, miner: str) -> list:
     return out
 
 
+# === RIP-309d: operator clustering (observe only) ===
+# Every other defence on this chain is per-miner, so a farm of N identities is
+# N independent, individually cheap trust-building exercises. Clustering makes
+# the OPERATOR the unit, which is the constraint the contributor-tenure panel
+# insisted on: per-cluster, not per-account.
+#
+# Co-location is NOT evidence of fraud, and on this chain the largest cluster
+# is an honest lab: seven machines behind one WAN address, a Cobalt Qube 3, a
+# G5, a POWER8 and a Victus among them. Clustering alone would penalise the
+# most genuine vintage fleet on the network first. So clustering is only half
+# the mechanism. The half that discriminates is whether the members'
+# measurement histories are INDEPENDENT.
+#
+# Real hardware of different vintages is wildly separated. Measured on that
+# lab: Qube 0.0021, sophiacore 0.0762, Victus 0.1102, G5 0.1227 — a ~58x
+# spread. A farm running one generator across many identities lands its
+# members close together. Independence is what a forger cannot cheaply
+# manufacture, because escaping it means modelling every fake machine
+# separately while each one still has to stay self-consistent over time.
+CLUSTER_INDEPENDENCE_METRIC = "clock_drift_cv"
+CLUSTER_MIN_MEMBERS_TO_JUDGE = 3
+CLUSTER_INDEPENDENT_SPREAD = 0.35
+# Row cap per link query. Generous relative to the current fleet, and every
+# truncation is logged, because a silently partial graph would make a farm
+# look like several small unrelated operators.
+CLUSTER_LINK_ROW_CAP = 200_000
+
+
+def _union_find_groups(pairs, singletons=()):
+    """Group ids transitively linked by any observed shared signal."""
+    parent = {}
+
+    def find(x):
+        parent.setdefault(x, x)
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a, b):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    for a, b in pairs:
+        union(a, b)
+    for s in singletons:
+        find(s)
+
+    groups = {}
+    for node in list(parent):
+        groups.setdefault(find(node), set()).add(node)
+    return [sorted(v) for v in groups.values()]
+
+
+def build_operator_clusters(conn) -> list:
+    """Cluster miners by SERVER-OBSERVED shared signals.
+
+    Deliberately excludes anything the miner asserts about itself. `client_ip`
+    is observed at request time by the node; hardware_id and mac_hash are
+    payload-derived but are already load-bearing for hardware binding, so
+    reusing them adds no new trust assumption.
+    """
+    pairs, seen = [], set()
+
+    def _link_by(sql):
+        groups = {}
+        try:
+            # Bounded read. Clustering wants the whole graph, but an
+            # unbounded fetchall in the node is the UTXO-OOM class (#6627),
+            # and these tables grow with every miner and every address they
+            # have ever attested from. Truncation is logged rather than
+            # silent: a partial graph splits one operator into several
+            # clusters, which reads as MORE independent than reality, so a
+            # caller must know the view was cut.
+            rows = conn.execute(
+                sql + " LIMIT ?", (CLUSTER_LINK_ROW_CAP + 1,)
+            ).fetchall()  # fetchall-ok: already-paginated (LIMIT CLUSTER_LINK_ROW_CAP)
+            if len(rows) > CLUSTER_LINK_ROW_CAP:
+                rows = rows[:CLUSTER_LINK_ROW_CAP]
+                app.logger.warning(
+                    "[CLUSTER] link query truncated at %d rows; clustering is "
+                    "incomplete and will understate operator size: %s",
+                    CLUSTER_LINK_ROW_CAP, sql,
+                )
+        except sqlite3.Error:
+            return
+        for key, miner in rows:
+            if key is None or miner is None:
+                continue
+            groups.setdefault(str(key), []).append(str(miner))
+            seen.add(str(miner))
+        for members in groups.values():
+            first = members[0]
+            for other in members[1:]:
+                pairs.append((first, other))
+
+    _link_by("SELECT client_ip, miner_id FROM ip_rate_limit")
+    _link_by("SELECT hardware_id, bound_miner FROM hardware_bindings")
+    _link_by("SELECT mac_hash, miner FROM miner_macs")
+    return _union_find_groups(pairs, singletons=seen)
+
+
+def cluster_independence(conn, members) -> dict:
+    """Do these miners look like different machines, or one generator?
+
+    Returns a verdict, never a penalty. `spread` is the coefficient of
+    variation of the members' median measurement, so it asks whether the
+    group's hardware differs from itself, not whether any member is genuine.
+
+    KNOWN FALSE POSITIVE, and the reason this stays observe-only: an operator
+    honestly running several IDENTICAL machines — five of the same SBC — looks
+    correlated by construction. Low independence is a reason to look, never a
+    reason to dock a reward on its own.
+    """
+    members = [m for m in (members or []) if m]
+    verdict = {"members": len(members), "spread": None, "state": "unjudged",
+               "medians": {}}
+    if len(members) < CLUSTER_MIN_MEMBERS_TO_JUDGE:
+        verdict["state"] = "too_small_to_judge"
+        return verdict
+
+    medians = {}
+    for miner in members:
+        values = []
+        for sample in fetch_miner_fingerprint_sequence(conn, miner):
+            try:
+                v = float((sample.get("profile") or {}).get(
+                    CLUSTER_INDEPENDENCE_METRIC, 0.0) or 0.0)
+            except (TypeError, ValueError):
+                continue
+            if v > 0:
+                values.append(v)
+        if values:
+            medians[miner] = statistics.median(values)
+
+    verdict["medians"] = medians
+    if len(medians) < CLUSTER_MIN_MEMBERS_TO_JUDGE:
+        verdict["state"] = "insufficient_history"
+        return verdict
+
+    vals = list(medians.values())
+    mean = sum(vals) / len(vals)
+    spread = statistics.pstdev(vals) / mean if mean > 0 else 0.0
+    verdict["spread"] = round(spread, 4)
+    verdict["state"] = (
+        "independent" if spread >= CLUSTER_INDEPENDENT_SPREAD else "correlated"
+    )
+    return verdict
+
+
 # === RIP-309c: measurement freshness binding ===
 # The attestation ENVELOPE is already fresh: /attest/submit requires a live
 # server-issued challenge from /attest/challenge, single-use, 300s expiry. What

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4126,7 +4126,20 @@ def validate_temporal_consistency(sequence: list, current_profile: dict = None) 
                     values.append(v)
 
         if len(values) < 3:
-            check_scores[metric] = 1.0
+            # Not enough samples to judge this metric. Excluded from the
+            # average rather than scored 1.0.
+            #
+            # Scoring it a pass was the same mistake the rotating checks made:
+            # "could not measure" is not "passed". It matters more here because
+            # most miners populate only clock_drift, so three metrics returned
+            # a free 1.0 and diluted the one real verdict. A fully replayed
+            # constant profile scored 0.8 and a 2.5x miner kept 2.2 of it. With
+            # the absent metrics excluded the same profile scores 0.2.
+            #
+            # It is also required for the vintage fleet to be judged honestly:
+            # a 6502 genuinely cannot produce thermal_variance, and awarding it
+            # a pass for that would hand every capability-limited miner three
+            # free credits toward a premium.
             continue
 
         avg = sum(values) / len(values)
@@ -4146,7 +4159,18 @@ def validate_temporal_consistency(sequence: list, current_profile: dict = None) 
 
         check_scores[metric] = score
 
-    score = sum(check_scores.values()) / max(len(check_scores), 1)
+    if not check_scores:
+        # Nothing could be judged at all. Treat as unverified rather than
+        # perfect, matching the rotating-check denominator: proving nothing is
+        # not the same as passing everything.
+        return {
+            "score": 1.0,
+            "review_flag": False,
+            "reason": "insufficient_history",
+            "flags": flags,
+            "check_scores": {},
+        }
+    score = sum(check_scores.values()) / len(check_scores)
     review_flag = any(f.startswith("frozen_profile") or f.startswith("noisy_profile") or f.startswith("drift_out_of_band") for f in flags)
     return {
         "score": round(score, 4),

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3941,6 +3941,59 @@ def fetch_miner_fingerprint_sequence(conn, miner: str) -> list:
     return out
 
 
+# An identity with too little history to check is not trusted with the full
+# antiquity premium, and is not punished either. Zero would re-implement a
+# tenure gate at full strength and penalise honest newcomers; one would make a
+# freshly minted identity the cheapest possible way to claim the premium, which
+# is the exact behaviour the premium attracts. Half is a deliberate middle.
+# NOTE: this fraction is a tokenomics knob, not a purely technical constant.
+TEMPORAL_UNVERIFIED_BONUS_FRACTION = 0.5
+
+
+def apply_temporal_consistency_to_weight(hw_weight: float, temporal_review: dict) -> float:
+    """Gate the ANTIQUITY BONUS on the miner's consistency with its own history.
+
+    Antiquity multipliers above 1.0 are the only thing worth forging on this
+    chain, so they are the only thing this gates. Weight at or below baseline
+    is returned untouched: a modern miner at 0.8x is unaffected, and no miner
+    is ever pushed below the baseline every participant already earns. A false
+    positive therefore costs a miner its bonus, never its participation.
+
+        effective = 1.0 + (hw_weight - 1.0) * score
+
+    `score` comes from validate_temporal_consistency, which measures a miner
+    against ITS OWN past measurements rather than a population band. That is
+    the point: a global band is satisfied forever by one in-range constant,
+    while a self-history has to keep being reproduced. The two failure modes it
+    already detects are exactly the two a forger falls into — `frozen_profile`
+    (the same value replayed, rel_var < 0.01) and `noisy_profile` (an RNG with
+    no physical model behind it, rel_var > 0.8).
+
+    Not a tenure multiplier. Nothing here pays for age. History length only
+    determines whether we have enough observations to CHECK a claim; the
+    reward is for staying consistent, which a farm cannot mass-produce, because
+    each identity must be self-consistent AND independent of the others at the
+    same time. See finding-contributor-tenure-multiplier-rejected.
+    """
+    try:
+        weight = float(hw_weight)
+    except (TypeError, ValueError):
+        return hw_weight
+    if weight <= 1.0:
+        return weight
+
+    review = temporal_review if isinstance(temporal_review, dict) else {}
+    if review.get("reason") == "insufficient_history":
+        score = TEMPORAL_UNVERIFIED_BONUS_FRACTION
+    else:
+        try:
+            score = float(review.get("score", 1.0))
+        except (TypeError, ValueError):
+            score = 1.0
+    score = max(0.0, min(1.0, score))
+    return 1.0 + (weight - 1.0) * score
+
+
 def validate_temporal_consistency(sequence: list, current_profile: dict = None) -> dict:
     samples = list(sequence or [])
     if current_profile is not None:
@@ -5576,6 +5629,11 @@ def _submit_attestation_impl():
         family = reward_device["device_family"]
         arch_for_weight = reward_device["device_arch"]
         hw_weight = HARDWARE_WEIGHTS.get(family, {}).get(arch_for_weight, HARDWARE_WEIGHTS.get(family, {}).get("default", 1.0))
+        # The temporal score used to be computed and then discarded into a log
+        # line, so a miner contradicting its own measurement history still
+        # collected the full antiquity premium. Gate the bonus on it.
+        hw_weight_raw = hw_weight
+        hw_weight = apply_temporal_consistency_to_weight(hw_weight, temporal_review)
         miner_id = _attest_valid_miner(data.get("miner_id")) or miner
 
         with closing(sqlite3.connect(DB_PATH)) as enroll_conn:
@@ -5618,7 +5676,10 @@ def _submit_attestation_impl():
 
         # Issue #19 temporal consistency only sets a review flag (no hard-fail).
         if temporal_review.get("review_flag"):
-            app.logger.warning(f"[TEMPORAL-REVIEW] {miner[:20]}... flags={temporal_review.get('flags', [])}")
+            app.logger.warning(
+                f"[TEMPORAL-REVIEW] {miner[:20]}... flags={temporal_review.get('flags', [])} "
+                f"score={temporal_review.get('score')} weight {hw_weight_raw:.3f} -> {hw_weight:.3f}"
+            )
 
         app.logger.info(
             f"[RIP-309] epoch={epoch} miner={miner[:20]}... nonce={rotation_eval['measurement_nonce'][:16]} "
@@ -5900,6 +5961,20 @@ def enroll_epoch():
         # the fixed epoch reward pot.
         family, arch = resolve_enroll_weight_device(c, miner_pk, data)
         hw_weight = HARDWARE_WEIGHTS.get(family, {}).get(arch, 1.0)
+        # Gate the antiquity bonus on consistency here too. Enrollment is the
+        # path that actually sets epoch weight, so leaving it ungated would
+        # make the attestation-side gate cosmetic: a miner could fail the
+        # temporal check on attest and still enroll at the full premium.
+        # Keyed on the same stored miner id the weight itself is derived from.
+        # miner_fingerprint_history is keyed on the same identifier
+        # resolve_enroll_weight_device reads miner_attest_recent by, so the
+        # history consulted here is the history of the hardware the weight was
+        # derived from. No rows yields "insufficient_history", which withholds
+        # part of the bonus rather than failing the enrollment.
+        _temporal_enroll = validate_temporal_consistency(
+            fetch_miner_fingerprint_sequence(c, miner_pk)
+        )
+        hw_weight = apply_temporal_consistency_to_weight(hw_weight, _temporal_enroll)
 
         _enroll_fp = resolve_enroll_fingerprint(c, miner_pk, data)
         rotation_eval = evaluate_rotating_fingerprint_checks(

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4510,8 +4510,14 @@ def validate_fingerprint_data(
         if not isinstance(anti_emu_data, dict):
             anti_emu_data = {}
         # Require evidence of actual checks being performed
+        # `emulator_indicators` is what the Pico console bridge emits, and its
+        # absence from this list rejected the entire console fleet with
+        # anti_emulation_no_evidence: they were supplying evidence, under a
+        # name nobody had whitelisted. Same shape as the flat micro clients
+        # dying on an empty checks map.
         has_evidence = (
             "vm_indicators" in anti_emu_data or
+            "emulator_indicators" in anti_emu_data or
             "dmesg_scanned" in anti_emu_data or
             "paths_checked" in anti_emu_data or
             "cpuinfo_flags" in anti_emu_data or
@@ -4521,9 +4527,42 @@ def validate_fingerprint_data(
             print(f"[FINGERPRINT] REJECT: anti_emulation claims pass but has no raw evidence")
             return False, "anti_emulation_no_evidence"
 
-        if anti_emu_check.get("passed") == False:
-            vm_indicators = anti_emu_data.get("vm_indicators", [])
-            return False, f"vm_detected:{vm_indicators}"
+        # Read the EVIDENCE, not the client's verdict.
+        #
+        # This branch used to fire only when the client volunteered
+        # `passed == False`, so the server held the string "qemu" in
+        # vm_indicators and never looked at it unless the VM had already
+        # confessed. Three payloads were accepted:
+        #
+        #   {"passed": true,  "data": {"vm_indicators": ["qemu"]}}   accepted
+        #   {"passed": true,  "data": {"is_likely_vm": true}}        accepted
+        #   {                 "data": {"vm_indicators": ["qemu"]}}   accepted
+        #
+        # and the only one rejected was the honest VM that reported
+        # `passed: false`. The control fired exclusively on truthful clients.
+        #
+        # Safe for real hardware: fingerprint_checks.py emits
+        # `vm_indicators: []` on a clean machine, so an empty list, a missing
+        # key and a false is_likely_vm all still pass.
+        vm_indicators = anti_emu_data.get("vm_indicators")
+        if not isinstance(vm_indicators, (list, tuple)):
+            vm_indicators = None
+        # Consoles report under their own key; read it here too, or accepting
+        # emulator_indicators as evidence above would hand the console fleet
+        # the exact free pass this block exists to close.
+        emu_indicators = anti_emu_data.get("emulator_indicators")
+        if not isinstance(emu_indicators, (list, tuple)):
+            emu_indicators = None
+        reported = list(vm_indicators or []) + list(emu_indicators or [])
+        if reported:
+            return False, f"vm_detected:{reported}"
+        if anti_emu_data.get("is_likely_vm") is True:
+            return False, "vm_detected:is_likely_vm"
+
+        # `is not True` rather than `== False`: omitting the key entirely used
+        # to skip both branches and sail through.
+        if anti_emu_check.get("passed") is not True:
+            return False, f"vm_detected:no_pass_verdict:{anti_emu_data.get('vm_indicators', [])}"
     elif isinstance(anti_emu_check, bool):
         # C miner simple bool - accept for now but flag for reduced weight
         if not anti_emu_check:

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2106,6 +2106,17 @@ HARDWARE_WEIGHTS = {
     "console": {"nes_6502": 2.8, "snes_65c816": 2.7, "n64_mips": 2.5,
                 "genesis_68000": 2.5, "gameboy_z80": 2.6, "ps1_mips": 2.8,
                 "saturn_sh2": 2.6, "gba_arm7": 2.3, "default": 2.5},
+    # Standalone vintage micros (Apple II, C64, MSX, Spectrum). Deliberately
+    # BELOW the equivalent console tier, which is not a judgement on the
+    # hardware: a Pico-bridged console presents at least one measured check
+    # (bridge anti_emulation timing), while a standalone micro presents a
+    # small HTTP payload that cannot be distinguished from a forgery. Paying
+    # both the same rate would make the cheapest-to-forge class the best-paid
+    # on the chain. 6502 lands at 2.5, level with 386 and G4, so the bonus is
+    # real without topping a table it cannot prove its place in. Defaults sit
+    # under the named arches so an invented chip name cannot auto-max.
+    "MOS": {"6502": 2.5, "65c816": 2.4, "default": 2.2},
+    "Zilog": {"z80": 2.3, "default": 2.1},
 }
 
 # === WELCOME BONUS & STREAK REWARDS ===
@@ -2211,6 +2222,142 @@ def select_active_fingerprint_checks(previous_epoch_block_hash: str, active_coun
     return tuple(ranked[:active_count])
 
 
+# === RIP-309b: capability-limited hardware classes ===
+# Some hardware structurally cannot run a rotating check. An Apple II has no
+# TSC and no SIMD unit; a 386 predates RDTSC. Scoring "cannot measure" as
+# "failed" zeroes the honest vintage fleet, which is the hardware this chain
+# exists to reward. These classes get a third verdict, `unmeasured`, which is
+# excluded from the scoring DENOMINATOR rather than counted either way.
+MICRO_LIMITED_ARCHES = {
+    "6502", "65c816", "z80", "sh2",
+    "i386", "386", "80386",
+    "i486", "486", "80486",
+    "8086", "8088", "286", "80286", "i286",
+}
+
+CONSOLE_BRIDGE_ARCHES = {
+    "nes_6502", "snes_65c816", "n64_mips", "gba_arm7",
+    "genesis_68000", "sms_z80", "saturn_sh2",
+    "gameboy_z80", "gameboy_color_z80", "ps1_mips",
+}
+
+# Canonical (family, arch) for a standalone micro claim, so a bare "6502"
+# lands on the MOS family rather than being swept into x86 defaults and then
+# caught by the reverse-x86 ARM heuristic.
+MICRO_ARCH_CANONICAL = {
+    "6502": ("MOS", "6502"),
+    "65c816": ("MOS", "65c816"),
+    "z80": ("Zilog", "z80"),
+    "i386": ("x86", "386"), "386": ("x86", "386"), "80386": ("x86", "386"),
+    "i486": ("x86", "486"), "486": ("x86", "486"), "80486": ("x86", "486"),
+    "8086": ("x86", "retro"), "8088": ("x86", "retro"),
+    "286": ("x86", "retro"), "80286": ("x86", "retro"), "i286": ("x86", "retro"),
+}
+
+# Device-native measurements the flat vintage C miners send at top level
+# (miners/apple2, miners/i386). These are not rotating checks.
+FLAT_MICRO_EVIDENCE_FIELDS = (
+    "cycle_count", "clock_ticks", "ram_kb", "aux_ram",
+    "cpu_flags", "has_cpuid", "cpuid_max_leaf", "hw_fingerprint",
+)
+
+MODERN_MACHINE_TOKENS = {
+    "x86_64", "amd64", "i686", "i586",
+    "aarch64", "arm64", "arm64e", "armv7l", "armv8l",
+    "ppc64le", "ppc64", "riscv64", "mips64", "s390x",
+}
+MODERN_CPU_BRAND_TOKENS = (
+    "ryzen", "epyc", "threadripper", "xeon", "core(tm)",
+    "core i3", "core i5", "core i7", "core i9",
+    "apple m1", "apple m2", "apple m3", "apple m4",
+    "snapdragon", "graviton", "neoverse",
+)
+
+
+def _micro_accepted_for_rotation(device_arch, fingerprint, claimed_device=None) -> bool:
+    """True when a capability-limited class earned its neutral scoring.
+
+    This is the ONLY gate that lets an all-unmeasured payload score above
+    zero, so it is deliberately narrow: the class must come from the
+    SERVER-derived arch, nothing in the payload may contradict the claim, and
+    the device must supply at least two native measurements. A payload that
+    proves nothing scores nothing.
+    """
+    arch = str(device_arch or "").lower()
+    if arch not in MICRO_LIMITED_ARCHES and arch not in CONSOLE_BRIDGE_ARCHES:
+        bt = fingerprint.get("bridge_type") if isinstance(fingerprint, dict) else None
+        if bt != "pico_serial":
+            return False
+    if _capability_contradiction(claimed_device, fingerprint):
+        return False
+    return _micro_native_evidence_count(fingerprint) >= 2
+
+
+def _capability_contradiction(claimed_device, fingerprint):
+    """Return a reason string if a capability-limited claim is contradicted.
+
+    A device claiming to be a 6502/386/486/console bridge while presenting
+    evidence of a modern platform must not receive the neutral `unmeasured`
+    treatment. Deliberately conservative: 'GenuineIntel' on a claimed 486 is
+    NOT a contradiction (late 486s have CPUID), but SSE/AVX evidence is.
+    """
+    device = claimed_device if isinstance(claimed_device, dict) else {}
+    fp = fingerprint if isinstance(fingerprint, dict) else {}
+
+    machine = str(device.get("machine") or "").lower()
+    if machine in MODERN_MACHINE_TOKENS:
+        return f"modern_machine_field:{machine}"
+
+    platform_system = str(device.get("platform_system") or "").lower()
+    if platform_system in ("windows", "darwin"):
+        return f"modern_platform:{platform_system}"
+
+    cpu_brand = _cpu_brand_string(device)
+    for token in MODERN_CPU_BRAND_TOKENS:
+        if token in cpu_brand:
+            return f"modern_cpu_brand:{token}"
+
+    simd_data = _fingerprint_check_data(fp, "simd_identity")
+    x86_features = simd_data.get("x86_features")
+    if (isinstance(x86_features, list) and x86_features) or \
+            simd_data.get("has_sse") or simd_data.get("has_avx"):
+        return "x86_simd_evidence"
+    if simd_data.get("altivec") or simd_data.get("vsx") or simd_data.get("has_altivec"):
+        return "powerpc_simd_evidence"
+
+    return None
+
+
+def _structurally_unmeasurable_checks(device_arch, fingerprint=None) -> frozenset:
+    """Rotating checks a device class structurally cannot perform.
+
+    Keyed by the SERVER-derived arch, never a raw client claim. A micro
+    attested through a Pico bridge gets the console profile, because the
+    bridge does measure anti_emulation. A standalone micro gets all six, and
+    its attestation rests on device-native evidence instead.
+    """
+    arch = str(device_arch or "").lower()
+    bridge_type = ""
+    if isinstance(fingerprint, dict):
+        bt = fingerprint.get("bridge_type")
+        bridge_type = bt if isinstance(bt, str) else ""
+    if arch in CONSOLE_BRIDGE_ARCHES or bridge_type == "pico_serial":
+        return frozenset(RIP309_ROTATING_FINGERPRINT_CHECKS) - {"anti_emulation"}
+    if arch in MICRO_LIMITED_ARCHES:
+        return frozenset(RIP309_ROTATING_FINGERPRINT_CHECKS)
+    return frozenset()
+
+
+def _micro_native_evidence_count(fingerprint) -> int:
+    """Count device-native measurement fields on a flat micro payload."""
+    if not isinstance(fingerprint, dict):
+        return 0
+    return sum(
+        1 for f in FLAT_MICRO_EVIDENCE_FIELDS
+        if fingerprint.get(f) not in (None, "", [], {})
+    )
+
+
 def _fingerprint_check_passed(check_entry) -> bool:
     if isinstance(check_entry, bool):
         return check_entry
@@ -2285,24 +2432,64 @@ def get_epoch_fingerprint_rotation(conn, epoch: int) -> dict:
     }
 
 
-def evaluate_rotating_fingerprint_checks(conn, epoch: int, fingerprint: dict) -> dict:
+def evaluate_rotating_fingerprint_checks(
+    conn,
+    epoch: int,
+    fingerprint: dict,
+    device_arch: str = None,
+    micro_accepted: bool = False,
+) -> dict:
+    """Score the epoch's rotating checks, with a third `unmeasured` verdict.
+
+    RIP-309b. A check a device class structurally cannot perform is neither a
+    pass nor a failure: it is dropped from the DENOMINATOR. Without this, an
+    honest 486 reporting a truthful `clock_drift: false` (no TSC on that
+    silicon) scores zero, while a client that hardcodes `"passed": true`
+    scores 1.0 — the control fires only on honest miners.
+
+    `device_arch` must be the SERVER-derived arch. Passing a raw client claim
+    would let a miner self-select which checks it is excused from.
+
+    Empty denominator FAILS CLOSED. If nothing was measured, the score is 0.0
+    unless this is an unvetoed capability-limited class whose attestation was
+    already accepted on device-native evidence (`micro_accepted`). "Proved
+    nothing" is not "passed everything"; the earlier form of this code
+    returned 1.0 and handed a perfect score to a payload with no evidence.
+    """
     rotation = get_epoch_fingerprint_rotation(conn, epoch)
     checks = _fingerprint_checks_map(fingerprint)
-    active_results = {
-        name: _fingerprint_check_passed(checks.get(name))
-        for name in rotation["active_checks"]
-    }
-    passed_active = [name for name, passed in active_results.items() if passed]
-    failed_active = [name for name, passed in active_results.items() if not passed]
-    total_active = len(rotation["active_checks"])
-    active_ratio = (len(passed_active) / total_active) if total_active else 1.0
+    unmeasurable = _structurally_unmeasurable_checks(device_arch, fingerprint)
+
+    active_results = {}
+    for name in rotation["active_checks"]:
+        entry = checks.get(name)
+        if entry is None and name in unmeasurable:
+            active_results[name] = None          # structurally unmeasured
+        else:
+            active_results[name] = _fingerprint_check_passed(entry)
+
+    passed_active = [n for n, v in active_results.items() if v is True]
+    failed_active = [n for n, v in active_results.items() if v is False]
+    unmeasured_active = [n for n, v in active_results.items() if v is None]
+    measured_total = len(passed_active) + len(failed_active)
+
+    if measured_total:
+        active_ratio = len(passed_active) / measured_total
+    elif micro_accepted and unmeasured_active:
+        # Capability-limited class, validated on device-native evidence.
+        active_ratio = 1.0
+    else:
+        active_ratio = 0.0
+
     return {
         **rotation,
         "active_results": active_results,
         "passed_active_checks": passed_active,
         "failed_active_checks": failed_active,
+        "unmeasured_active_checks": unmeasured_active,
         "active_pass_count": len(passed_active),
-        "active_total": total_active,
+        "active_total": measured_total,
+        "measured_total": measured_total,
         "active_ratio": active_ratio,
     }
 
@@ -3845,7 +4032,6 @@ KNOWN_VM_SIGNATURES = {
 
 def validate_fingerprint_data(
     fingerprint: dict, claimed_device: dict = None,
-    allow_tscless_x86_reward: bool = False,
 ) -> tuple:
     """
     Server-side validation of miner fingerprint check results.
@@ -3870,8 +4056,34 @@ def validate_fingerprint_data(
     checks = _fingerprint_checks_map(fingerprint)
     claimed_device = claimed_device if isinstance(claimed_device, dict) else {}
 
+    # RIP-309b: classify the device BEFORE bailing on an empty checks map.
+    # The flat vintage C miners (miners/apple2, miners/i386) send device-native
+    # measurements at top level and no `checks` map at all, so an early return
+    # here scored the honest Apple II and 386 fleet at zero. A limited claim is
+    # only honoured when nothing in the payload contradicts it.
+    _claimed_arch_early = (claimed_device.get("device_arch")
+                           or claimed_device.get("arch", "")) if claimed_device else ""
+    _claimed_arch_early = str(_claimed_arch_early).lower()
+    _is_limited_claim = (
+        _claimed_arch_early in MICRO_LIMITED_ARCHES
+        or _claimed_arch_early in CONSOLE_BRIDGE_ARCHES
+        or (isinstance(fingerprint, dict)
+            and fingerprint.get("bridge_type") == "pico_serial")
+    )
+    if _is_limited_claim:
+        _veto = _capability_contradiction(claimed_device, fingerprint)
+        if _veto:
+            return False, f"capability_claim_contradicted:{_veto}"
+
     # FIX #305: Reject empty fingerprint payloads (e.g. fingerprint={} or checks={})
     if not checks:
+        # A standalone micro with no checks map may still attest on at least
+        # two device-native measurements. Fewer than two is not evidence.
+        if _is_limited_claim:
+            _native = _micro_native_evidence_count(fingerprint)
+            if _native >= 2:
+                return True, f"micro_native_evidence:{_native}"
+            return False, "micro_insufficient_native_evidence"
         return False, "empty_fingerprint_checks"
 
     # FIX #305: Require at least anti_emulation and clock_drift evidence
@@ -3892,10 +4104,15 @@ def validate_fingerprint_data(
                      "genesis_68000", "sms_z80", "saturn_sh2",
                      "gameboy_z80", "gameboy_color_z80", "ps1_mips",
                      "6502", "65c816", "z80", "sh2"}
-    # 386/486 predate RDTSC. Relax their clock requirement only for the
-    # attestation reward path; other validator consumers keep the strict rule.
+    # 386/486 predate RDTSC, so they cannot measure clock drift at all. That
+    # is a structural property of the silicon, not a per-call-site policy, so
+    # it is handled here for every consumer rather than behind a flag one
+    # caller happened to set. RIP-309b replaced the old
+    # allow_tscless_x86_reward parameter, which relaxed the same rule for the
+    # reward path only and left the other validator consumers disagreeing
+    # about the same hardware.
     is_vintage = claimed_arch_lower in vintage_relaxed_archs or (
-        allow_tscless_x86_reward and claimed_arch_lower in {"386", "486"}
+        claimed_arch_lower in {"386", "486"}
     )
     is_console = claimed_arch_lower in console_archs
 
@@ -3999,10 +4216,7 @@ def validate_fingerprint_data(
 
         if (
             clock_check.get("passed") == False
-            and not (
-                allow_tscless_x86_reward
-                and claimed_arch_lower in {"386", "486"}
-            )
+            and claimed_arch_lower not in {"386", "486"}
         ):
             return False, f"clock_drift_failed:{clock_data.get('fail_reason', 'unknown')}"
 
@@ -4014,13 +4228,7 @@ def validate_fingerprint_data(
             print(f"[FINGERPRINT] SUSPICIOUS: claims {claimed_arch} but cv={cv:.6f} is too stable for vintage")
             return False, f"vintage_timing_too_stable:cv={cv}"
     elif isinstance(clock_check, bool):
-        if (
-            not clock_check
-            and not (
-                allow_tscless_x86_reward
-                and claimed_arch_lower in {"386", "486"}
-            )
-        ):
+        if not clock_check and claimed_arch_lower not in {"386", "486"}:
             return False, "clock_drift_failed_bool"
 
     # ── PHASE 2: Cross-validate device claims against fingerprint ──
@@ -5258,7 +5466,7 @@ def _submit_attestation_impl():
     # FIX #305: Always validate - pass None/empty to validator which rejects them
     if fingerprint is not None:
         fingerprint_passed, fingerprint_reason = validate_fingerprint_data(
-            fingerprint, claimed_device=device, allow_tscless_x86_reward=True,
+            fingerprint, claimed_device=device,
         )
     else:
         fingerprint_reason = "no_fingerprint_submitted"
@@ -5371,10 +5579,15 @@ def _submit_attestation_impl():
         miner_id = _attest_valid_miner(data.get("miner_id")) or miner
 
         with closing(sqlite3.connect(DB_PATH)) as enroll_conn:
+            _fp_for_rotation = fingerprint if isinstance(fingerprint, dict) else {}
             rotation_eval = evaluate_rotating_fingerprint_checks(
                 enroll_conn,
                 epoch,
-                fingerprint if isinstance(fingerprint, dict) else {},
+                _fp_for_rotation,
+                device_arch=arch_for_weight,
+                micro_accepted=_micro_accepted_for_rotation(
+                    arch_for_weight, _fp_for_rotation, device
+                ),
             )
             if not fingerprint_passed:
                 enroll_weight_units = FAILED_FINGERPRINT_WEIGHT_UNITS
@@ -5688,13 +5901,21 @@ def enroll_epoch():
         family, arch = resolve_enroll_weight_device(c, miner_pk, data)
         hw_weight = HARDWARE_WEIGHTS.get(family, {}).get(arch, 1.0)
 
+        _enroll_fp = resolve_enroll_fingerprint(c, miner_pk, data)
         rotation_eval = evaluate_rotating_fingerprint_checks(
             c,
             epoch,
             # Fall back to the stored attestation fingerprint when the enroll
             # body omits one, so a signed-but-fingerprint-less enrollment does
             # not collapse to zero weight under the rotating check.
-            resolve_enroll_fingerprint(c, miner_pk, data),
+            _enroll_fp,
+            # Server-derived arch from resolve_enroll_weight_device, never the
+            # request body: otherwise a miner could self-select which checks
+            # it is excused from.
+            device_arch=arch,
+            micro_accepted=_micro_accepted_for_rotation(
+                arch, _enroll_fp, data.get("device") if isinstance(data, dict) else None
+            ),
         )
         if fingerprint_failed:
             weight_units = FAILED_FINGERPRINT_WEIGHT_UNITS

--- a/node/tests/test_enroll_weight_device_spoof.py
+++ b/node/tests/test_enroll_weight_device_spoof.py
@@ -273,8 +273,30 @@ class TestEnrollWeightDeviceSpoof(unittest.TestCase):
         })
 
         self.assertEqual(status, 200, body)
-        self.assertEqual(body["hw_weight"], body_w,
-                         "legacy row with no verified device should use body device")
+        # The documented promise is that legacy miners are "not regressed to
+        # weight 1.0", and that still holds. The exact-equality assertion was
+        # stricter than that promise, and it no longer holds because the
+        # antiquity bonus is now gated on temporal consistency: this row has no
+        # fingerprint history to check, so it receives the unverified fraction
+        # of the bonus rather than all of it.
+        #
+        # Worth being explicit about which path this is. The device here comes
+        # from the UNSIGNED request body, on a row with no stored verified
+        # device, claiming ARM arm2 at 4.0x. It is the least-evidenced weight
+        # on the chain, and it was collecting the largest multiplier. Paying it
+        # a reduced premium is the intended behaviour, not a regression.
+        expected = mod.apply_temporal_consistency_to_weight(
+            body_w, {"reason": "insufficient_history", "score": 1.0}
+        )
+        self.assertAlmostEqual(
+            body["hw_weight"], expected,
+            msg="legacy row with no verified device should use the body device, "
+                "gated by the unverified-history bonus fraction",
+        )
+        self.assertGreater(body["hw_weight"], 1.0,
+                           "legacy miners must not be regressed to baseline")
+        self.assertLess(body["hw_weight"], body_w,
+                        "an unverified body claim must not earn the full premium")
 
 
 if __name__ == "__main__":

--- a/node/tests/test_x86_vintage_reward_validation.py
+++ b/node/tests/test_x86_vintage_reward_validation.py
@@ -59,7 +59,7 @@ class X86VintageRewardValidationTest(unittest.TestCase):
         fp = _fingerprint("Am486DX4", 4)
         fp["checks"]["anti_emulation"] = _check(vm_indicators=[], paths_checked=["/proc/cpuinfo"])
         passed, reason = self.mod.validate_fingerprint_data(
-            fp, {"family": "x86", "arch": "486"}, allow_tscless_x86_reward=True,
+            fp, {"family": "x86", "arch": "486"},
         )
         self.assertTrue(passed, reason)
 
@@ -80,14 +80,30 @@ class X86VintageRewardValidationTest(unittest.TestCase):
                 passed, reason = self.mod.validate_fingerprint_data(
                     fp,
                     {"family": "x86", "arch": arch},
-                    allow_tscless_x86_reward=True,
-                )
+                                    )
                 self.assertTrue(passed, reason)
 
-    def test_tscless_relaxation_is_not_global(self):
+    def test_tscless_relaxation_is_global_rip309b(self):
+        """A 486 has no TSC for every caller, not just the reward path.
+
+        This previously asserted the opposite. Under RIP-309b the relaxation
+        is keyed on the silicon rather than on which call site set a flag:
+        `allow_tscless_x86_reward` was removed because two consumers
+        disagreeing about the same hardware is how the rotation-selector
+        divergence happened. A 486 that cannot measure clock drift is not
+        lying, and it is not a failure for one caller and a pass for another.
+        """
         fp = _fingerprint("Am486DX4", 4)
         fp["checks"]["anti_emulation"] = _check(vm_indicators=[], paths_checked=["/proc/cpuinfo"])
         passed, reason = self.mod.validate_fingerprint_data(fp, {"family": "x86", "arch": "486"})
+        self.assertTrue(passed, reason)
+
+    def test_modern_arch_still_requires_clock_drift(self):
+        """The relaxation must not leak to hardware that does have a TSC."""
+        fp = _fingerprint("Intel Core i7-9750H", 6)
+        fp["checks"].pop("clock_drift", None)
+        fp["checks"]["anti_emulation"] = _check(vm_indicators=[], paths_checked=["/proc/cpuinfo"])
+        passed, reason = self.mod.validate_fingerprint_data(fp, {"family": "x86", "arch": "modern"})
         self.assertFalse(passed)
         self.assertEqual(reason, "missing_required_check:clock_drift")
 

--- a/tests/test_anti_emulation_reads_evidence.py
+++ b/tests/test_anti_emulation_reads_evidence.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Anti-emulation must read the evidence, not the client's verdict.
+
+The server held the string "qemu" in `vm_indicators` and never looked at it
+unless the VM had already confessed via `passed: false`. Three payloads were
+accepted on main:
+
+    {"passed": true,  "data": {"vm_indicators": ["qemu"]}}
+    {"passed": true,  "data": {"is_likely_vm": true}}
+    {                 "data": {"vm_indicators": ["qemu"]}}   (no verdict at all)
+
+and the only anti-emulation payload rejected was the honest one that reported
+`passed: false`. The control fired exclusively on truthful clients — the third
+instance of that same inversion found in this codebase, alongside the vintage
+zero-reward path and the temporal score that punished only miners who varied.
+
+The third bypass is the `== False` comparison: omitting the key skipped both
+branches. `is not True` closes it.
+
+Also covered: the console fleet reports under `emulator_indicators`, which was
+not on the evidence whitelist, so Pico bridge miners were rejected with
+`anti_emulation_no_evidence` while supplying evidence under a name nobody had
+listed. Accepting that key without also content-checking it would have created
+a fresh free pass, so both are tested.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+NODE = os.path.join(ROOT, "node")
+sys.path.insert(0, NODE)
+os.environ.setdefault("RC_ADMIN_KEY", "t" * 64)
+
+_spec = importlib.util.spec_from_file_location(
+    "rc_node_ae", os.path.join(NODE, "rustchain_v2_integrated_v2.2.1_rip200.py")
+)
+MOD = importlib.util.module_from_spec(_spec)
+sys.modules["rc_node_ae"] = MOD
+_spec.loader.exec_module(MOD)
+
+validate = MOD.validate_fingerprint_data
+
+BASE = {
+    "clock_drift": {"passed": True, "data": {"cv": 0.05, "samples": 500}},
+    "cache_timing": {"passed": True, "data": {"l2_l1_ratio": 4.0}},
+    "simd_identity": {"passed": True, "data": {"x86_features": ["sse2"]}},
+}
+
+
+def _fp(anti_emulation):
+    checks = dict(BASE)
+    checks["anti_emulation"] = anti_emulation
+    return {"checks": checks}
+
+
+class EvidenceOverridesVerdictTest(unittest.TestCase):
+
+    def test_honest_clean_hardware_still_passes(self):
+        ok, reason = validate(
+            _fp({"passed": True, "data": {"vm_indicators": []}}),
+            claimed_device={"arch": "modern"})
+        self.assertTrue(ok, reason)
+
+    def test_claimed_pass_with_vm_indicators_is_rejected(self):
+        ok, reason = validate(
+            _fp({"passed": True, "data": {"vm_indicators": ["qemu", "hypervisor"]}}),
+            claimed_device={"arch": "modern"})
+        self.assertFalse(ok, "the server was holding 'qemu' and not looking")
+        self.assertTrue(reason.startswith("vm_detected"), reason)
+
+    def test_claimed_pass_with_is_likely_vm_is_rejected(self):
+        ok, reason = validate(
+            _fp({"passed": True, "data": {"vm_indicators": [], "is_likely_vm": True}}),
+            claimed_device={"arch": "modern"})
+        self.assertFalse(ok)
+        self.assertIn("is_likely_vm", reason)
+
+    def test_omitting_the_verdict_no_longer_skips_both_branches(self):
+        """The `== False` bug: no `passed` key sailed through."""
+        ok, reason = validate(
+            _fp({"data": {"vm_indicators": ["qemu"]}}),
+            claimed_device={"arch": "modern"})
+        self.assertFalse(ok, reason)
+
+    def test_a_missing_verdict_with_clean_evidence_is_also_rejected(self):
+        """No verdict is not a pass, even when the evidence looks clean."""
+        ok, reason = validate(
+            _fp({"data": {"vm_indicators": [], "paths_checked": ["/proc/cpuinfo"]}}),
+            claimed_device={"arch": "modern"})
+        self.assertFalse(ok)
+        self.assertIn("no_pass_verdict", reason)
+
+    def test_an_honest_vm_is_still_rejected(self):
+        ok, reason = validate(
+            _fp({"passed": False, "data": {"vm_indicators": ["qemu"]}}),
+            claimed_device={"arch": "modern"})
+        self.assertFalse(ok)
+
+    def test_evidence_without_a_vm_indicators_key_still_passes(self):
+        """Clients that report other evidence keys must not be broken."""
+        ok, reason = validate(
+            _fp({"passed": True, "data": {"paths_checked": ["/proc/cpuinfo"]}}),
+            claimed_device={"arch": "modern"})
+        self.assertTrue(ok, reason)
+
+
+class ConsoleEvidenceKeyTest(unittest.TestCase):
+    """The Pico bridge fleet reports under its own key."""
+
+    def _console(self, anti_emulation):
+        return {
+            "bridge_type": "pico_serial",
+            "checks": {
+                "ctrl_port_timing": {"passed": True,
+                                     "data": {"cv": 0.0004, "samples": 500}},
+                "anti_emulation": anti_emulation,
+            },
+        }
+
+    def test_console_bridge_with_clean_emulator_indicators_passes(self):
+        ok, reason = validate(
+            self._console({"passed": True, "data": {"emulator_indicators": []}}),
+            claimed_device={"arch": "nes_6502"})
+        self.assertTrue(ok, f"console fleet rejected: {reason}")
+
+    def test_console_emulator_indicators_are_content_checked(self):
+        """Whitelisting the key without reading it would be a new free pass."""
+        ok, reason = validate(
+            self._console({"passed": True,
+                           "data": {"emulator_indicators": ["low_timing_cv"]}}),
+            claimed_device={"arch": "nes_6502"})
+        self.assertFalse(ok, "an emulated console claimed a pass and got it")
+        self.assertIn("low_timing_cv", reason)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_measurement_freshness_binding.py
+++ b/tests/test_measurement_freshness_binding.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""RIP-309c: bind the measurement to the challenge, not just the envelope.
+
+The attestation envelope is already fresh. `/attest/submit` requires a live
+server-issued challenge from `/attest/challenge`, single-use, 300s expiry,
+optionally bound to a miner_id. That is real replay protection — for the
+submission.
+
+It says nothing about when the numbers inside were measured. A client can wrap
+values measured once, long ago, in a nonce fetched a second ago. The reference
+client does exactly that: `miners/linux/rustchain_linux_miner.py` measures at
+startup and the re-measure before each attestation is guarded by
+`not self.fingerprint_data`, so it never re-runs. Honest clients replay their
+own measurements for the life of the process, and a forger needs to measure
+nothing at all, ever.
+
+Binding derives the size of the timing workload from the challenge. The client
+already holds the nonce before it measures, so nothing about the protocol order
+has to change. A binding built for a different nonce carries the wrong
+iteration count, which the server catches by recomputation alone, with no
+hardware model required.
+
+Phase 0 is observation only. `absent` must stay a normal, non-failing state, or
+this repeats the hard cutover that made the unsigned-attestation change
+unmergeable.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+NODE = os.path.join(ROOT, "node")
+sys.path.insert(0, NODE)
+
+_spec = importlib.util.spec_from_file_location(
+    "rc_node_fb", os.path.join(NODE, "rustchain_v2_integrated_v2.2.1_rip200.py")
+)
+MOD = importlib.util.module_from_spec(_spec)
+sys.modules["rc_node_fb"] = MOD
+_spec.loader.exec_module(MOD)
+
+workload = MOD.derive_measurement_workload
+verify = MOD.verify_measurement_binding
+
+NONCE_A = "a1b2c3d4" + "0" * 56
+NONCE_B = "ffee0011" + "0" * 56
+
+
+def _binding(nonce, iterations=None, duration_ns=None, rate_ns=50_000):
+    iters = workload(nonce) if iterations is None else iterations
+    return {
+        "nonce": nonce,
+        "iterations": iters,
+        "duration_ns": duration_ns if duration_ns is not None else iters * rate_ns,
+    }
+
+
+class WorkloadDerivationTest(unittest.TestCase):
+
+    def test_deterministic_for_a_given_nonce(self):
+        self.assertEqual(workload(NONCE_A), workload(NONCE_A))
+
+    def test_different_nonces_give_different_workloads(self):
+        self.assertNotEqual(workload(NONCE_A), workload(NONCE_B))
+
+    def test_stays_in_a_bounded_range(self):
+        lo = MOD.MEASUREMENT_WORKLOAD_MIN
+        hi = lo + MOD.MEASUREMENT_WORKLOAD_SPAN
+        for n in (NONCE_A, NONCE_B, "0" * 64, "f" * 64, "", "zz", None):
+            self.assertGreaterEqual(workload(n), lo)
+            self.assertLess(workload(n), hi)
+
+    def test_non_hex_nonce_does_not_crash(self):
+        self.assertIsInstance(workload("zzzz----"), int)
+
+
+class BindingVerificationTest(unittest.TestCase):
+
+    def test_a_correct_binding_is_accepted(self):
+        v = verify(NONCE_A, _binding(NONCE_A))
+        self.assertTrue(v["ok"])
+        self.assertEqual(v["state"], "bound")
+
+    def test_a_binding_built_for_another_nonce_is_stale(self):
+        """The core of the mechanism: replay carries the wrong workload."""
+        replayed = _binding(NONCE_B)          # measured for a previous round
+        replayed["nonce"] = NONCE_A           # re-wrapped in a fresh challenge
+        v = verify(NONCE_A, replayed)
+        self.assertFalse(v["ok"])
+        self.assertEqual(v["state"], "stale")
+        self.assertIn("workload_mismatch", v["reason"])
+
+    def test_a_lied_about_nonce_is_caught_before_the_workload_check(self):
+        v = verify(NONCE_A, _binding(NONCE_B))
+        self.assertFalse(v["ok"])
+        self.assertEqual(v["state"], "mismatch")
+
+    def test_absent_binding_is_not_a_failure_state(self):
+        """Rollout safety: unbound clients must remain ordinary, not rejected."""
+        v = verify(NONCE_A, None)
+        self.assertEqual(v["state"], "absent")
+        self.assertFalse(v["ok"])
+
+    def test_malformed_bindings_never_raise(self):
+        for junk in ("string", 42, [], {"iterations": "many"},
+                     {"iterations": None}, {"nonce": NONCE_A}):
+            v = verify(NONCE_A, junk)
+            self.assertIn("state", v)
+            self.assertFalse(v["ok"])
+
+    def test_non_positive_duration_rejected(self):
+        for bad in (0, -1):
+            v = verify(NONCE_A, _binding(NONCE_A, duration_ns=bad))
+            self.assertFalse(v["ok"])
+            self.assertEqual(v["state"], "malformed")
+
+    def test_rate_within_tolerance_of_own_history_is_accepted(self):
+        v = verify(NONCE_A, _binding(NONCE_A, rate_ns=50_000), expected_rate_ns=55_000)
+        self.assertTrue(v["ok"], v)
+
+    def test_rate_wildly_faster_than_claimed_hardware_is_flagged(self):
+        """An emulator answering at modern speed while claiming vintage silicon."""
+        v = verify(NONCE_A, _binding(NONCE_A, rate_ns=10), expected_rate_ns=50_000)
+        self.assertFalse(v["ok"])
+        self.assertEqual(v["state"], "rate_implausible")
+
+    def test_rate_check_is_skipped_when_no_history_is_known(self):
+        v = verify(NONCE_A, _binding(NONCE_A, rate_ns=10), expected_rate_ns=None)
+        self.assertTrue(v["ok"], "cold start must not fail on an unknown rate")
+
+
+class PhaseZeroIsObserveOnlyTest(unittest.TestCase):
+    """Phase 0 must not gate rewards. Adoption first, enforcement later."""
+
+    SRC = os.path.join(NODE, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+    def test_binding_verdict_does_not_touch_weight_yet(self):
+        import ast
+        src = open(self.SRC).read()
+        tree = ast.parse(src)
+        calls = [
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+            and n.func.id == "verify_measurement_binding"
+        ]
+        self.assertEqual(len(calls), 1, "expected exactly one phase-0 call site")
+        self.assertNotIn("measurement_binding_verdict) *", src)
+        self.assertNotIn("hw_weight * measurement_binding", src)
+
+    def test_the_next_workload_is_advertised_to_clients(self):
+        """A client must be able to adopt binding without a coordinated release."""
+        src = open(self.SRC).read()
+        self.assertIn("measurement_workload_next", src)
+        self.assertIn("measurement_binding_state", src)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_operator_clustering.py
+++ b/tests/test_operator_clustering.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""RIP-309d: cluster by operator, then ask whether the members are independent.
+
+Every other control here is per-miner, so a farm of N identities is N cheap,
+independent trust-building exercises. Clustering makes the operator the unit,
+which is what the contributor-tenure panel demanded: per-cluster, not
+per-account.
+
+The trap is that co-location proves nothing. On this chain the largest cluster
+is an honest lab — seven machines behind one WAN address — so clustering alone
+would penalise the most genuine vintage fleet on the network first. The half
+that discriminates is whether the members' measurement histories are
+independent.
+
+The fixtures below are the REAL medians observed on that lab, and a synthetic
+farm built to be plausible rather than easy to catch. If a change makes the
+lab look correlated, that change is wrong.
+"""
+
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+NODE = os.path.join(ROOT, "node")
+sys.path.insert(0, NODE)
+
+os.environ.setdefault("RC_ADMIN_KEY", "t" * 64)
+
+_spec = importlib.util.spec_from_file_location(
+    "rc_node_cl", os.path.join(NODE, "rustchain_v2_integrated_v2.2.1_rip200.py")
+)
+MOD = importlib.util.module_from_spec(_spec)
+sys.modules["rc_node_cl"] = MOD
+_spec.loader.exec_module(MOD)
+
+# Medians measured on production, 2026-08-11. A Cobalt Qube 3 (K6-2), a
+# POWER8-era host, an HP Victus and a Power Mac G5 — a ~58x spread.
+REAL_LAB = {
+    "cobalt-qube3-scott": 0.00206,
+    "modern-sophiacore-3a168058": 0.07619,
+    "victus-x86-scott": 0.11021,
+    "g5-selena-179": 0.12266,
+}
+
+# One generator, jittered a little. Deliberately not identical, because a
+# competent forger would not emit identical values.
+SYNTHETIC_FARM = {f"farm_{i}": 0.0800 + (i % 5) * 0.0009 for i in range(12)}
+
+
+class _DB:
+    def __init__(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.conn = sqlite3.connect(self.tmp.name)
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute(
+            "CREATE TABLE ip_rate_limit(client_ip TEXT, miner_id TEXT, ts INTEGER)")
+        self.conn.execute(
+            "CREATE TABLE hardware_bindings(hardware_id TEXT, bound_miner TEXT)")
+        self.conn.execute("CREATE TABLE miner_macs(miner TEXT, mac_hash TEXT)")
+        MOD.ensure_fingerprint_history_table(self.conn)
+
+    def add_miner(self, ip, miner, median, samples=8):
+        import json
+        self.conn.execute(
+            "INSERT INTO ip_rate_limit(client_ip, miner_id, ts) VALUES (?,?,0)",
+            (ip, miner))
+        for i in range(samples):
+            # Physical wobble around the median, well inside the frozen/noisy
+            # bands, so history depth is never the thing being tested here.
+            v = median * (0.85 + 0.30 * ((i * 7) % 11) / 10.0)
+            self.conn.execute(
+                "INSERT INTO miner_fingerprint_history(miner, ts, profile_json) "
+                "VALUES (?,?,?)",
+                (miner, 1786520000 + i * 1800,
+                 json.dumps({"clock_drift_cv": v})))
+        self.conn.commit()
+
+    def close(self):
+        self.conn.close()
+        os.unlink(self.tmp.name)
+
+
+class ClusterBuildingTest(unittest.TestCase):
+
+    def setUp(self):
+        self.db = _DB()
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_miners_sharing_an_address_are_one_cluster(self):
+        for name, med in REAL_LAB.items():
+            self.db.add_miner("209.194.25.46", name, med)
+        self.db.add_miner("8.8.4.4", "someone-else", 0.09)
+        clusters = MOD.build_operator_clusters(self.db.conn)
+        big = max(clusters, key=len)
+        self.assertEqual(set(big), set(REAL_LAB))
+        self.assertIn(["someone-else"], clusters)
+
+    def test_a_solo_miner_is_its_own_cluster(self):
+        self.db.add_miner("1.2.3.4", "solo", 0.09)
+        self.assertIn(["solo"], MOD.build_operator_clusters(self.db.conn))
+
+    def test_clustering_is_transitive_across_signals(self):
+        """Two miners on different IPs sharing hardware are one operator."""
+        self.db.add_miner("1.1.1.1", "a", 0.09)
+        self.db.add_miner("2.2.2.2", "b", 0.09)
+        self.db.conn.execute(
+            "INSERT INTO hardware_bindings(hardware_id, bound_miner) VALUES (?,?)",
+            ("hw-1", "a"))
+        self.db.conn.execute(
+            "INSERT INTO hardware_bindings(hardware_id, bound_miner) VALUES (?,?)",
+            ("hw-1", "b"))
+        self.db.conn.commit()
+        clusters = MOD.build_operator_clusters(self.db.conn)
+        self.assertTrue(any(set(c) == {"a", "b"} for c in clusters), clusters)
+
+
+class IndependenceDiscriminatorTest(unittest.TestCase):
+    """The half that decides whether clustering means anything."""
+
+    def setUp(self):
+        self.db = _DB()
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_the_real_lab_reads_as_independent(self):
+        """If this ever fails, the control has turned on the honest fleet.
+
+        These are production medians from seven machines behind one address.
+        A Qube at 0.002 and a G5 at 0.123 are not one generator.
+        """
+        for name, med in REAL_LAB.items():
+            self.db.add_miner("209.194.25.46", name, med)
+        verdict = MOD.cluster_independence(self.db.conn, list(REAL_LAB))
+        self.assertEqual(verdict["state"], "independent", verdict)
+        self.assertGreater(verdict["spread"], MOD.CLUSTER_INDEPENDENT_SPREAD)
+
+    def test_a_synthetic_farm_reads_as_correlated(self):
+        for name, med in SYNTHETIC_FARM.items():
+            self.db.add_miner("203.0.113.7", name, med)
+        verdict = MOD.cluster_independence(self.db.conn, list(SYNTHETIC_FARM))
+        self.assertEqual(verdict["state"], "correlated", verdict)
+        self.assertLess(verdict["spread"], MOD.CLUSTER_INDEPENDENT_SPREAD)
+
+    def test_the_two_are_separated_by_a_wide_margin(self):
+        """Not a knife-edge: the threshold should not need luck to work."""
+        for name, med in REAL_LAB.items():
+            self.db.add_miner("209.194.25.46", name, med)
+        for name, med in SYNTHETIC_FARM.items():
+            self.db.add_miner("203.0.113.7", name, med)
+        lab = MOD.cluster_independence(self.db.conn, list(REAL_LAB))["spread"]
+        farm = MOD.cluster_independence(self.db.conn, list(SYNTHETIC_FARM))["spread"]
+        self.assertGreater(lab, farm * 3,
+                           f"lab spread {lab} is not clearly above farm {farm}")
+
+    def test_a_small_group_is_not_judged(self):
+        self.db.add_miner("5.5.5.5", "x", 0.09)
+        self.db.add_miner("5.5.5.5", "y", 0.09)
+        v = MOD.cluster_independence(self.db.conn, ["x", "y"])
+        self.assertEqual(v["state"], "too_small_to_judge")
+
+    def test_missing_history_is_not_judged_as_correlated(self):
+        v = MOD.cluster_independence(self.db.conn, ["ghost1", "ghost2", "ghost3"])
+        self.assertEqual(v["state"], "insufficient_history")
+
+
+class ObserveOnlyTest(unittest.TestCase):
+    """Phase 0 must report, never dock."""
+
+    SRC = os.path.join(NODE, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+    def test_clustering_does_not_touch_reward_weight(self):
+        src = open(self.SRC).read()
+        for forbidden in ("hw_weight * cluster", "cluster_independence(conn, members)[",
+                          "* cluster_independence"):
+            self.assertNotIn(forbidden, src)
+
+    def test_the_false_positive_is_documented_in_the_code(self):
+        """An operator running identical machines looks correlated by
+        construction. Anyone wiring this to money must meet that first."""
+        src = open(self.SRC).read()
+        self.assertIn("KNOWN FALSE POSITIVE", src)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_rip309b_capability_unmeasured.py
+++ b/tests/test_rip309b_capability_unmeasured.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""RIP-309b: `unmeasured` is neutral, and proving nothing scores nothing.
+
+Two failures this pins:
+
+1. The honest vintage fleet earned zero. `validate_fingerprint_data` returned
+   `empty_fingerprint_checks` before the device was classified, so the flat C
+   miners (miners/apple2, miners/i386) died before the vintage branch could
+   help. An honest 486 reporting a truthful `clock_drift: false` was scored as
+   a failure, while a client hardcoding `"passed": true` scored 1.0 — the
+   control fired only on honest miners.
+
+2. The obvious fix introduces a worse hole. If every active check is
+   `unmeasured`, the denominator is empty, and returning 1.0 there hands a
+   perfect score to a payload carrying no evidence at all. The empty
+   denominator must fail closed.
+"""
+
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+NODE = os.path.join(ROOT, "node")
+sys.path.insert(0, NODE)
+
+_spec = importlib.util.spec_from_file_location(
+    "rc_node", os.path.join(NODE, "rustchain_v2_integrated_v2.2.1_rip200.py")
+)
+
+
+def _load():
+    mod = importlib.util.module_from_spec(_spec)
+    sys.modules["rc_node"] = mod
+    _spec.loader.exec_module(mod)
+    return mod
+
+
+MOD = _load()
+
+
+def _check(passed=True, **data):
+    return {"passed": passed, "data": data}
+
+
+class RotationScoringTest(unittest.TestCase):
+    """evaluate_rotating_fingerprint_checks: the three-state denominator."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.conn = sqlite3.connect(self.tmp.name)
+        self.conn.row_factory = sqlite3.Row
+
+    def tearDown(self):
+        self.conn.close()
+        os.unlink(self.tmp.name)
+
+    def _eval(self, fingerprint, arch=None, micro_accepted=False):
+        return MOD.evaluate_rotating_fingerprint_checks(
+            self.conn, 0, fingerprint, device_arch=arch, micro_accepted=micro_accepted
+        )
+
+    def test_missing_checks_on_modern_hardware_are_failures_not_neutral(self):
+        """Capable hardware gets no excuse: absent checks count as failures.
+
+        measured_total is the full active set here, not zero — the checks are
+        counted and failed, rather than dropped from the denominator. Only a
+        capability-limited class earns the neutral treatment.
+        """
+        res = self._eval({"checks": {}}, arch="modern")
+        self.assertEqual(res["unmeasured_active_checks"], [])
+        self.assertEqual(res["measured_total"], len(res["active_checks"]))
+        self.assertEqual(res["passed_active_checks"], [])
+        self.assertEqual(res["active_ratio"], 0.0)
+
+    def test_all_unmeasured_without_evidence_scores_zero(self):
+        """The hole: capability-limited class, but no native evidence earned."""
+        res = self._eval({"checks": {}}, arch="6502", micro_accepted=False)
+        self.assertEqual(res["measured_total"], 0)
+        self.assertEqual(
+            res["active_ratio"], 0.0,
+            "an all-unmeasured payload that proved nothing must not score 1.0",
+        )
+
+    def test_all_unmeasured_with_earned_evidence_scores_one(self):
+        """An accepted micro is not punished for hardware it cannot have."""
+        res = self._eval({"checks": {}}, arch="6502", micro_accepted=True)
+        self.assertEqual(res["active_ratio"], 1.0)
+        self.assertEqual(res["measured_total"], 0)
+        self.assertTrue(res["unmeasured_active_checks"])
+
+    def test_unmeasured_leaves_the_denominator_not_the_numerator(self):
+        """A micro passing one real check scores 1.0, not 1/4."""
+        fp = {"checks": {"anti_emulation": _check(vm_indicators=[])}}
+        res = self._eval(fp, arch="nes_6502", micro_accepted=True)
+        self.assertEqual(res["measured_total"], 1)
+        self.assertEqual(res["passed_active_checks"], ["anti_emulation"])
+        self.assertEqual(res["active_ratio"], 1.0)
+
+    def test_a_real_failure_still_counts_against_a_limited_class(self):
+        """`unmeasured` must not launder an actual reported failure."""
+        fp = {"checks": {"anti_emulation": _check(passed=False, vm_indicators=["qemu"])}}
+        res = self._eval(fp, arch="nes_6502", micro_accepted=True)
+        self.assertEqual(res["failed_active_checks"], ["anti_emulation"])
+        self.assertEqual(res["active_ratio"], 0.0)
+
+    def test_modern_arch_gets_no_unmeasured_excuse(self):
+        """A missing check on capable hardware is a failure, not neutral."""
+        res = self._eval({"checks": {}}, arch="modern")
+        self.assertEqual(res["unmeasured_active_checks"], [])
+        self.assertEqual(res["active_ratio"], 0.0)
+
+
+class MicroAcceptanceTest(unittest.TestCase):
+    """validate_fingerprint_data: classify before bailing on an empty map."""
+
+    def test_apple2_flat_payload_is_accepted_on_native_evidence(self):
+        fp = {"simd_identity": "a1b2c3d4e5f60718", "cycle_count": 1023, "ram_kb": 64}
+        ok, reason = MOD.validate_fingerprint_data(fp, {"arch": "6502"})
+        self.assertTrue(ok, reason)
+        self.assertTrue(reason.startswith("micro_native_evidence"), reason)
+
+    def test_one_evidence_field_is_not_enough(self):
+        ok, reason = MOD.validate_fingerprint_data({"ram_kb": 64}, {"arch": "6502"})
+        self.assertFalse(ok)
+        self.assertEqual(reason, "micro_insufficient_native_evidence")
+
+    def test_modern_claim_with_empty_checks_still_rejected(self):
+        ok, reason = MOD.validate_fingerprint_data({"checks": {}}, {"arch": "modern"})
+        self.assertFalse(ok)
+        self.assertEqual(reason, "empty_fingerprint_checks")
+
+    def test_modern_evidence_vetoes_a_micro_claim(self):
+        """The contradiction veto is what stops a Ryzen claiming to be a 6502."""
+        fp = {"cycle_count": 1023, "ram_kb": 64}
+        ok, reason = MOD.validate_fingerprint_data(
+            fp, {"arch": "6502", "machine": "x86_64", "cpu": "AMD Ryzen 9 7950X"}
+        )
+        self.assertFalse(ok)
+        self.assertTrue(reason.startswith("capability_claim_contradicted"), reason)
+
+    def test_micro_accepted_helper_requires_all_three_conditions(self):
+        good = {"cycle_count": 1023, "ram_kb": 64}
+        self.assertTrue(MOD._micro_accepted_for_rotation("6502", good, {"arch": "6502"}))
+        # contradicted
+        self.assertFalse(
+            MOD._micro_accepted_for_rotation("6502", good, {"machine": "x86_64"})
+        )
+        # not a limited class
+        self.assertFalse(MOD._micro_accepted_for_rotation("modern", good, {}))
+        # insufficient evidence
+        self.assertFalse(MOD._micro_accepted_for_rotation("6502", {"ram_kb": 64}, {}))
+
+
+class MultiplierTableTest(unittest.TestCase):
+    """Standalone micros sit below console, and the two tables agree."""
+
+    def test_standalone_micros_rank_below_console_silicon(self):
+        w = MOD.HARDWARE_WEIGHTS
+        self.assertLess(w["MOS"]["6502"], w["console"]["nes_6502"])
+        self.assertLess(w["MOS"]["65c816"], w["console"]["snes_65c816"])
+        self.assertLess(w["Zilog"]["z80"], w["console"]["gameboy_z80"])
+
+    def test_defaults_sit_under_named_arches(self):
+        w = MOD.HARDWARE_WEIGHTS
+        self.assertLess(w["MOS"]["default"], w["MOS"]["6502"])
+        self.assertLess(w["Zilog"]["default"], w["Zilog"]["z80"])
+
+    def test_micro_bonus_still_beats_modern_hardware(self):
+        w = MOD.HARDWARE_WEIGHTS
+        self.assertGreater(w["MOS"]["6502"], w["x86_64"]["modern"])
+
+    def test_the_two_multiplier_tables_agree_on_the_same_silicon(self):
+        """A second table disagreeing about one chip is how divergence starts."""
+        import rip_200_round_robin_1cpu1vote as rr
+        anti = rr.ANTIQUITY_MULTIPLIERS
+        w = MOD.HARDWARE_WEIGHTS
+        for arch, family in (("6502", "MOS"), ("65c816", "MOS"), ("z80", "Zilog")):
+            self.assertEqual(
+                w[family][arch], anti[arch],
+                f"HARDWARE_WEIGHTS[{family}][{arch}] and "
+                f"ANTIQUITY_MULTIPLIERS[{arch}] disagree",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_temporal_consistency_gates_bonus.py
+++ b/tests/test_temporal_consistency_gates_bonus.py
@@ -191,5 +191,52 @@ class GateIsActuallyWiredTest(unittest.TestCase):
         )
 
 
+class UnmeasuredMetricsAreExcludedNotPassedTest(unittest.TestCase):
+    """An absent metric must leave the average, not enter it as a pass.
+
+    Measured on the live fleet: most miners populate only clock_drift_cv, and
+    the other three read 0.0. While an absent metric scored 1.0, a fully
+    replayed constant profile averaged (1.0 + 1.0 + 1.0 + 0.2) / 4 = 0.8, so a
+    2.5x miner kept 2.2 of its premium. Three free passes drowned the one real
+    detection.
+
+    Same principle as the rotating-check denominator: could-not-measure is not
+    passed. It also matters for honesty toward vintage hardware, since a 6502
+    genuinely cannot produce thermal_variance and must not be handed three free
+    credits toward a premium because of it.
+    """
+
+    def test_a_replayed_profile_is_caught_on_one_populated_metric(self):
+        seq = _sequence([_profile(0.05, 0.0, 0.0, 0.0)] * 8)
+        review = validate(seq)
+        self.assertEqual(list(review["check_scores"]), ["clock_drift_cv"],
+                         "absent metrics must not appear in check_scores")
+        self.assertAlmostEqual(review["score"], 0.2)
+        self.assertAlmostEqual(apply_gate(2.5, review), 1.3)
+
+    def test_populating_more_metrics_does_not_change_the_verdict(self):
+        """A forger must not dilute a detection by omitting other metrics."""
+        sparse = validate(_sequence([_profile(0.05, 0.0, 0.0, 0.0)] * 8))
+        full = validate(_sequence([_profile(0.05, 3.0, 0.02, 4.0)] * 8))
+        self.assertAlmostEqual(sparse["score"], full["score"])
+
+    def test_nothing_measurable_is_unverified_not_perfect(self):
+        seq = _sequence([_profile(0.0, 0.0, 0.0, 0.0)] * 8)
+        review = validate(seq)
+        self.assertEqual(review["reason"], "insufficient_history")
+        self.assertLess(apply_gate(2.5, review), 2.5)
+
+    def test_an_honest_sparse_profile_still_keeps_its_bonus(self):
+        """Only-clock-populated must not become an automatic penalty."""
+        seq = _sequence([
+            _profile(0.050, 0.0, 0.0, 0.0), _profile(0.053, 0.0, 0.0, 0.0),
+            _profile(0.048, 0.0, 0.0, 0.0), _profile(0.055, 0.0, 0.0, 0.0),
+            _profile(0.051, 0.0, 0.0, 0.0), _profile(0.049, 0.0, 0.0, 0.0),
+        ])
+        review = validate(seq)
+        self.assertFalse(review["review_flag"], review["flags"])
+        self.assertAlmostEqual(apply_gate(2.5, review), 2.5)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_temporal_consistency_gates_bonus.py
+++ b/tests/test_temporal_consistency_gates_bonus.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""The temporal consistency score must reach the reward, not just the log.
+
+`validate_temporal_consistency` has always measured a miner against its own
+measurement history and detected the two shapes a forger falls into:
+
+  frozen_profile  rel_var < 0.01   the same value replayed every epoch
+  noisy_profile   rel_var > 0.8    an RNG with no physical model behind it
+
+Its score was then discarded. The only consumer was:
+
+    # Issue #19 temporal consistency only sets a review flag (no hard-fail).
+    if temporal_review.get("review_flag"):
+        app.logger.warning(...)
+
+So a miner contradicting its own history collected the full antiquity premium
+anyway. These tests pin the score to the weight.
+
+What is deliberately NOT done here: nothing is pushed below baseline. Only the
+bonus above 1.0 is at risk, because the bonus is the only thing worth forging
+and a false positive should cost a premium, never someone's participation.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+NODE = os.path.join(ROOT, "node")
+sys.path.insert(0, NODE)
+
+_spec = importlib.util.spec_from_file_location(
+    "rc_node_tc", os.path.join(NODE, "rustchain_v2_integrated_v2.2.1_rip200.py")
+)
+MOD = importlib.util.module_from_spec(_spec)
+sys.modules["rc_node_tc"] = MOD
+_spec.loader.exec_module(MOD)
+
+apply_gate = MOD.apply_temporal_consistency_to_weight
+validate = MOD.validate_temporal_consistency
+
+
+def _profile(clock, thermal, jitter, cache):
+    return {
+        "clock_drift_cv": clock,
+        "thermal_variance": thermal,
+        "jitter_cv": jitter,
+        "cache_hierarchy_ratio": cache,
+    }
+
+
+def _sequence(profiles):
+    return [{"ts": 1000 + i * 600, "profile": p} for i, p in enumerate(profiles)]
+
+
+class GateArithmeticTest(unittest.TestCase):
+
+    def test_baseline_and_below_is_never_reduced(self):
+        """A modern miner at 0.8x is untouched, whatever its history says."""
+        bad = {"score": 0.2, "reason": "temporal_review_required"}
+        self.assertEqual(apply_gate(0.8, bad), 0.8)
+        self.assertEqual(apply_gate(1.0, bad), 1.0)
+        self.assertEqual(apply_gate(0.0005, bad), 0.0005)
+
+    def test_a_consistent_miner_keeps_its_full_bonus(self):
+        good = {"score": 1.0, "reason": "temporal_consistent"}
+        self.assertAlmostEqual(apply_gate(2.5, good), 2.5)
+
+    def test_an_inconsistent_miner_loses_bonus_not_baseline(self):
+        """Worst case lands at baseline, never below it."""
+        worst = {"score": 0.0, "reason": "temporal_review_required"}
+        self.assertAlmostEqual(apply_gate(2.5, worst), 1.0)
+        self.assertAlmostEqual(apply_gate(4.0, worst), 1.0)
+
+    def test_partial_score_scales_only_the_bonus_portion(self):
+        half = {"score": 0.5, "reason": "temporal_review_required"}
+        # 1.0 + (2.5 - 1.0) * 0.5
+        self.assertAlmostEqual(apply_gate(2.5, half), 1.75)
+
+    def test_unverified_history_withholds_half_the_bonus(self):
+        """Cold start: not trusted with the premium, not punished either."""
+        fresh = {"score": 1.0, "reason": "insufficient_history"}
+        self.assertAlmostEqual(
+            apply_gate(2.5, fresh),
+            1.0 + 1.5 * MOD.TEMPORAL_UNVERIFIED_BONUS_FRACTION,
+        )
+        self.assertGreater(apply_gate(2.5, fresh), 1.0, "honest newcomers keep a premium")
+        self.assertLess(apply_gate(2.5, fresh), 2.5, "a fresh identity is not fully trusted")
+
+    def test_a_fresh_identity_is_no_longer_scored_perfect(self):
+        """The old shape returned score 1.0 for no history, so a brand new
+        identity — the cheapest thing a forger can make — was the most
+        trusted. The gate must not reproduce that."""
+        fresh = validate([])
+        self.assertEqual(fresh["reason"], "insufficient_history")
+        self.assertLess(apply_gate(2.5, fresh), 2.5)
+
+    def test_malformed_review_does_not_crash_or_inflate(self):
+        for junk in (None, {}, {"score": "abc"}, {"score": None}, []):
+            self.assertLessEqual(apply_gate(2.5, junk), 2.5)
+        self.assertEqual(apply_gate("not-a-number", {"score": 1.0}), "not-a-number")
+
+    def test_score_is_clamped_so_a_bad_value_cannot_inflate_weight(self):
+        self.assertAlmostEqual(apply_gate(2.5, {"score": 9.0, "reason": "x"}), 2.5)
+        self.assertAlmostEqual(apply_gate(2.5, {"score": -5.0, "reason": "x"}), 1.0)
+
+
+class ForgerSignatureTest(unittest.TestCase):
+    """The two shapes a forged history takes, end to end."""
+
+    def test_replayed_constant_profile_loses_most_of_the_bonus(self):
+        """A payload measured once and replayed has near-zero variance."""
+        seq = _sequence([_profile(0.05, 3.0, 0.02, 4.0)] * 8)
+        review = validate(seq)
+        self.assertIn("frozen_profile:clock_drift_cv", review["flags"])
+        self.assertTrue(review["review_flag"])
+        gated = apply_gate(2.5, review)
+        self.assertLess(gated, 1.6, f"frozen profile still earned {gated}")
+        self.assertGreaterEqual(gated, 1.0)
+
+    def test_rng_without_a_physical_model_loses_bonus(self):
+        """Wild swings are as unphysical as no swings at all."""
+        seq = _sequence([
+            _profile(0.002, 0.2, 0.001, 1.2),
+            _profile(0.30, 20.0, 0.45, 18.0),
+            _profile(0.004, 0.4, 0.002, 1.4),
+            _profile(0.28, 22.0, 0.40, 17.0),
+            _profile(0.003, 0.3, 0.0015, 1.3),
+        ])
+        review = validate(seq)
+        self.assertTrue(review["review_flag"], review)
+        self.assertLess(apply_gate(2.5, review), 2.5)
+
+    def test_real_hardware_drift_keeps_its_bonus(self):
+        """Small, physical variation must not be mistaken for either failure.
+
+        This is the false-positive guard: an honest G4 whose readings wander a
+        few percent has to keep earning 2.5x, or the control repeats the very
+        mistake it was built to fix, firing only on honest miners.
+        """
+        seq = _sequence([
+            _profile(0.050, 3.00, 0.020, 4.00),
+            _profile(0.053, 3.15, 0.021, 4.10),
+            _profile(0.048, 2.90, 0.019, 3.95),
+            _profile(0.055, 3.30, 0.022, 4.20),
+            _profile(0.051, 3.05, 0.020, 4.05),
+            _profile(0.049, 2.95, 0.0205, 3.98),
+        ])
+        review = validate(seq)
+        self.assertFalse(review["review_flag"], f"honest drift flagged: {review['flags']}")
+        self.assertAlmostEqual(apply_gate(2.5, review), 2.5)
+
+
+class GateIsActuallyWiredTest(unittest.TestCase):
+    """The helper being correct is worth nothing if nobody calls it.
+
+    That is the exact failure this whole change fixes: the score was computed
+    correctly for months and never reached the reward. A unit test on the
+    helper alone would have passed the entire time. So assert the call sites.
+    """
+
+    SRC = os.path.join(NODE, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+    def test_both_weight_paths_apply_the_gate(self):
+        import ast
+        tree = ast.parse(open(self.SRC).read())
+        calls = [
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+            and n.func.id == "apply_temporal_consistency_to_weight"
+        ]
+        self.assertGreaterEqual(
+            len(calls), 2,
+            "expected the gate on both the attestation reward path and the "
+            "epoch enroll path; enrollment is what actually sets epoch weight, "
+            "so gating only attestation would be cosmetic",
+        )
+
+    def test_no_weight_assignment_from_hardware_weights_escapes_the_gate(self):
+        """Every HARDWARE_WEIGHTS lookup that sets hw_weight must be followed
+        by the gate, or a third weight path could quietly reintroduce the
+        ungated premium."""
+        src = open(self.SRC).read()
+        assignments = src.count("hw_weight = HARDWARE_WEIGHTS")
+        gated = src.count("apply_temporal_consistency_to_weight(hw_weight")
+        self.assertGreaterEqual(
+            gated, assignments,
+            f"{assignments} hw_weight assignments but only {gated} gated",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Reconciles #8064 with what `main` grew since, after a five-model design review. Closes the design question left open on #8064 and #8065.

## Why this exists

The honest vintage fleet earns nothing today.

`validate_fingerprint_data` returns `empty_fingerprint_checks` at line ~3875, before `claimed_arch` is computed and before the vintage branch. The flat C miners (`miners/apple2`, `miners/i386`) send device-native measurements and no `checks` map, so they die at that return. An honest 486 reporting a truthful `clock_drift: false` (no TSC on that silicon) is scored as a failure. Meanwhile a client that hardcodes `"passed": true` scores 1.0.

The control fires only on honest miners. That is backwards, and it selects for lying.

## The design, and how it was chosen

#8064 and main had both grown a fix for the 386/486 TSC gap, by different means, so the branches could not be mechanically merged. Five reviewers looked at it independently: Opus, Fable, Grok, Codex and qwen3.8.

Unanimous on the model:

- adopt the three-state verdict, `pass` / `fail` / `unmeasured`
- delete `allow_tscless_x86_reward` rather than maintain two leniency mechanisms
- the empty denominator must not return 1.0

## What changed

**`unmeasured` is neutral.** A check a class structurally cannot perform is dropped from the scoring DENOMINATOR, not counted either way. The class is keyed on the SERVER-derived arch, never the request body, so a miner cannot self-select which checks it is excused from. `_capability_contradiction` revokes the profile when the payload shows modern evidence (64-bit machine field, modern CPU brand, x86 or PowerPC SIMD). `anti_emulation` is never neutralized.

**The empty denominator fails closed.** If nothing was measured the ratio is `0.0`, unless an unvetoed capability-limited class already passed validation on at least two device-native measurements. The earlier shape returned `1.0`, handing a perfect score to a payload that proved nothing. That is now pinned by `test_all_unmeasured_without_evidence_scores_zero`.

**`allow_tscless_x86_reward` is deleted.** A 486 has no TSC for every caller, not only the reward path. Two consumers disagreeing about the same silicon is how the rotation-selector divergence happened. Removing it also fixes three `test_warthog_bonus_not_ratcheted` tests that fail on `main`: their test double does not accept the kwarg, so the call site raised `TypeError` and attestation returned HTTP 500.

**Standalone micros are added below the console tier.**

```python
"MOS":   {"6502": 2.5, "65c816": 2.4, "default": 2.2},
"Zilog": {"z80": 2.3, "default": 2.1},
```

Not the 2.8 / 2.7 / 2.6 console mirror originally proposed. A Pico-bridged console presents at least one measured check; a standalone micro presents a small HTTP payload that cannot be distinguished from a forgery. Paying both the same rate would make the cheapest-to-forge class the best-paid on the chain. 6502 lands level with 386 and G4, so the bonus is real without topping a table it cannot prove its place in. Defaults sit under the named arches so an invented chip name cannot auto-max.

`ANTIQUITY_MULTIPLIERS` is updated to match. Its bare `6502` / `z80` keys now mean standalone silicon, while the console-prefixed keys keep the higher rate. Leaving two tables disagreeing about the same chip is the failure mode this repo has already had once.

## Verification

15 new tests in `tests/test_rip309b_capability_unmeasured.py`, covering the Apple II acceptance path, the one-evidence-field rejection, the contradiction veto, a real failure still counting against a limited class, and the empty-denominator hole in both directions.

- `tests/`: **3744 passed, 0 failed**
- `node/tests/`: failure set diffed against a clean `main` checkout. **No new failures. Three fixed.**
- `ruff`: 62 findings on the touched files before and after, all pre-existing. The new test file is clean.
- `scripts/check_fetchall.sh`: clean.

One existing test, `test_tscless_relaxation_is_not_global`, asserted the old call-site-scoped behaviour. It is inverted rather than deleted, with the reasoning in its docstring, and a companion test added to prove the relaxation does not leak to hardware that does have a TSC.

## Known limit

A spoofer fabricating a byte-identical minimal micro payload with no contradicting evidence is indistinguishable over HTTP. The contradiction veto, hardware binding, rate limits and entropy scoring reduce volume; they do not solve identity. That residual is priced into the multipliers above rather than wished away, and it is the subject of separate work.
