### PR TITLE
fix(monitor): a 200 is not evidence of a node

### DIFF
--- a/tests/test_health_monitor.py
+++ b/tests/test_health_monitor.py
@@ -133,23 +133,43 @@ class TestCheckNode(unittest.TestCase):
         self.assertEqual(result.miners,  3)
 
     @patch("urllib.request.urlopen")
-    def test_missing_fields_are_none(self, mock_open):
-        """A node returning empty JSON → epoch/miners are None."""
+    def test_json_without_node_state_is_not_online(self, mock_open):
+        """Empty JSON is a reply, not a node.
+
+        This previously asserted "online". The reasoning was that a reply
+        proves reachability, which is true and is still reported: the response
+        time is kept and `error` says exactly what came back. What changed is
+        that it no longer counts toward nodes_online.
+
+        The cost of the old behaviour was concrete. Node 4 stopped being a node
+        and the host was reused for a single-page app, which answers 200 on
+        every path. It was reported online for months and the fleet was
+        believed to be four nodes when it was two.
+        """
         mock_open.return_value = _make_response({})
         result = self.monitor.check_node(self.url)
         self.assertIsNone(result.epoch)
         self.assertIsNone(result.miners)
-        self.assertEqual(result.status, "online")
+        self.assertEqual(result.status, "offline")
+        self.assertIsNotNone(result.error)
+        self.assertIsNotNone(result.response_time_ms,
+                             "reachability information must not be lost")
 
     @patch("urllib.request.urlopen")
-    def test_non_object_json_is_reachable_with_missing_fields(self, mock_open):
-        """A node returning JSON with the wrong shape is reachable, not offline."""
+    def test_non_object_json_is_reachable_but_not_online(self, mock_open):
+        """Wrong-shaped JSON still reports reachability, but is not a node.
+
+        Also previously "online". A JSON array is something else answering on
+        this address; the probe should say so rather than count it as a healthy
+        node.
+        """
         mock_open.return_value = _make_raw_response("[]")
         result = self.monitor.check_node(self.url)
-        self.assertEqual(result.status, "online")
+        self.assertEqual(result.status, "offline")
         self.assertIsNone(result.epoch)
         self.assertIsNone(result.miners)
-        self.assertIsNone(result.error)
+        self.assertIsNotNone(result.error, "the operator needs to know WHY")
+        self.assertIsNotNone(result.response_time_ms)
 
 
 class TestCheckAll(unittest.TestCase):

