### PR TITLE
fix(airdrop): scope _determine_tier to org merged PRs (fixes #8184)

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -661,16 +661,18 @@ class AirdropV2:
             if user_resp.status_code != 200:
                 return None
 
-            # Get contributions (PRs merged)
-            # Use GitHub search API for contributions
+            # Get contributions – merged PRs authored by this user SCOPED TO
+            # the RustChain org, not GitHub-wide. Previously this queried
+            # /search/commits with `author:<user> merged:true`, which counts
+            # the user's commits anywhere on GitHub and lets any established
+            # account reach CORE without ever contributing to RustChain.
+            # Now we use the issues search with `is:pr is:merged` + `org:`
+            # so the tier reflects actual RustChain contributions (#8184).
             contrib_resp = requests.get(
-                f"https://api.github.com/search/commits",
-                headers={
-                    **headers,
-                    "Accept": "application/vnd.github.cloak-preview",
-                },
+                "https://api.github.com/search/issues",
+                headers=headers,
                 params={
-                    "q": f"author:{github_username} merged:true",
+                    "q": f"author:{github_username} org:Scottcjn is:pr is:merged",
                     "per_page": 1,
                 },
                 timeout=10,

--- a/node/test_airdrop_v2.py
+++ b/node/test_airdrop_v2.py
@@ -141,7 +141,7 @@ class TestEligibilityChecks(unittest.TestCase):
                 return mock_user
             elif "starred" in url:
                 return mock_stars
-            elif "search/commits" in url:
+            elif "search/issues" in url:
                 return mock_contrib
             return Mock(status_code=404)
 
@@ -159,6 +159,71 @@ class TestEligibilityChecks(unittest.TestCase):
         self.assertTrue(result.eligible)
         self.assertEqual(result.tier, "builder")  # 3 PRs = Builder tier
         self.assertEqual(result.reward_uwrtc, 100 * 1_000_000)
+
+    @patch("requests.get")
+    def test_determine_tier_scoped_to_org(self, mock_get):
+        """Regression: tier must count merged PRs to THIS org, not GitHub-wide.
+
+        Guards against the #8184 defect where _determine_tier queried
+        /search/commits with `author:<user> merged:true` (GitHub-wide), so any
+        established account reached CORE without contributing to RustChain.
+        The query must now hit /search/issues scoped with
+        `org:Scottcjn is:pr is:merged`.
+        """
+        captured = {}
+
+        mock_user = Mock()
+        mock_user.status_code = 200
+        mock_user.json.return_value = {
+            "login": "testuser",
+            "created_at": "2020-01-01T00:00:00Z",
+            "starred_url": "https://api.github.com/users/testuser/starred{/owner}{/repo}",
+        }
+        mock_user.headers = {}
+
+        mock_stars = Mock()
+        mock_stars.status_code = 200
+        mock_stars.headers = {
+            "Link": '<https://api.github.com/user/starred?page=5>; rel="last"'
+        }
+        mock_stars.json.return_value = []
+
+        mock_contrib = Mock()
+        mock_contrib.status_code = 200
+        mock_contrib.json.return_value = {"total_count": 5}  # 5 merged PRs -> CORE
+
+        def side_effect(url, *args, **kwargs):
+            if "users/testuser" in url and "starred" not in url:
+                return mock_user
+            elif "starred" in url:
+                return mock_stars
+            elif "search/issues" in url:
+                captured["url"] = url
+                captured["params"] = kwargs.get("params", {})
+                return mock_contrib
+            return Mock(status_code=404)
+
+        mock_get.side_effect = side_effect
+
+        result = self.airdrop.check_eligibility(
+            github_username="testuser",
+            wallet_address="RTC1234567890123456789012345678901234567890",
+            chain="base",
+            skip_antisybil=True,
+        )
+
+        # The contribution query must be scoped to the org and to merged PRs.
+        self.assertIn("search/issues", captured["url"])
+        q = captured["params"].get("q", "")
+        self.assertIn("org:Scottcjn", q)
+        self.assertIn("is:pr", q)
+        self.assertIn("is:merged", q)
+        self.assertNotIn("merged:true", q)  # the old, unscoped qualifier
+
+        # 5 merged PRs to the org => CORE tier.
+        self.assertTrue(result.eligible)
+        self.assertEqual(result.tier, "core")
+        self.assertEqual(result.reward_uwrtc, 200 * 1_000_000)
 
     def test_invalid_chain(self):
         """Test eligibility check with invalid chain."""


### PR DESCRIPTION
## Summary

`_determine_tier()` decided an airdrop claimant's tier — up to **CORE = 200 wRTC** — from GitHub activity queried with `author:<user> merged:true` against `/search/commits`. That counts the user's commits **anywhere on GitHub**, so any established account reached CORE without ever contributing to RustChain (see #8184).

## Root cause

- Query was `/search/commits?q=author:<user> merged:true` — no `org:`/`repo:` scope, and `merged:true` is a PR-search qualifier sent to the commits endpoint.
- Result: `total_prs` reflected "is this a real GitHub user with history", not "did they contribute here".

## Fix

Switch to the issues search scoped to the org and to merged PRs:

```python
contrib_resp = requests.get(
    "https://api.github.com/search/issues",
    headers=headers,
    params={
        "q": f"author:{github_username} org:Scottcjn is:pr is:merged",
        "per_page": 1,
    },
    timeout=10,
)
```

The tier now reflects actual RustChain contributions, paired with the airdrop's existing per-account/per-wallet dedup.

## Verification

- Updated `test_eligibility_with_mock_github` to match the new `/search/issues` endpoint.
- Added `test_determine_tier_scoped_to_org` regression test asserting the query is scoped (`org:Scottcjn`, `is:pr`, `is:merged`) and no longer uses the unscoped `merged:true` qualifier, and that 5 org-merged PRs => CORE.
- Full suite `python -m unittest test_airdrop_v2` — **32 passed**.

Fixes #8184.