### PR TITLE
fix(vintage): stop penalising a G5 for having no L3 and a Qube for what it cannot measure

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2321,6 +2321,14 @@ MICRO_LIMITED_ARCHES = {
     "i386", "386", "80386",
     "i486", "486", "80486",
     "8086", "8088", "286", "80286", "i286",
+    # "retro" is the server-derived class for pre-Pentium-II x86 that is not
+    # resolved to a specific tier — a Cobalt Qube 3 (K6-2) lands here. Those
+    # machines run cut-down clients that emit only the checks their silicon and
+    # OS can actually perform: the live Qube sends clock_drift and
+    # anti_emulation and nothing else. Scored strictly that was 2 of 6, so the
+    # ratio was 0.333 and a 1.4x machine earned 0.467 — below a modern miner,
+    # for the crime of being unable to run four checks it has no hardware for.
+    "retro",
 }
 
 CONSOLE_BRIDGE_ARCHES = {
@@ -2748,7 +2756,24 @@ def _has_powerpc_cache_profile(fingerprint: dict) -> bool:
     l2_l1_ratio = float(cache_data.get("l2_l1_ratio", 0.0) or 0.0)
     l3_l2_ratio = float(cache_data.get("l3_l2_ratio", 0.0) or 0.0)
     hierarchy_ratio = float(cache_data.get("hierarchy_ratio", 0.0) or 0.0)
-    return (l2_l1_ratio >= 1.05 and l3_l2_ratio >= 1.05) or hierarchy_ratio >= 1.2
+    if hierarchy_ratio >= 1.2:
+        return True
+    if l2_l1_ratio >= 1.05:
+        # A PowerPC 970/970FX (Power Mac G5) has L1 and L2 and NO L3 AT ALL, so
+        # l3_l2_ratio is absent or zero on genuine silicon. Requiring it
+        # rejected every real G5 with "lacks PowerPC cache profile" — the
+        # machine was failing for not having a cache level it was never built
+        # with. An absent L3 is a fact about the hardware, not a missing
+        # measurement, so it is not treated as a failure.
+        #
+        # Safe because this function only ever runs AFTER
+        # _has_powerpc_simd_evidence has already passed: AltiVec/VSX is the
+        # strong proof of PowerPC and the cache profile is corroboration. A
+        # forger must already have produced convincing PowerPC SIMD evidence
+        # to reach here, and a two-level hierarchy alone was never the barrier.
+        if l3_l2_ratio >= 1.05 or l3_l2_ratio <= 0.0:
+            return True
+    return False
 
 
 def _detect_arm_evidence(device: dict, fingerprint: dict) -> bool:

--- a/tests/test_vintage_g5_and_qube.py
+++ b/tests/test_vintage_g5_and_qube.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Two real vintage machines were being penalised for what they are.
+
+Both found by reading production enrollment weights after a deploy, not by
+reading code.
+
+**Power Mac G5.** Rejected on every attestation with "claims g5 but lacks
+PowerPC cache profile". The check required `l2_l1_ratio >= 1.05 AND
+l3_l2_ratio >= 1.05`, but a PowerPC 970/970FX has L1 and L2 and **no L3at
+all**. The machine was failing for not having a cache level Apple never put in
+it. An absent L3 is a fact about the silicon, not a missing measurement.
+
+**Cobalt Qube 3 (K6-2).** Enrolled at 0.4667. Classified `x86/retro` (1.4x) but
+its cut-down client emits only `clock_drift` and `anti_emulation`, so it scored
+2 of 6 and 1.4 x 0.333 = 0.4667 — below a modern miner, for being unable to run
+four checks its hardware cannot perform.
+
+Same shape as everything else in this area: a control that fires on honest
+hardware because it assumes a capability the hardware does not have.
+"""
+
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+NODE = os.path.join(ROOT, "node")
+sys.path.insert(0, NODE)
+os.environ.setdefault("RC_ADMIN_KEY", "t" * 64)
+
+_spec = importlib.util.spec_from_file_location(
+    "rc_node_vin", os.path.join(NODE, "rustchain_v2_integrated_v2.2.1_rip200.py")
+)
+MOD = importlib.util.module_from_spec(_spec)
+sys.modules["rc_node_vin"] = MOD
+_spec.loader.exec_module(MOD)
+
+
+def _cache(**data):
+    return {"checks": {"cache_timing": {"passed": True, "data": data}}}
+
+
+class PowerPCCacheProfileTest(unittest.TestCase):
+    """A two-level hierarchy is valid PowerPC."""
+
+    def test_g5_with_no_l3_is_accepted(self):
+        """The 970FX has L1+L2 only. This is the live rejection."""
+        self.assertTrue(MOD._has_powerpc_cache_profile(
+            _cache(l2_l1_ratio=3.2, l3_l2_ratio=0.0)))
+
+    def test_g5_with_l3_key_absent_entirely_is_accepted(self):
+        self.assertTrue(MOD._has_powerpc_cache_profile(_cache(l2_l1_ratio=3.2)))
+
+    def test_three_level_powerpc_still_accepted(self):
+        self.assertTrue(MOD._has_powerpc_cache_profile(
+            _cache(l2_l1_ratio=2.0, l3_l2_ratio=1.5)))
+
+    def test_flat_power8_hierarchy_still_accepted(self):
+        """POWER8's unified caches read flat; that path must not regress."""
+        self.assertTrue(MOD._has_powerpc_cache_profile(_cache(hierarchy_ratio=1.4)))
+
+    def test_explicit_arch_tag_still_wins(self):
+        self.assertTrue(MOD._has_powerpc_cache_profile(
+            {"checks": {"cache_timing": {"passed": True, "data": {"arch": "ppc64le"}}}}))
+
+    def test_no_cache_evidence_at_all_is_still_rejected(self):
+        """Relaxing L3 must not become 'accept anything'."""
+        self.assertFalse(MOD._has_powerpc_cache_profile(_cache()))
+
+    def test_an_inverted_hierarchy_is_still_rejected(self):
+        """L2 faster than L1 is not a cache hierarchy, it is a fabrication."""
+        self.assertFalse(MOD._has_powerpc_cache_profile(
+            _cache(l2_l1_ratio=0.4, l3_l2_ratio=0.0)))
+
+    def test_a_negative_l3_ratio_does_not_slip_through(self):
+        self.assertFalse(MOD._has_powerpc_cache_profile(
+            _cache(l2_l1_ratio=0.9, l3_l2_ratio=-5.0)))
+
+
+class RetroCapabilityClassTest(unittest.TestCase):
+    """The Qube's missing checks are structural, not failures."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.conn = sqlite3.connect(self.tmp.name)
+        self.conn.row_factory = sqlite3.Row
+        # exactly what the live Cobalt Qube 3 sends
+        self.qube_fp = {"checks": {
+            "clock_drift": {"passed": True, "data": {"cv": 0.002056, "samples": 500}},
+            "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
+        }}
+
+    def tearDown(self):
+        self.conn.close()
+        os.unlink(self.tmp.name)
+
+    def test_retro_is_a_capability_limited_class(self):
+        self.assertIn("retro", MOD.MICRO_LIMITED_ARCHES)
+
+    def test_the_qube_recovers_its_full_retro_tier(self):
+        r = MOD.evaluate_rotating_fingerprint_checks(
+            self.conn, 0, self.qube_fp, device_arch="retro", micro_accepted=True)
+        self.assertEqual(r["measured_total"], 2)
+        self.assertEqual(sorted(r["passed_active_checks"]),
+                         ["anti_emulation", "clock_drift"])
+        self.assertEqual(r["active_ratio"], 1.0)
+        self.assertAlmostEqual(1.4 * r["active_ratio"], 1.4,
+                               msg="the Qube earned 0.4667 before this fix")
+
+    def test_a_modern_miner_gets_no_such_excuse(self):
+        """The identical sparse payload from capable hardware still scores low."""
+        r = MOD.evaluate_rotating_fingerprint_checks(
+            self.conn, 0, self.qube_fp, device_arch="modern", micro_accepted=False)
+        self.assertEqual(r["unmeasured_active_checks"], [])
+        self.assertLess(r["active_ratio"], 0.5)
+
+    def test_a_retro_claim_still_cannot_launder_a_real_failure(self):
+        fp = {"checks": {
+            "clock_drift": {"passed": True, "data": {"cv": 0.002, "samples": 500}},
+            "anti_emulation": {"passed": False, "data": {"vm_indicators": ["qemu"]}},
+        }}
+        r = MOD.evaluate_rotating_fingerprint_checks(
+            self.conn, 0, fp, device_arch="retro", micro_accepted=True)
+        self.assertIn("anti_emulation", r["failed_active_checks"])
+        self.assertEqual(r["active_ratio"], 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Two genuine vintage machines were being penalised for what they are. Both found by reading production enrollment weights after the deploy.

## Power Mac G5 — rejected on every attestation

The live node is logging this right now:

```
[FINGERPRINT] REJECT: claims g5 but lacks PowerPC cache profile
```

`_has_powerpc_cache_profile()` required:

```python
(l2_l1_ratio >= 1.05 and l3_l2_ratio >= 1.05) or hierarchy_ratio >= 1.2
```

**A PowerPC 970/970FX has L1 and L2 and no L3 at all.** The G5 was failing for not having a cache level Apple never put in it. An absent L3 is a fact about the silicon, not a missing measurement.

A two-level hierarchy is now accepted. That is safe because this function only runs **after** `_has_powerpc_simd_evidence` has already passed — AltiVec/VSX is the strong proof of PowerPC and the cache profile is corroboration, so a forger must already have produced convincing PowerPC SIMD evidence to reach here. A missing third cache level was never the barrier.

Still rejected: an inverted hierarchy (L2 faster than L1), a negative L3 ratio, and a payload with no cache evidence at all.

## Cobalt Qube 3 — earning less than a modern miner

Enrolled at **0.4667**. It is classified `x86/retro`, which is 1.4x, but its cut-down client emits only `clock_drift` and `anti_emulation`:

```
1.4 x (2/6) = 0.4667
```

Four checks its K6-2 hardware cannot perform were scored as failures, so a genuinely vintage machine earned less than a modern x86 at 0.8. `retro` now joins the capability-limited classes, so those four are `unmeasured` rather than failed:

| | before | after |
|---|---|---|
| measured | 2 of 6 scored | 2 measured, 4 unmeasured |
| ratio | 0.333 | 1.0 |
| weight | **0.4667** | **1.4** |

## The excuse cannot be claimed by anyone else

- a **modern** miner sending the identical sparse payload still scores **0.333** — the class comes from the server-derived arch, never from what the client chooses to send
- a retro claim **cannot launder a real failure**: a reported `anti_emulation` failure still counts against it

## Verification

- 12 new tests, including the inverted-hierarchy guard, the no-evidence guard, and the modern-miner control
- `tests/`: **3820 passed, 0 failed**
- `node/tests/`: diffed against clean `main`, **no new failures**

## Note

Same shape as the rest of this area: a control that fires on honest hardware because it assumes a capability the hardware does not have. That is now four in a row, so it is worth treating as the default failure mode when adding any new check here.