--- a/tests/test_node_liveness_requires_node_state.py
+++ b/tests/test_node_liveness_requires_node_state.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""A 200 is not evidence of a node.
+
+RustChain node 4 stopped being a node. The operator took it down and the host
+was reused for a single-page app, which answers **200 on every unknown path**.
+So `/status` returned 200 with HTML, `json.loads` raised, the body was quietly
+replaced with `{}`, and the node was reported `online` — because status was
+decided purely on response time:
+
+    status = "slow" if elapsed_ms > SLOW_THRESHOLD_MS else "online"
+
+The loss went unnoticed for months, and the fleet was believed to be four nodes
+when it was two. Node 3 was only spotted because it had the decency to stop
+answering at all.
+
+A node is online only if it answered with JSON carrying node state. These tests
+pin the three ways something can pretend: HTML, valid JSON from an unrelated
+service, and an empty body.
+"""
+
+import importlib.util
+import io
+import os
+import sys
+import unittest
+from unittest import mock
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TOOLS = os.path.join(ROOT, "tools")
+sys.path.insert(0, TOOLS)
+
+_spec = importlib.util.spec_from_file_location(
+    "node_health_monitor", os.path.join(TOOLS, "node_health_monitor.py")
+)
+MOD = importlib.util.module_from_spec(_spec)
+sys.modules["node_health_monitor"] = MOD
+_spec.loader.exec_module(MOD)
+
+
+class _Resp(io.BytesIO):
+    """Minimal stand-in for the urlopen context manager."""
+
+    def __init__(self, payload: bytes):
+        super().__init__(payload)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _probe(payload: bytes):
+    mon = MOD.NodeHealthMonitor(nodes=["http://example.invalid"])
+    with mock.patch.object(MOD.urllib.request, "urlopen",
+                           return_value=_Resp(payload)):
+        return mon.check_node("http://example.invalid")
+
+
+REAL_STATUS = b'{"epoch": 254, "miners": 19, "ok": true}'
+
+# what an SPA actually returns on every path
+SPA_HTML = (b'<!doctype html><html lang="en"><head><title>New API</title>'
+            b'</head><body><div id="root"></div></body></html>')
+
+
+class ImpersonationTest(unittest.TestCase):
+
+    def test_a_real_node_is_online(self):
+        st = _probe(REAL_STATUS)
+        self.assertEqual(st.status, "online")
+        self.assertEqual(st.epoch, 254)
+        self.assertEqual(st.miners, 19)
+        self.assertIsNone(st.error)
+
+    def test_an_spa_serving_html_is_offline(self):
+        """The exact failure: 200 + HTML was reported online for months."""
+        st = _probe(SPA_HTML)
+        self.assertEqual(st.status, "offline",
+                         "a website answering 200 must not count as a node")
+        self.assertIsNone(st.epoch)
+        self.assertIn("non-JSON", st.error)
+
+    def test_valid_json_from_an_unrelated_service_is_offline(self):
+        """Some other API on the address speaks JSON but is not a node."""
+        st = _probe(b'{"error":{"message":"Invalid URL (GET /status)"}}')
+        self.assertEqual(st.status, "offline")
+        self.assertIn("no epoch", st.error)
+
+    def test_an_empty_body_is_offline(self):
+        st = _probe(b"")
+        self.assertEqual(st.status, "offline")
+
+    def test_a_json_array_is_offline(self):
+        """json.loads succeeds but it is not an object."""
+        st = _probe(b"[1, 2, 3]")
+        self.assertEqual(st.status, "offline")
+
+
+class ToleranceTest(unittest.TestCase):
+    """Hardening must not make a healthy node look broken."""
+
+    def test_alternate_field_names_still_resolve(self):
+        st = _probe(b'{"current_epoch": 7, "active_miners": 3}')
+        self.assertEqual(st.status, "online")
+        self.assertEqual(st.epoch, 7)
+        self.assertEqual(st.miners, 3)
+
+    def test_a_node_reporting_zero_miners_is_still_online(self):
+        """Node 2 legitimately had 0 enrolled miners; that is not death."""
+        st = _probe(b'{"epoch": 254, "miners": 0}')
+        self.assertEqual(st.status, "online")
+
+    def test_a_malformed_miner_count_does_not_kill_the_probe(self):
+        st = _probe(b'{"epoch": 254, "miners": "lots"}')
+        self.assertEqual(st.status, "online")
+        self.assertIsNone(st.miners)
+
+    def test_a_malformed_epoch_is_treated_as_missing_state(self):
+        st = _probe(b'{"epoch": "soon", "miners": 4}')
+        self.assertEqual(st.status, "offline")
+
+    def test_response_time_is_still_reported_when_impersonating(self):
+        """Operators need the timing even when the body is rejected."""
+        st = _probe(SPA_HTML)
+        self.assertIsNotNone(st.response_time_ms)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/node_health_monitor.py
+++ b/tools/node_health_monitor.py
@@ -96,18 +96,57 @@ class NodeHealthMonitor:
                 try:
                     data = json.loads(raw)
                 except json.JSONDecodeError:
-                    data = {}
+                    data = None
                 if not isinstance(data, dict):
-                    data = {}
+                    data = None
+
+                # A 200 is not evidence of a node.
+                #
+                # RustChain node 4 stopped being a node and the host was reused
+                # for a single-page app. An SPA answers 200 on EVERY unknown
+                # path, so /status returned 200 with HTML, json.loads failed,
+                # the body was quietly replaced with {}, and the node was
+                # reported "online" indefinitely because status was decided
+                # purely on response time. The loss went unnoticed for months.
+                #
+                # A node is online only if it answered with JSON that actually
+                # carries node state. Anything else is impersonating one.
+                if data is None:
+                    return NodeStatus(
+                        url=url,
+                        status="offline",
+                        response_time_ms=round(elapsed_ms, 1),
+                        epoch=None,
+                        miners=None,
+                        error=(f"/status returned {len(raw)} bytes of non-JSON "
+                               f"(is this still a node?): {raw[:60]!r}"),
+                    )
 
                 epoch  = data.get("epoch") or data.get("current_epoch")
                 miners = data.get("miners") or data.get("active_miners") or data.get("miner_count")
 
-                # Coerce to int if present
-                if epoch is not None:
-                    epoch = int(epoch)
-                if miners is not None:
-                    miners = int(miners)
+                # Coerce to int if present, tolerating a malformed value rather
+                # than raising inside the probe.
+                try:
+                    epoch = int(epoch) if epoch is not None else None
+                except (TypeError, ValueError):
+                    epoch = None
+                try:
+                    miners = int(miners) if miners is not None else None
+                except (TypeError, ValueError):
+                    miners = None
+
+                # JSON with no epoch is not node state either — it is some
+                # other service that happens to speak JSON on this address.
+                if epoch is None:
+                    return NodeStatus(
+                        url=url,
+                        status="offline",
+                        response_time_ms=round(elapsed_ms, 1),
+                        epoch=None,
+                        miners=miners,
+                        error="/status carried no epoch (not a RustChain node?)",
+                    )
 
                 status = "slow" if elapsed_ms > SLOW_THRESHOLD_MS else "online"
                 return NodeStatus(


### PR DESCRIPTION
RustChain node 4 stopped being a node. The operator took it down and the host was reused for a single-page app, which answers **200 on every unknown path**.

```python
try:
    data = json.loads(raw)
except json.JSONDecodeError:
    data = {}          # HTML silently becomes an empty dict
...
status = "slow" if elapsed_ms > SLOW_THRESHOLD_MS else "online"
```

Status was decided **purely on response time**. So `/status` returned 200 with HTML, parsing failed, and the node was reported `online` — for months. The fleet was documented and believed to be four attestation nodes when it was two. Node 3 was only noticed because it stopped answering entirely; node 4 answered cheerfully the whole time.

## The fix

A node is online only if it replied with JSON carrying node state. Non-JSON, a JSON array, and JSON with no epoch are all `offline`, each with an `error` string saying which, and **response time is still recorded** so no reachability information is lost.

## A deliberate decision I changed

Two existing tests asserted the old behaviour on purpose — *"a node returning JSON with the wrong shape is reachable, not offline"*. That reasoning is sound, and the information it wanted is preserved in `response_time_ms` and `error`.

What changed is that such a reply no longer counts toward `nodes_online`, because that count being wrong is exactly what hid a real loss. Both tests are updated rather than deleted, with the tradeoff written into them.

## Tests

10 new: the three ways something can impersonate a node (HTML, unrelated JSON, empty body), plus tolerance cases — alternate field names still resolve, a malformed miner count does not kill the probe, and **a node legitimately reporting zero miners stays online**, which node 2 currently does.

`tests/` 3845 passed, 0 failed. `ruff` clean.