### PR TITLE
fix(fingerprint): say what the PowerPC cache check actually saw

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4748,7 +4748,15 @@ def validate_fingerprint_data(
             return False, f"missing_powerpc_simd:{claimed_arch}"
 
         if not _has_powerpc_cache_profile(fingerprint):
-            print(f"[FINGERPRINT] REJECT: claims {claimed_arch} but lacks PowerPC cache profile")
+            # Log what was actually seen. "lacks PowerPC cache profile" alone
+            # gives an operator nothing to act on, and this check has already
+            # rejected a genuine Power Mac G5 once for a cache level the 970FX
+            # was never built with.
+            _cd = _fingerprint_check_data(fingerprint, "cache_timing")
+            print(f"[FINGERPRINT] REJECT: claims {claimed_arch} but lacks PowerPC cache profile "
+                  f"(l2_l1={_cd.get('l2_l1_ratio')!r} l3_l2={_cd.get('l3_l2_ratio')!r} "
+                  f"hierarchy={_cd.get('hierarchy_ratio')!r} arch={_cd.get('arch')!r} "
+                  f"keys={sorted(_cd)[:8]})")
             return False, f"missing_powerpc_cache_profile:{claimed_arch}"
 
     # ── PHASE 3: ROM fingerprint (retro platforms) ──


### PR DESCRIPTION
`lacks PowerPC cache profile` gave an operator nothing to act on.

This check had already rejected a genuine Power Mac G5 on **every attestation** for a cache level the 970FX was never built with, and diagnosing it meant reading the source to work out which ratio was missing, because the log line carried none of the values it rejected on.

It now logs `l2_l1`, `l3_l2`, `hierarchy`, the arch tag, and which keys were actually present.

Deployed to production ahead of this merge while investigating the G5, so landing it also removes that drift rather than leaving the node running code that is not on `main`.