### PR TITLE
feat(attest): port the phased signed-attestation rollout from the production node

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -333,6 +333,94 @@ def _attest_text(value):
     return None
 
 
+# phased rollout, a strict self-certifying identity gate, and a freeze/generation
+# ledger for the admin unpin/rotate path. DB_PATH is resolved at CALL time (these
+# run per request), so their placement ahead of the DB_PATH module constant is safe.
+_RTC_HEX_ADDRESS_RE = re.compile(r"^RTC[0-9a-f]{40}$")  # lowercase only: node-derived addrs
+
+def _is_rtc_hex_address(miner):
+    """True only for canonical, self-certifying RTC addresses (``RTC`` + 40 lowercase hex).
+
+    Such an address is ``RTC`` + SHA256(pubkey)[:40] (see ``address_from_pubkey``),
+    so a signature whose public key derives to the address is cryptographic proof
+    of ownership — the ONLY case where trust-on-first-use pinning is safe. Symbolic
+    / legacy names (dual-g4-125, power8-s824-sophia, …) are NOT self-certifying and
+    are never public-TOFU-pinned.
+    """
+    return bool(isinstance(miner, str) and _RTC_HEX_ADDRESS_RE.fullmatch(miner))
+
+_ATTEST_ENFORCE_MODES = ("log_only", "enforce_new", "enforce_all")
+
+def _attest_enforce_mode():
+    """Rollout phase for attestation signature enforcement (env RTC_ATTEST_ENFORCE_MODE).
+
+    log_only     (Phase 0, DEFAULT) — verify signatures if present; log, enforce nothing.
+    enforce_new  (Phase 1)          — new identities must sign; grandfathered stay unsigned.
+    enforce_all  (Phase 2)          — every miner must present a valid signature.
+    """
+    mode = (os.environ.get("RTC_ATTEST_ENFORCE_MODE", "log_only") or "").strip().lower()
+    return mode if mode in _ATTEST_ENFORCE_MODES else "log_only"
+
+def _attest_unsigned_allowlist():
+    """Case-SENSITIVE set of miner IDs permitted to attest unsigned in enforcing phases.
+
+    Miner IDs are case-sensitive on the node; folding case here would conflate
+    distinct identities, so the split values are compared verbatim.
+    """
+    raw = os.environ.get("RTC_UNSIGNED_ATTEST_ALLOWLIST", "") or ""
+    return {a.strip() for a in raw.split(",") if a.strip()}
+
+def _ensure_attest_grandfather_table(conn):
+    """Snapshot of identities established before the signature cutover.
+
+    Populated once by the migration script (see MIGRATION_PLAN.md). Membership is
+    FROZEN at cutover so a post-cutover attacker cannot mint an identity, attest
+    once, and thereby become 'grandfathered'.
+    """
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS attest_grandfathered ("
+        "miner TEXT PRIMARY KEY, added_at INTEGER NOT NULL DEFAULT 0, reason TEXT DEFAULT '')"
+    )
+
+def _ensure_attest_key_admin_table(conn):
+    """Freeze/generation ledger backing the admin unpin/rotate path.
+
+    ``pin_frozen=1`` disables public TOFU re-pinning after an admin unpin so a
+    stranger cannot immediately re-capture an unpinned identity; ``generation``
+    is a monotonically increasing audit counter bumped on every admin action.
+    """
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS attest_key_admin ("
+        "miner TEXT PRIMARY KEY, pin_frozen INTEGER NOT NULL DEFAULT 0, "
+        "generation INTEGER NOT NULL DEFAULT 0, updated_at INTEGER NOT NULL DEFAULT 0, "
+        "note TEXT DEFAULT '')"
+    )
+
+def _attest_identity_state(miner):
+    """Read pinned key, grandfather status, and pin-freeze in a single connection.
+
+    Returns ``(stored_pubkey_or_None, is_grandfathered, is_pin_frozen)``. Raises on
+    DB error so callers can FAIL CLOSED in enforcing phases rather than silently
+    treating a broken DB as 'no key on file' (which would be fail-open).
+    """
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        _ensure_attest_grandfather_table(conn)
+        _ensure_attest_key_admin_table(conn)
+        stored = None
+        row = conn.execute(
+            "SELECT signing_pubkey FROM miner_attest_recent WHERE miner = ?", (miner,)
+        ).fetchone()
+        if row and row[0]:
+            stored = row[0].strip().lower()
+        gf = conn.execute(
+            "SELECT 1 FROM attest_grandfathered WHERE miner = ?", (miner,)
+        ).fetchone()
+        frozen_row = conn.execute(
+            "SELECT pin_frozen FROM attest_key_admin WHERE miner = ?", (miner,)
+        ).fetchone()
+        is_frozen = bool(frozen_row and frozen_row[0])
+        return stored, bool(gf), is_frozen
+
 def _attest_valid_miner(value):
     """Accept only bounded miner identifiers with a conservative character set."""
     text = _attest_text(value)
