### PR TITLE
fix(monitor): probe an endpoint the node actually serves

### DIFF
--- a/tests/test_node_liveness_requires_node_state.py
+++ b/tests/test_node_liveness_requires_node_state.py
@@ -127,5 +127,61 @@ class ToleranceTest(unittest.TestCase):
         self.assertIsNotNone(st.response_time_ms)
 
 
+class EndpointDiscoveryTest(unittest.TestCase):
+    """The monitor asked for a path the node has never served.
+
+    `/status` 404s on both live nodes; they serve `/health` and `/epoch`. Every
+    probe of a real node therefore came back 404 and was filed as "slow" with
+    no epoch, so the monitor had never once read state from node 1 or node 2.
+    Together with a dead node reporting "online", the picture was exactly
+    inverted: the two working nodes looked degraded and the departed one looked
+    healthy.
+    """
+
+    def test_epoch_is_tried_before_status(self):
+        """/epoch carries both the epoch and the miner count."""
+        self.assertEqual(MOD.STATUS_ENDPOINTS[0], "/epoch")
+        self.assertIn("/status", MOD.STATUS_ENDPOINTS)
+
+    def test_enrolled_miners_is_recognised(self):
+        """/epoch names the field `enrolled_miners`, which was not read."""
+        st = _probe(b'{"epoch": 254, "enrolled_miners": 16}')
+        self.assertEqual(st.status, "online")
+        self.assertEqual(st.miners, 16)
+
+    def test_a_404_falls_through_to_the_next_endpoint(self):
+        """A missing path is a deployment difference, not ill health."""
+        mon = MOD.NodeHealthMonitor(nodes=["http://example.invalid"])
+        calls = []
+
+        def fake_urlopen(req, timeout=None):
+            calls.append(req.full_url)
+            if req.full_url.endswith("/epoch"):
+                raise MOD.urllib.error.HTTPError(
+                    req.full_url, 404, "NOT FOUND", {}, None)
+            return _Resp(b'{"epoch": 99, "miners": 2}')
+
+        with mock.patch.object(MOD.urllib.request, "urlopen", fake_urlopen):
+            st = mon.check_node("http://example.invalid")
+
+        self.assertEqual(st.status, "online", st.error)
+        self.assertEqual(st.epoch, 99)
+        self.assertTrue(any(u.endswith("/epoch") for u in calls))
+        self.assertGreater(len(calls), 1, "it should have tried another path")
+
+    def test_a_real_error_code_is_still_degraded(self):
+        """Only 404 falls through; a 500 still means something is wrong."""
+        mon = MOD.NodeHealthMonitor(nodes=["http://example.invalid"])
+
+        def fake_urlopen(req, timeout=None):
+            raise MOD.urllib.error.HTTPError(
+                req.full_url, 500, "SERVER ERROR", {}, None)
+
+        with mock.patch.object(MOD.urllib.request, "urlopen", fake_urlopen):
+            st = mon.check_node("http://example.invalid")
+        self.assertEqual(st.status, "slow")
+        self.assertIn("500", st.error)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tools/node_health_monitor.py
+++ b/tools/node_health_monitor.py
@@ -30,6 +30,14 @@ DIM    = "\033[2m"
 
 # ── Thresholds ────────────────────────────────────────────────────────────────
 SLOW_THRESHOLD_MS = 1000   # response times above this are "yellow"
+
+# The node exposes /health and /epoch. It has never exposed /status, which is
+# what this monitor asked for, so every probe of a real node returned 404 and
+# was filed as "slow" with no epoch: the monitor had never once read state from
+# node 1 or node 2. Combined with a dead node reporting online, the result was
+# exactly inverted. /epoch is tried first because it carries both the epoch and
+# the enrolled miner count; /status is kept for any deployment that has it.
+STATUS_ENDPOINTS = ("/epoch", "/status", "/health")
 REQUEST_TIMEOUT   = 5      # seconds per HTTP request
 
 # ── Known attestation nodes ───────────────────────────────────────────────────
@@ -86,8 +94,9 @@ class NodeHealthMonitor:
         """
         start = time.monotonic()
         try:
+            path = getattr(self, "_status_path", None) or STATUS_ENDPOINTS[0]
             req = urllib.request.Request(
-                f"{url}/status",
+                f"{url}{path}",
                 headers={"Accept": "application/json", "User-Agent": "RustChain-HealthMonitor/1.0"},
             )
             with urllib.request.urlopen(req, timeout=self.timeout) as resp:
@@ -123,7 +132,8 @@ class NodeHealthMonitor:
                     )
 
                 epoch  = data.get("epoch") or data.get("current_epoch")
-                miners = data.get("miners") or data.get("active_miners") or data.get("miner_count")
+                miners = (data.get("miners") or data.get("active_miners")
+                          or data.get("miner_count") or data.get("enrolled_miners"))
 
                 # Coerce to int if present, tolerating a malformed value rather
                 # than raising inside the probe.
@@ -160,6 +170,21 @@ class NodeHealthMonitor:
 
         except urllib.error.HTTPError as exc:
             elapsed_ms = (time.monotonic() - start) * 1000
+            # A 404 means this deployment does not expose the path we asked
+            # for, not that the node is unwell. Try the next known endpoint
+            # before concluding anything: asking /status of a node that only
+            # serves /epoch is how every real node came back "slow" forever.
+            if exc.code == 404:
+                tried = getattr(self, "_status_path", None) or STATUS_ENDPOINTS[0]
+                remaining = [p for p in STATUS_ENDPOINTS if p != tried]
+                for nxt in remaining:
+                    self._status_path = nxt
+                    try:
+                        result = self.check_node(url)
+                    finally:
+                        self._status_path = None
+                    if result.status != "offline" or "404" not in (result.error or ""):
+                        return result
             # Node replied but with an error code — treat as degraded
             return NodeStatus(
                 url=url,


### PR DESCRIPTION
Found by running the newly hardened probe against the real fleet — the first time it reported anything specific enough to notice.

**The monitor asked for `/status`. Neither live node has ever served it.** Both 404; they serve `/health` and `/epoch`. So every probe of a real node came back 404 and was filed as `slow` with no epoch. The monitor had **never once** read state from node 1 or node 2.

Together with #8220's finding, the picture was exactly inverted:

| node | before | after |
|---|---|---|
| node1 | `slow`, no state | **`online` epoch=254 miners=16** |
| node2 | `slow`, no state | **`online` epoch=254 miners=0** |
| node3 | offline | offline |
| node4 | **`online`** | **offline** |

The two working nodes looked degraded, and the one that had stopped being a node looked healthy.

## Changes

- `/epoch` is tried first — it carries both the epoch and the enrolled miner count
- `/status` kept for any deployment that has it
- a **404 falls through** to the next known endpoint, because a missing path is a deployment difference, not ill health. Other error codes still mean something is wrong and are unchanged
- reads `enrolled_miners`, which is what `/epoch` calls that field and which nothing was looking for

## Tests

4 new: endpoint order, the `enrolled_miners` alias, 404 fall-through, and that a 500 is still degraded. `tests/` 3849 passed, 0 failed.