@@ -4970,6 +5058,83 @@ def _submit_attestation_impl():
     canonical_payload_verified = False
     miner_id_raw = _attest_valid_miner(data.get('miner_id')) or miner
     commitment = report.get('commitment') or ''
+    # ── Ed25519 identity binding & phased enforcement (#8016 hardened) ──────────
+    # signing_pubkey is the authority /epoch/enroll verifies against, so this gate
+    # decides (a) whether an UNSIGNED submission is allowed this phase and (b) later
+    # which verified keys are safe to pin. See _is_rtc_hex_address / _attest_*.
+    enforce_mode = _attest_enforce_mode()
+    _enforcing = (enforce_mode != "log_only")
+    has_signature = bool(sig_hex and pubkey_hex)
+
+    # Reject partial pairs — a lone signature or lone public_key is malformed and
+    # must never fall through to the "unsigned" path (would strip auth silently).
+    # ALWAYS-ON (input validation, not phase enforcement): identical in log_only.
+    if bool(sig_hex) != bool(pubkey_hex):
+        return jsonify({
+            "ok": False,
+            "error": "incomplete_signature",
+            "message": "Both signature and public_key are required together",
+            "code": "INCOMPLETE_SIGNATURE",
+        }), 400
+
+    # FAIL CLOSED on identity-state read errors while enforcing; a broken DB must
+    # not be treated as 'no key on file' (which would be fail-open).
+    try:
+        stored_signing_pubkey, is_grandfathered, is_pin_frozen = _attest_identity_state(miner)
+    except Exception as _id_err:
+        if _enforcing:
+            print(f"[ATTEST/ENFORCE:{enforce_mode}] IDENTITY STATE READ FAILED "
+                  f"(fail-closed): miner={str(miner)[:32]} err={_id_err}")
+            return jsonify({
+                "ok": False,
+                "error": "identity_state_unavailable",
+                "message": "Unable to verify miner identity state; try again shortly",
+                "code": "IDENTITY_STATE_UNAVAILABLE",
+            }), 503
+        stored_signing_pubkey, is_grandfathered, is_pin_frozen = None, False, False
+        print(f"[ATTEST/ENFORCE:log_only] identity state read failed "
+              f"(fail-open in log_only): miner={str(miner)[:32]} err={_id_err}")
+
+    allowlisted = miner in _attest_unsigned_allowlist()  # case-SENSITIVE
+    is_rtc_hex = _is_rtc_hex_address(miner)
+
+    if not has_signature:
+        if allowlisted:
+            pass  # operator-permitted structural-no-signature hardware
+        elif enforce_mode == "log_only":
+            if stored_signing_pubkey:
+                print(f"[ATTEST/ENFORCE:log_only] UNSIGNED but key on file — would "
+                      f"reject in enforce_new+: miner={str(miner)[:32]}")
+            elif not is_grandfathered:
+                print(f"[ATTEST/ENFORCE:log_only] UNSIGNED new identity — would "
+                      f"reject in enforce_new+: miner={str(miner)[:32]}")
+        else:
+            # enforce_new / enforce_all
+            must_sign = (
+                bool(stored_signing_pubkey)        # key on file → must use it
+                or enforce_mode == "enforce_all"   # Phase 2 → everyone signs
+                or not is_grandfathered             # Phase 1 → new identities sign
+            )
+            if must_sign:
+                if stored_signing_pubkey:
+                    _why = "a signing key is already on file for this miner"
+                elif enforce_mode == "enforce_all":
+                    _why = "all miners must sign in the enforce_all phase"
+                else:
+                    _why = "new miners must sign from their first attestation"
+                print(f"[ATTEST/ENFORCE:{enforce_mode}] REJECT unsigned: "
+                      f"miner={str(miner)[:32]} ({_why})")
+                return jsonify({
+                    "ok": False,
+                    "error": "missing_signature",
+                    "message": f"Ed25519 signature required — {_why}",
+                    "code": "MISSING_SIGNATURE",
+                }), 400
+            else:
+                print(f"[ATTEST/ENFORCE:{enforce_mode}] grandfathered unsigned "
+                      f"attestation allowed (add a signing key before Phase 2): "
+                      f"miner={str(miner)[:32]}")
+
     if sig_hex and pubkey_hex:
         if HAVE_NACL:
             # Type-guard signature_type too — reject a non-string value with 400,
@@ -5049,6 +5214,80 @@ def _submit_attestation_impl():
                 ),
                 "code": "ED25519_UNAVAILABLE",
             }), 503
+
+    # ── Post-verification identity binding & pin decision (#8016 hardened) ──────
+    # If has_signature, the signature is now cryptographically verified (else we
+    # already returned 400/503). Decide which — if any — key is safe to PIN.
+    # pin_pubkey is what we persist into miner_attest_recent.signing_pubkey; None
+    # means 'do not add a key' (COALESCE keeps any existing pin).
+    pin_pubkey = None
+    if has_signature:
+        derives_to_addr = False
+        if is_rtc_hex:
+            try:
+                derives_to_addr = (address_from_pubkey(pubkey_hex) == miner)
+            except Exception:
+                derives_to_addr = False
+
+        # RTC-hex identities MUST prove ownership by key derivation. A regex match
+        # alone is insufficient — the key must hash to the claimed address.
+        if is_rtc_hex and not derives_to_addr:
+            if _enforcing:
+                print(f"[ATTEST/SIG] PUBKEY-ADDRESS MISMATCH (reject): "
+                      f"miner={miner[:24]}...")
+                return jsonify({
+                    "ok": False,
+                    "error": "pubkey_address_mismatch",
+                    "message": "The public key does not derive to this RTC address",
+                    "code": "PUBKEY_ADDRESS_MISMATCH",
+                }), 400
+            print(f"[ATTEST/ENFORCE:log_only] PUBKEY-ADDRESS MISMATCH — would "
+                  f"reject in enforcing phase: miner={miner[:24]}...")
+
+        # Rotation block: a pinned key cannot be swapped by re-signing with a new
+        # key. Legitimate rotation goes through the admin path (freeze + set).
+        if stored_signing_pubkey and pubkey_hex != stored_signing_pubkey:
+            if _enforcing:
+                print(f"[ATTEST/SIG] KEY ROTATION BLOCKED (reject): miner={miner[:24]}... "
+                      f"provided={pubkey_hex[:12]}... pinned={stored_signing_pubkey[:12]}...")
+                return jsonify({
+                    "ok": False,
+                    "error": "signing_key_mismatch",
+                    "message": "The provided signing key does not match the pinned key; "
+                               "use the admin rotate path to change keys",
+                    "code": "SIGNING_KEY_MISMATCH",
+                }), 400
+            print(f"[ATTEST/ENFORCE:log_only] KEY ROTATION — would reject in "
+                  f"enforcing phase: miner={miner[:24]}...")
+
+        # Pin eligibility (first-signer-hijack protection). Persist a key ONLY when
+        # trust-on-first-use cannot be used to capture someone else's identity:
+        #   • already pinned         → keep existing (COALESCE); pin_pubkey None.
+        #   • pin_frozen             → admin unpinned it; only admin 'set' may re-pin.
+        #   • self-certifying RTC-hex→ pin iff the key derives to the address
+        #                              (cryptographic proof of ownership).
+        #   • brand-NEW identity     → TOFU-safe: no existing owner to hijack, and
+        #                              Phase 1 forces new miners to sign, so the id
+        #                              is key-bound from birth (kills cheap minting).
+        #   • grandfathered + not derivable (existing symbolic/legacy name such as
+        #     dual-g4-125) → HELD: never public-TOFU-pinned; key must be admin-
+        #     enrolled via /admin/attest/key. This is the anti-hijack core.
+        if stored_signing_pubkey:
+            pin_pubkey = None
+        elif is_pin_frozen:
+            pin_pubkey = None
+            print(f"[ATTEST/PIN] HELD (pin frozen — admin 'set' required): miner={miner[:32]}")
+        elif is_rtc_hex:
+            pin_pubkey = pubkey_hex if derives_to_addr else None
+            if not derives_to_addr:
+                print(f"[ATTEST/PIN] HELD (RTC-hex key does not derive): miner={miner[:32]}")
+        elif not is_grandfathered:
+            pin_pubkey = pubkey_hex
+        else:
+            pin_pubkey = None
+            print(f"[ATTEST/PIN] HELD (grandfathered identity — admin enrollment "
+                  f"required to pin a key): miner={miner[:32]}")
+
 
     # IP rate limiting (Security Hardening 2026-02-02)
     ip_ok, ip_reason = check_ip_rate_limit(client_ip, miner)
@@ -5314,7 +5553,7 @@ def _submit_attestation_impl():
         except Exception:
             pass
 
-    record_attestation_success(miner, device, fingerprint_passed, client_ip, signals=signals, fingerprint=fingerprint, signing_pubkey=pubkey_hex or None, entropy_score=entropy_score)
+    record_attestation_success(miner, device, fingerprint_passed, client_ip, signals=signals, fingerprint=fingerprint, signing_pubkey=pin_pubkey, entropy_score=entropy_score)
 
     temporal_review = {"score": 1.0, "review_flag": False, "reason": "insufficient_history", "flags": [], "check_scores": {}}
     try:
@@ -6032,6 +6271,112 @@ def miner_set_header_key():
         _prune_header_keys(db, miner_id)
         db.commit()
     return jsonify({"ok":True,"miner_id":miner_id,"pubkey_hex":pubkey_hex})
+
+@app.route('/admin/attest/key', methods=['POST'])
+def admin_attest_key():
+    """Admin management of a miner's ATTESTATION signing key (#8016 hardened).
+
+    This is the authenticated unpin/rotate path that closes the lockout attack:
+    a real owner who lost a key, or an entry pinned by the wrong party, is fixed
+    here. It manages miner_attest_recent.signing_pubkey (the key /epoch/enroll
+    verifies against) plus the freeze/generation ledger (attest_key_admin).
+
+    Body: {"miner":"<id>", "action":"status|unpin|set|unfreeze",
+           "public_key":"<64 hex>"   # required for action=set
+           "note":"<audit note>"}     # optional
+
+      status   — report pinned key, pin_frozen, generation.
+      unpin    — clear the pinned key AND set pin_frozen=1 (bump generation). The
+                 freeze stops a stranger from immediately public-TOFU re-capturing
+                 the identity; re-pin then requires an admin 'set' (or, for a
+                 self-certifying RTC-hex address, an admin 'unfreeze' so only the
+                 key that derives to the address can re-pin).
+      set      — pin an operator-supplied key directly (authoritative rotate/
+                 enroll). Clears the freeze. This is the ONLY way a symbolic/legacy
+                 name (dual-g4-125, power8-s824-sophia, …) ever gets a pinned key.
+      unfreeze — clear pin_frozen without setting a key (allows RTC-hex self-
+                 certifying public re-pin to resume).
+    """
+    gate = _require_admin_request(request)
+    if gate is not None:
+        return gate
+
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return jsonify({"ok": False, "error": "invalid_json_body", "code": "INVALID_JSON_BODY"}), 400
+    miner = _attest_valid_miner(body.get("miner"))
+    if not miner:
+        return jsonify({"ok": False, "error": "invalid_miner", "code": "INVALID_MINER"}), 400
+    action = body.get("action")
+    action = action.strip().lower() if isinstance(action, str) else ""
+    if action not in ("status", "unpin", "set", "unfreeze"):
+        return jsonify({"ok": False, "error": "invalid_action",
+                        "message": "action must be one of status|unpin|set|unfreeze",
+                        "code": "INVALID_ACTION"}), 400
+
+    new_key = None
+    if action == "set":
+        new_key = _valid_ed25519_pubkey_hex(body.get("public_key"))
+        if not new_key:
+            return jsonify({"ok": False, "error": "invalid_public_key",
+                            "message": "action=set requires a 64-hex-char Ed25519 public_key",
+                            "code": "INVALID_PUBLIC_KEY"}), 400
+
+    note = body.get("note")
+    note = note.strip()[:256] if isinstance(note, str) else ""
+    now = int(time.time())
+
+    with closing(sqlite3.connect(DB_PATH)) as db:
+        _ensure_attest_key_admin_table(db)
+        # Ensure the target row / column exist so status is meaningful even for a
+        # miner that has not attested yet.
+        try:
+            db.execute("ALTER TABLE miner_attest_recent ADD COLUMN signing_pubkey TEXT")
+        except Exception:
+            pass
+        cur = db.execute(
+            "SELECT signing_pubkey FROM miner_attest_recent WHERE miner = ?", (miner,)
+        ).fetchone()
+        current_key = (cur[0].strip().lower() if cur and cur[0] else None)
+        adm = db.execute(
+            "SELECT pin_frozen, generation FROM attest_key_admin WHERE miner = ?", (miner,)
+        ).fetchone()
+        pin_frozen = bool(adm[0]) if adm else False
+        generation = int(adm[1]) if adm else 0
+
+        if action == "status":
+            return jsonify({"ok": True, "miner": miner, "pinned_pubkey": current_key,
+                            "pin_frozen": pin_frozen, "generation": generation})
+
+        if action == "unpin":
+            db.execute("UPDATE miner_attest_recent SET signing_pubkey = NULL WHERE miner = ?", (miner,))
+            new_frozen, new_key_val = 1, None
+        elif action == "set":
+            # Direct authoritative write bypasses the COALESCE pin-once guard.
+            db.execute(
+                "INSERT INTO miner_attest_recent (miner, ts_ok, signing_pubkey) VALUES (?, ?, ?) "
+                "ON CONFLICT(miner) DO UPDATE SET signing_pubkey = excluded.signing_pubkey",
+                (miner, now, new_key),
+            )
+            new_frozen, new_key_val = 0, new_key
+        else:  # unfreeze
+            new_frozen, new_key_val = 0, current_key
+
+        db.execute(
+            "INSERT INTO attest_key_admin (miner, pin_frozen, generation, updated_at, note) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(miner) DO UPDATE SET pin_frozen = excluded.pin_frozen, "
+            "generation = attest_key_admin.generation + 1, updated_at = excluded.updated_at, "
+            "note = excluded.note",
+            (miner, new_frozen, generation + 1, now, note),
+        )
+        db.commit()
+
+    print(f"[ADMIN/ATTEST-KEY] action={action} miner={miner[:32]} "
+          f"frozen={bool(new_frozen)} gen={generation + 1} note={note!r}")
+    return jsonify({"ok": True, "miner": miner, "action": action,
+                    "pinned_pubkey": new_key_val, "pin_frozen": bool(new_frozen),
+                    "generation": generation + 1})
 
 @app.route('/headers/ingest_signed', methods=['POST'])
 def ingest_signed_header():

--- a/tests/test_attest_identity_pinning.py
+++ b/tests/test_attest_identity_pinning.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Attestation identity: phased enforcement and first-signer-hijack protection.
+
+Ported from the live production node, which carried a complete three-phase
+signed-attestation rollout that never reached main. Main meanwhile pinned
+whatever public key a client presented:
+
+    signing_pubkey=pubkey_hex or None
+
+That is a capture vector. `signing_pubkey` is the authority `/epoch/enroll`
+verifies against, so whoever signed first for a symbolic identity such as
+`dual-g4-125` became its owner, and the real operator was locked out. The
+production code decides which keys are safe to pin, and this file pins that
+decision so a later change cannot quietly restore trust-on-first-use for
+identities that cannot prove ownership.
+
+The phases exist so the vintage fleet is not cut off mid-upgrade, which is the
+same rollout mistake that made the unsigned-attestation PR unmergeable:
+
+    log_only     (default) verify if present, enforce nothing
+    enforce_new            new identities must sign, grandfathered stay unsigned
+    enforce_all            everyone signs
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+NODE = os.path.join(ROOT, "node")
+sys.path.insert(0, NODE)
+os.environ.setdefault("RC_ADMIN_KEY", "t" * 64)
+
+_spec = importlib.util.spec_from_file_location(
+    "rc_node_id", os.path.join(NODE, "rustchain_v2_integrated_v2.2.1_rip200.py")
+)
+MOD = importlib.util.module_from_spec(_spec)
+sys.modules["rc_node_id"] = MOD
+_spec.loader.exec_module(MOD)
+
+
+class EnforceModeTest(unittest.TestCase):
+
+    def setUp(self):
+        os.environ.pop("RTC_ATTEST_ENFORCE_MODE", None)
+
+    tearDown = setUp
+
+    def test_default_is_log_only_so_a_deploy_changes_nothing(self):
+        """The whole point of the phasing: shipping this must be a no-op."""
+        self.assertEqual(MOD._attest_enforce_mode(), "log_only")
+
+    def test_each_phase_is_selectable_by_env(self):
+        for mode in ("log_only", "enforce_new", "enforce_all"):
+            os.environ["RTC_ATTEST_ENFORCE_MODE"] = mode
+            self.assertEqual(MOD._attest_enforce_mode(), mode)
+
+    def test_an_unknown_mode_falls_back_to_log_only(self):
+        """A typo in an env var must not silently start rejecting the fleet."""
+        for junk in ("enforce", "ENFORCE_ALL_PLEASE", "1", ""):
+            os.environ["RTC_ATTEST_ENFORCE_MODE"] = junk
+            self.assertEqual(MOD._attest_enforce_mode(), "log_only")
+
+
+class SelfCertifyingAddressTest(unittest.TestCase):
+    """Only an address derived from a key may be pinned on first sight."""
+
+    def test_canonical_rtc_hex_address_is_self_certifying(self):
+        self.assertTrue(MOD._is_rtc_hex_address("RTC" + "a1b2c3d4" * 5))
+
+    def test_symbolic_legacy_names_are_not(self):
+        """These are the identities a first signer could otherwise capture."""
+        for name in ("dual-g4-125", "power8-s824-sophia", "victus-x86-scott",
+                     "cobalt-qube3-scott", "g5-selena-179"):
+            self.assertFalse(MOD._is_rtc_hex_address(name), name)
+
+    def test_uppercase_hex_is_rejected(self):
+        """Node-derived addresses are lowercase; accepting both would let one
+        machine hold two spellings of the same identity."""
+        self.assertFalse(MOD._is_rtc_hex_address("RTC" + "A1B2C3D4" * 5))
+
+    def test_wrong_length_and_junk_rejected(self):
+        for bad in ("RTC", "RTC" + "a" * 39, "RTC" + "a" * 41,
+                    "rtc" + "a" * 40, "", None, 12345, b"RTC" + b"a" * 40):
+            self.assertFalse(MOD._is_rtc_hex_address(bad), repr(bad))
+
+
+class UnsignedAllowlistTest(unittest.TestCase):
+
+    def setUp(self):
+        os.environ.pop("RTC_UNSIGNED_ATTEST_ALLOWLIST", None)
+
+    tearDown = setUp
+
+    def test_empty_by_default(self):
+        self.assertEqual(MOD._attest_unsigned_allowlist(), set())
+
+    def test_parses_and_strips_a_comma_list(self):
+        os.environ["RTC_UNSIGNED_ATTEST_ALLOWLIST"] = " dual-g4-125 , g5-selena-179 ,"
+        self.assertEqual(MOD._attest_unsigned_allowlist(),
+                         {"dual-g4-125", "g5-selena-179"})
+
+    def test_matching_is_case_sensitive(self):
+        """Miner ids are case-sensitive on the node; folding case here would
+        conflate two distinct identities into one allowlist entry."""
+        os.environ["RTC_UNSIGNED_ATTEST_ALLOWLIST"] = "dual-g4-125"
+        allow = MOD._attest_unsigned_allowlist()
+        self.assertIn("dual-g4-125", allow)
+        self.assertNotIn("DUAL-G4-125", allow)
+
+
+class PinDecisionIsWiredTest(unittest.TestCase):
+    """The decision must reach the database, not sit in a local variable."""
+
+    SRC = os.path.join(NODE, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+    def test_the_pinned_key_is_the_decided_key_not_the_supplied_one(self):
+        src = open(self.SRC).read()
+        self.assertIn("signing_pubkey=pin_pubkey", src)
+        self.assertNotIn(
+            "signing_pubkey=pubkey_hex or None", src,
+            "main pinned whatever the client sent, which is the capture vector",
+        )
+
+    def test_the_hijack_protection_branches_are_present(self):
+        """Each branch is a distinct way to refuse a pin; losing any one of
+        them reopens capture for that class of identity."""
+        src = open(self.SRC).read()
+        for marker in ("is_pin_frozen", "derives_to_addr",
+                       "is_grandfathered", "pin_pubkey = None"):
+            self.assertIn(marker, src, marker)
+
+    def test_admin_rotation_path_exists(self):
+        """Without it, an honest owner who loses a key is locked out for good,
+        which is what makes strict pinning safe to turn on at all."""
+        src = open(self.SRC).read()
+        self.assertIn("/admin/attest/key", src)
+        self.assertIn("def admin_attest_key", src)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Ports seven functions that have been running on the production node since 2026-07-29 and never reached `main`.

## Why this exists

Production is 14 days behind `main`, so none of the recent security work is deployed. Deploying `main` was the obvious fix, and it would have **deleted working code**: the live node carries a complete three-phase signed-attestation rollout that exists nowhere in git except a snapshot commit that rescued it from uncommitted drift on the box.

`main` is ahead on everything else and behind on this. This closes that gap so a deploy is safe.

## What arrives

```
RTC_ATTEST_ENFORCE_MODE
  log_only     (DEFAULT)  verify signatures if present, enforce nothing
  enforce_new             new identities must sign; grandfathered stay unsigned
  enforce_all             every miner must sign
```

Plus a frozen grandfather table, a case-sensitive unsigned allowlist, a pin-freeze ledger, and the `/admin/attest/key` rotation endpoint.

**Default is `log_only`, so merging and deploying this changes nothing for any current miner.** Turning it on later is an environment variable, not a redeploy.

## The part that is a real fix, not just a merge

`main` persists whatever key a client presents:

```python
signing_pubkey=pubkey_hex or None
```

`signing_pubkey` is the authority `/epoch/enroll` verifies against. So whoever signed first for a symbolic identity such as `dual-g4-125` became its owner, and the real operator was locked out. That is a capture vector, and it is open on `main` today.

The ported logic pins a key only where trust-on-first-use cannot capture someone else's identity:

| identity | behaviour |
|---|---|
| already pinned | keep existing; never silently rotated |
| pin frozen by admin | held; only an admin `set` may re-pin |
| self-certifying `RTC` + 40 hex | pinned **only if** the key derives to the address |
| brand new identity | safe to pin; no existing owner to hijack |
| grandfathered symbolic name | **never** publicly pinned; admin enrollment required |

An admin unpin freezes re-pinning, so a stranger cannot immediately recapture an identity the moment it is released. The `/admin/attest/key` path is what makes strict pinning safe to enable at all: without it, an honest owner who loses a key is locked out permanently.

Also ported: fail-closed identity-state reads while enforcing, so a broken database cannot be read as "no key on file", and rejection of a lone `signature` or lone `public_key`, which previously fell through to the unsigned path and silently stripped authentication.

## What was deliberately kept from `main`

`main` is ahead of production inside the verification block, including `_canonical_attestation_signer_owns_miner`. That is untouched. Only the enforcement wrapper before it and the pin decision after it come from production, so this is a splice rather than a replacement.

## Verification

- 13 new tests: phase defaults, fallback to `log_only` on an unknown mode, which identities are self-certifying, case-sensitive allowlist matching, and that the decided key is what reaches the database
- `tests/`: **3742 passed, 0 failed**
- `node/tests/`: diffed against a clean `main` checkout, **no new failures**
- `ruff` clean, `check_fetchall.sh` clean
- Behaviour probed directly: default mode is `log_only`, an unknown mode falls back, `dual-g4-125` is correctly not self-certifying, uppercase hex is rejected, allowlist matching is case-sensitive

## Suggested order

1. This PR
2. #8204 (the RIP-309b/c/d work)
3. Deploy to production at an epoch boundary, diffing once more first
4. Only then consider `RTC_ATTEST_ENFORCE_MODE=enforce_new`
