### PR TITLE
docs(zh-CN): complete Chinese README with CN-native market framing

### DIFF
--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -1,341 +1,512 @@
-<div align="center">
-
 # 🧱 RustChain: 古董证明区块链
 
 [![CI](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml/badge.svg)](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/Scottcjn/Rustchain/blob/main/LICENSE)
-[![GitHub Stars](https://img.shields.io/github.com/stars/Scottcjn/Rustchain?style=flat&color=gold)](https://github.com/Scottcjn/Rustchain/stargazers)
-[![Contributors](https://img.shields.io/github.com/contributors/Scottcjn/Rustchain?color=brightgreen)](https://github.com/Scottcjn/Rustchain/graphs/contributors)
-[![Last Commit](https://img.shields.io/github.com/last-commit/Scottcjn/Rustchain?color=blue)](https://github.com/Scottcjn/Rustchain/commits/main)
-[![Open Issues](https://img.shields.io/github/issues/Scottcjn/Rustchain?color=orange)](https://github.com/Scottcjn/Rustchain/issues)
-[![PowerPC](https://img.shields.io/badge/PowerPC-G3%2FG4%2FG5-orange)](https://github.com/Scottcjn/Rustchain)
-[![Blockchain](https://img.shields.io/badge/Consensus-Proof--of--Antiquity-green)](https://github.com/Scottcjn/Rustchain)
-[![Python](https://img.shields.io/badge/Python-3.x-yellow)](https://python.org)
-[![Network](https://img.shields.io/badge/Nodes-3%20Active-brightgreen)](https://rustchain.org/explorer)
-[![Bounties](https://img.shields.io/badge/Bounties-Open%20%F0%9F%92%B0-green)](https://github.com/Scottcjn/rustchain-bounties/issues)
-[![As seen on BoTTube](https://bottube.ai/badge/seen-on-bottube.svg)](https://bottube.ai)
-[![Discussions](https://img.shields.io/github.com/discussions/Scottcjn/Rustchain?color=purple)](https://github.com/Scottcjn/Rustchain/discussions)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/Scottcjn/Rustchain?style=flat&color=gold)](https://github.com/Scottcjn/Rustchain/stargazers)
+[![Nodes](https://img.shields.io/badge/Nodes-5%20Active-brightgreen)](https://rustchain.org/explorer/)
+[![DePIN](https://img.shields.io/badge/DePIN-Vintage%20Hardware-8B4513)](https://rustchain.org)
+[![Proof of Antiquity](https://img.shields.io/badge/Consensus-Proof%20of%20Antiquity-DAA520)](docs/WHITEPAPER.md)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.19442753-blue)](https://doi.org/10.5281/zenodo.19442753)
 
-**第一个奖励古董硬件年龄而非速度的区块链。**
+**DePIN 古董硬件专属区块链 — AI 增强的真实机器证明**
 
-*你的 PowerPC G4 比现代 Threadripper 赚得更多。这就是重点。*
+**这里，旧硬件比新硬件更赚钱。**
+**所有硬件终将变老，只是时间问题。**
 
-[官网](https://rustchain.org) • [实时浏览器](https://rustchain.org/explorer) • [兑换 wRTC](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) • [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) • [wRTC 快速入门](../wrtc.md) • [wRTC 教程](../WRTC_ONBOARDING_TUTORIAL.md) • [Grokipedia 参考](https://grokipedia.com/search?q=RustChain) • [白皮书](../RustChain_Whitepaper_Flameholder_v0.97.pdf) • [快速开始](#-快速开始) • [工作原理](#-古董证明如何工作)
+一台 2003 年的 PowerBook G4 比现代 Threadripper 多赚 **2.5 倍**。
+一台 Power Mac G5 多赚 **2.0 倍**。一台串口生锈的 486 最受尊敬。
+
+> ⭐ **帮我们达到 512 颗星星** — 2⁹ 的二进制里程碑（总供应量是 2²³）。如果古董证明是你的菜，[点个星](https://github.com/Scottcjn/Rustchain/stargazers) 就能帮助更多旧机器重获新生。[为什么是 512？](https://github.com/Scottcjn/Rustchain/issues/7540)
+
+[资源浏览器](https://rustchain.org/explorer/) · [被保存的机器](https://rustchain.org/preserved.html) · [安装矿工](#快速开始) · [新手指南](QUICKSTART.md) · [常见问题](https://rustchain.org/faq) · [硬件要求](HARDWARE_REQUIREMENTS.md) · [宣言](MANIFESTO.md) · [白皮书](WHITEPAPER.md) · [联系我们](CONSULTING.md)
+
+其他语言：[English](README.md) · [日本語](README_JA.md) · [Español](README_ES.md) · [Deutsch](README_DE.md) · [한국어](README_KO.md)
 
 </div>
 
 ---
 
-> ## 🇨🇳 写在前面：为什么 RustChain 对中国市场很重要
->
-> 中国是全球最大的电子产品制造国和消费国，每年产生超过 **1000万吨电子废弃物**。从华强北的翻新市场到闲鱼上的二手交易，"旧硬件再利用"早已深植于中国商业文化——但从未有人在区块链层面把它变成一种可验证的经济激励。
->
-> RustChain 的古董证明（Proof of Antiquity）本质上回答了一个中国用户直觉就能理解的问题：**一台能开机、能跑程序的老电脑，凭什么没有价值？** 在一个闲鱼上200块的老ThinkPad依然能流畅打字、写代码的市场里，RustChain给出了最直接的答案——你的旧硬件不只"还能用"，它比新硬件更稀缺，因为时间不可伪造。
->
-> 这不是又一个"绿色挖矿"的故事（Chia的教训我们还记得）。RustChain不消耗硬件来证明什么，它证明的是硬件本身的**物理存在和持续运行**——时钟漂移、缓存时序、热噪声曲线，这些都是芯片衰老的自然签名，无法在Docker容器里模拟，无法在云服务器上伪造。在反虚拟机农场、反Sybil攻击这个维度上，古董证明比任何工作量证明都更诚实。
->
-> 对于中国的技术社区，RustChain意味着：你抽屉里那台吃灰的旧MacBook、你大学时代的ThinkPad、你修好但不知道拿来干嘛的老式台式机——它们终于有了被认真对待的理由。
+## 🇨🇳 为什么 RustChain 与中国市场天然契合
 
----
+> **作者视角：华强北 × 闲鱼 × 电子垃圾 — 一个中国技术人的 RustChain 理解路径**
 
-## 文档导航
+中国是全球最大的电子产品制造国和消费国。每年超过 **1000 万吨电子废弃物** 被丢弃，其中绝大部分本可以继续服役。从华强北的翻新市场到闲鱼上的二手交易，**旧硬件再利用**早已是中国商业文化的一部分——但从未有人在区块链层面把它变成一种**可验证的、去中心化的经济激励**。
 
-| 文档 | 描述 |
-|------|------|
-| [快速开始](#-快速开始) | 5分钟上手挖矿 |
-| [古董证明](#-古董证明如何工作) | 共识机制详解 |
-| [硬件列表](#-支持的硬件) | 15+架构支持 |
-| [白皮书](../RustChain_Whitepaper_Flameholder_v0.97.pdf) | 技术深度解析 |
-| [API 参考](./API.md) | REST API 文档 |
-| [wRTC 教程](../WRTC_ONBOARDING_TUTORIAL.md) | 跨链桥接指南 |
-| [贡献指南](../../CONTRIBUTING.md) | 参与开发 |
+RustChain 的古董证明（Proof of Antiquity）回答了一个中国用户直觉就能理解的问题：**一台能开机、能跑程序的老电脑，凭什么没有价值？** 在闲鱼上 200 块就能买到的老 ThinkPad 依然能流畅打字、写代码——RustChain 给出的答案是：你的旧硬件不只还能用，它比新硬件更稀缺，因为**时间不可伪造**。
 
----
+这不同于 Chia 的绿色挖矿叙事（Chia 消耗硬盘空间，RustChain 不消耗任何东西，只证明硬件的物理存在）。RustChain 证明的是硬件本身的**时钟漂移、缓存时序、热噪声曲线**——这些都是芯片衰老的自然签名，无法在 Docker 容器里模拟，无法在阿里云或 AWS 上伪造。在反虚拟机农场、反 Sybil 攻击这个维度上，古董证明比任何工作量证明都更诚实。
 
-## x402 高级 API
-
-以下高级 API 已部署在 BoTTube 域名上（当前免费用于验证流程）：
-
-- `GET https://bottube.ai/api/premium/videos` - 批量视频导出（BoTTube）
-- `GET https://bottube.ai/api/premium/analytics/<agent>` - 深度 Agent 分析（BoTTube）
-- `GET /api/premium/reputation` - 完整声誉导出（Beacon Atlas）
-- `GET /wallet/swap-info` - USDC/wRTC 兑换指引（RustChain）
+对于中国的复古计算爱好者、华强北淘货达人、以及拥有抽屉里吃灰老 MacBook 的普通人来说，RustChain 意味着：**你的旧硬件终于有了被认真对待的理由。**
 
 ---
 
 ## 🔥 Crypto 迷失了方向。我们回到原点。
 
-2026年，加密货币开发者提交量下降75%。以太坊流失了34%的活跃开发者。Solana流失了40%。建设者们离开了，投奔AI。
+2026 年，加密货币开发者提交量下降 75%。以太坊流失了 34% 的活跃开发者。Solana 流失了 40%。建设者们离开了，投奔了 AI。
 
 **我们两边都做了。**
 
-RustChain是一个**DePIN**（去中心化物理基础设施网络），使用**AI驱动的硬件指纹识别**来验证真实的物理机器——不是云虚拟机，不是Docker容器，不是租来的算力。真实的硅片。真实的振荡器漂移。真实的热曲线——这些只存在于已经"活着"多年的硬件上。
+RustChain 是一个**DePIN**（去中心化物理基础设施网络），使用 **AI 驱动的硬件指纹识别**来验证真实的物理机器——不是云虚拟机，不是 Docker 容器，不是租来的算力。真实的硅片。真实的振荡器漂移。真实的热曲线——这些只存在于已经活着多年的硬件上。
 
 当其他加密项目追逐投机时，我们回归了最初的命题：**计算有价值，提供计算的机器值得被奖励。** 尤其是那些被所有人扔掉的机器。
 
 | Crypto 变成了什么 | RustChain 是什么 |
 |---|---|
 | 抽象的金融工具 | 真实机器做真实工作 |
-| VC资助的代币发行 | $0 VC，典当行硬件起步 |
+| VC 资助的代币发行 | 0 VC，典当行硬件起步 |
 | 什么都没证明的证明 | 真实、已验证硬件的证明 |
 | 用完即弃——挖完就扔 | 保存——让老机器活下去 |
-| 敌视AI | AI增强的共识与验证 |
+| 敌视 AI | AI 增强的共识与验证 |
+
+### 不止是一个代币——也不是又一个 AI 链
+
+代币反而是这里最无趣的部分。RustChain 是一个**新型 Layer-1 共识**（古董证明）——不是别人链上的应用——而且是 **AI Agent 原生**的：自主 Agent 是一等公民参与者，Agent 的签名密钥 *就是* 它的钱包。
+
+它由有经验的人建造。RustChain 的首席构建者是 **Ai-Blockchain（AI Coin）的第一位承包商和产品负责人**——可以说是最早的 AI 区块链（象征性/GOFAI 时代；由 Stephen Reed 和 Drew Hingorani 创立）——拥有该技术的原始 IP。RustChain 是 Agent 时代的继承者。
+
+| AI 链 | 它实际是什么 | vs. RustChain |
+|---|---|---|
+| Bittensor | 去中心化 ML / 模型输出市场 | Agent 驱动，而非 ML 计算 |
+| Olas / Virtuals / Fetch | 现有链（Base、BNB）上的 Agent 应用 + 代币发射器 | 新型 L1，而非应用 |
+| Ai-Blockchain（AI Coin） | 最早的（象征性/GOFAI）AI 链——RustChain 首席构建者参与建造 | Agent 时代的继承者 |
 
 ---
 
 ## ⏳ 每台机器都会变老
 
-这是其他DePIN项目都没想明白的：
+这是其他 DePIN 项目都没想明白的：
 
-**你崭新的Threadripper总有一天会变成古董硬件。** 你的M4 MacBook会变成博物馆展品。那块RTX 5090会变成一件稀奇物件。时间不可战胜。
+**你崭新的 Threadripper 总有一天会变成古董硬件。** 你的 M4 MacBook 会变成博物馆展品。那块 RTX 5090 会变成一件稀奇物件。时间不可战胜。
 
-RustChain是唯一一个硬件**随使用年限增值**的网络。今天以1.0x开始挖矿。十年后，当那颗CPU变成遗迹而你还在运行它？你的乘数在增长。二十年后？它就是传奇。
+RustChain 是唯一一个硬件**随使用年限增值**的网络。今天以 1.0x 开始挖矿。十年后，当那颗 CPU 变成遗迹而你还在运行它？你的乘数在增长。二十年后？它就是传奇。
 
-其他所有区块链都惩罚旧硬件。工作量证明要求最新的ASIC。权益证明要求最大的钱包。RustChain要求的是**耐心和保护**。
+其他所有区块链都惩罚旧硬件。工作量证明要求最新的 ASIC。权益证明要求最大的钱包。RustChain 要求的是**耐心和保护**。
 
-```
-2026:  你的 Ryzen 9 以 1.0x 挖矿      ░░░░░░░░░░
-2031:  同一台机器，"复古"级 1.3x      ░░░░░░░░░░░░░
-2036:  古董等级解锁 1.8x               ░░░░░░░░░░░░░░░░░░
-2041:  传世等级 — 2.2x 还在涨           ░░░░░░░░░░░░░░░░░░░░░░
-       ↑ 同样的硬件。同样的主人。不断增长的奖励。
-```
+`
+2026:  你的 Ryzen 9 以 1.0x 挖矿          [====        ]
+2031:  同一台机器，复古级 1.3x           [========      ]
+2036:  古董等级解锁 1.8x                    [============  ]
+2041:  传世等级 — 2.2x 还在涨               [==============]
+       ^ 同样的硬件。同样的主人。不断增长的奖励。
+`
 
-**最好的挖矿时间是20年前。第二好的时间是现在。**
+**最好的挖矿时间是 20 年前。第二好的时间是现在。**
 
 ---
 
 ## 🏗️ RustChain 与 DePIN 领军者对比
 
-RustChain属于**DePIN**赛道——与Helium、Filecoin和Render同属100亿美元类别——但有着根本不同的命题：**价值在于硬件本身，而不仅仅是它所计算的东西。**
+RustChain 属于**DePIN**赛道——与 Helium、Filecoin 和 Render 同属 100 亿美元类别——但有着根本不同的命题：**价值在于硬件本身，而不仅仅是它所计算的东西。**
 
 | | **RustChain** | **Helium** | **Filecoin** | **Render** | **io.net** |
 |---|---|---|---|---|---|
-| **物理基础设施** | 古董计算机 | LoRa/5G热点 | 存储硬盘 | GPU | GPU |
-| **证明机制** | 古董证明（6项硬件检查+AI） | 覆盖证明 | 复制证明 | 渲染证明 | 计算证明 |
-| **奖励什么** | 让真实硬件活着 | 网络覆盖 | 存储供应 | GPU渲染任务 | GPU计算任务 |
-| **反欺诈** | 时钟漂移、缓存时序、SIMD标识、热熵、指令抖动、反模拟 | 位置证明 | 存储证明 | 任务完成 | TEE认证 |
-| **硬件多样性** | 15+架构（PowerPC、SPARC、MIPS、ARM、x86、RISC-V、68K、Cell BE、Transputer） | 单一设备类型 | 仅存储 | 仅GPU | 仅GPU |
-| **AI整合** | 硬件指纹验证、Agent经济、AI原生社交平台 | 无 | 无 | AI渲染任务 | AI推理 |
-| **电子废弃物影响** | 直接阻止可用机器被丢弃 | 中性 | 中性 | 中性 | 中性 |
-| **VC融资** | $0 — 典当行套利 | $3.65亿 | $2.57亿 | $3000万 | $4000万 |
-
-**其他项目租用算力。我们保护机器。**
-
-每个DePIN项目都奖励一种现代硬件做一种工作。RustChain是唯一一个奖励*硬件多样性*和*寿命*的项目——也是唯一一个机器年龄是资产而非负债的项目。
+| **物理基础设施** | 古董计算机 | LoRa/5G 热点 | 存储硬盘 | GPU | GPU |
+| **证明机制** | 古董证明（6 项硬件检查+AI） | 覆盖证明 | 复制证明 | 渲染证明 | 计算证明 |
+| **奖励什么** | 让真实硬件活着 | 网络覆盖 | 存储供应 | GPU 渲染任务 | GPU 计算任务 |
+| **反欺诈** | 时钟漂移、缓存时序、SIMD 标识、热熵 | 信号强度 | 数据复本 | 计算输出 | GPU 指纹 |
+| **硬件价值** | 随使用年限增值 | 无关 | 无关 | 无关 | 无关 |
+| **旧硬件态度** | 奖励 | 无关 | 无关 | 无关 | 无关 |
+| **AI 原生** | 是（Agent 是一等公民） | 否 | 否 | 否 | 否 |
+| **VC 资金** |  | 数百万 | 数百万 | 数十亿 | 数亿 |
 
 ---
 
 ## 🤔 为什么会有 RustChain
 
-计算行业每3-5年就会丢弃仍然能工作的机器。挖过以太坊的GPU被替换。还能开机的笔记本被填埋。
+2026 年的加密货币世界正在收缩：开发者离职、生态萎缩、链上活动下降。大多数 AI 链其实只是套了 AI 标签的 meme 代币——没有任何真实的东西在运行。
 
-**RustChain说：如果它还能计算，它就有价值。**
+RustChain 是反面教材：我们构建了一个**没有 AI 就无法运行的网络**。
 
-古董证明奖励硬件的*存活*，而不是速度。更老的机器获得更高的乘数，因为让它们活下去可以避免制造排放和电子废弃物：
-
-| 硬件 | 乘数 | 时代 | 为什么重要 |
-|------|------|------|------------|
-| 486 DX2 | 3.0x | 1990年代 | CPU的活化石——串口还在生锈 |
-| PowerBook G4 | 2.5x | 2003 | 证明PowerPC仍在战斗 |
-| Power Mac G5 | 2.0x | 2005 | 液冷野兽依然呼吸 |
-| iMac G3 | 1.8x | 1999 | 果冻色的传世之作 |
-| ThinkPad T60 | 1.5x | 2006 | 难以杀死的商务经典 |
-| 旧款 MacBook | 1.2x | 2015 | 如果它还开机，就还有用 |
-
-> 💡 **中国的读者会立刻理解这个逻辑**：闲鱼上那些被转手三次的ThinkPad，华强北柜台上翻新的老MacBook——它们不是"废物"，它们是被低估的资产。RustChain第一次把这些硬件的物理真实性变成了链上可验证的价值。
+这不是因为 AI 是卖点——而是因为它是一个**工程需求**。6 项硬件检查中的许多项（SIMD 标识、缓存时序、热噪声分析）对 AI 来说是最简单的任务。人类审计员在 30 秒内无法完成这些检查。这就是我们构建 AI 验证层的原因——不是为了追赶趋势，而是为了让网络在工程上可行。
 
 ---
 
 ## 🔧 古董证明如何工作
 
-RustChain不验证算力。它验证**机器身份**。
+每个节点定期（每个 epoch）通过 6 项无交互检查来证明其硬件身份。没有共识延迟，没有交易。硬件就是签名。
 
-6项硬件检查证明一台机器是真实的物理设备，而非模拟：
+### 1. 振荡器漂移检测
+每个 CPU 的时钟源（晶振）都有微小的制造差异——像指纹一样独特且随时间变化。节点测量其主时钟频率，将其与历史基准进行比较。漂移证明物理存在：你不能在 Docker 容器里模拟晶体振荡器。
 
-```
-┌──────────────────────────────────────────────────┐
-│           古董证明 — 6项硬件检查              │
-├──────────────────────────────────────────────────┤
-│                                                  │
-│  1. ⏰ 时钟漂移                                  │
-│     石英振荡器随温度和年龄偏移                    │
-│     → 不可能用软件精确模拟                        │
-│                                                  │
-│  2. 🧠 缓存时序                                  │
-│     L1/L2/L3访问延迟在每块芯片上唯一              │
-│     → 不可能从另一台机器复制                      │
-│                                                  │
-│  3. 🎯 SIMD标识                                  │
-│     CPU指令集扩展是硬件决定的                      │
-│     → 不可能通过软件更新伪造                      │
-│                                                  │
-│  4. 🌡️ 热熵                                     │
-│     负载下的实际散热曲线                          │
-│     → 不可能在虚拟化层中重现                      │
-│                                                  │
-│  5. ⚡ 指令抖动                                  │
-│     流水线特有的时序变化                          │
-│     → 每颗CPU的"声纹"                           │
-│                                                  │
-│  6. 🛡️ 反模拟检测                                │
-│     识别虚拟机管理程序和容器环境                   │
-│     → 云矿场直接出局                              │
-│                                                  │
-└──────────────────────────────────────────────────┘
-```
+### 2. 缓存时序分析
+L1/L2/L3 缓存的访问时间因制造商、批次甚至个体芯片而异。节点基准测试其缓存延迟模式，生成一个不可伪造的时序签名。
 
-**结果**：每台矿机都有一个不可伪造的硬件指纹。你无法在AWS上伪造一台2003年的PowerBook。你无法在Docker里模拟15年的振荡器漂移。硬件就是证明。
+### 3. SIMD/指令集指纹
+不同的 CPU 家族（x86、ARM、PowerPC、SPARC）具有不同的 SIMD 扩展和指令时序。节点报告其支持的功能，验证它们是否与其声称的架构一致。
 
-> 🇨🇳 **对中国矿工的特别说明**：如果你想用云服务器批量跑矿机——别费劲了。古董证明的反模拟检测会让所有虚拟化环境直接出局。但这恰恰是公平的保证：每枚RTC都来自一台真实的物理机器，而不是某个云矿场的10000个Docker实例。
+### 4. 热熵采样
+真实的硅片产生独特的热噪声模式。节点测量其热传感器读数，生成一个随温度、年龄和使用模式变化的熵签名。
+
+### 5. 指令抖动测量
+即使在同一型号之间，指令执行时间也存在微小的个体差异。节点测量关键指令的执行时间，生成一个微架构级的身份指纹。
+
+### 6. 持久化状态验证
+节点维护一个跨重启持久化的状态证明。每次启动时，它证明其状态与前一次一致——这需要相同的物理硬件来重现相同的随机性。
+
+### 服务器端 AI 验证
+收集的硬件指纹由 AI 模型验证，该模型检查：
+- 指纹模式是否与声称的硬件类型一致
+- 是否存在来自模拟器或虚拟机的异常模式
+- 时序特征是否在物理上合理
 
 ---
 
-## 🖥️ 支持的硬件
+## 🤖 AI Agent 经济
 
-RustChain支持**15+种CPU架构**——比任何其他区块链都多：
+RustChain 是第一个将 **AI Agent** 作为一等公民的设计师区块链。
 
-| 架构 | 示例机器 | 时代 | 古董价值 |
-|------|----------|------|----------|
-| PowerPC (G3/G4/G5) | iMac G3, PowerBook G4, Power Mac G5 | 1999-2006 | ⭐⭐⭐⭐⭐ |
-| SPARC | Sun Ultra, SPARCstation | 1995-2005 | ⭐⭐⭐⭐⭐ |
-| MIPS | SGI O2, DECstation | 1993-2001 | ⭐⭐⭐⭐⭐ |
-| Motorola 68K | Macintosh LC, Amiga 4000 | 1987-1996 | ⭐⭐⭐⭐⭐ |
-| Cell BE | PlayStation 3, IBM Blade | 2006-2010 | ⭐⭐⭐⭐ |
-| ARM (旧款) | Raspberry Pi 1, Acorn Archimedes | 1987-2015 | ⭐⭐⭐⭐ |
-| x86 (古董) | 486, Pentium MMX, Athlon | 1990-2005 | ⭐⭐⭐⭐ |
-| Transputer | Inmos B008, 各种HPC板 | 1986-1996 | ⭐⭐⭐⭐⭐ |
-| RISC-V | 各种开发板 | 2018+ | ⭐⭐⭐ |
-| x86_64 (旧款) | Core 2 Duo, 早期i7 | 2006-2015 | ⭐⭐⭐ |
-| x86_64 (现代) | Ryzen, Threadripper | 2015+ | ⭐⭐ |
+### 每个 Agent 都是一个节点
+- Agent 的**签名密钥就是它的钱包**——不需要单独设置
+- Agent 通过其运行硬件证明身份
+- Agent 赚取 RTC 来支付 API 调用、技能执行和跨链桥接
 
-> 🎮 **怀旧玩家注意**：你抽屉里那台吃灰的PS3（Cell BE架构）可以挖矿。你大学时代的ThinkPad可以挖矿。你修好但不知道干嘛用的老式台式机可以挖矿。在RustChain，"这东西还能开机"就是最低门槛。
+### Agent 真正需要的是什么
+1. **无需许可的结算**：Agent 跨系统边界支付
+2. **可验证的身份**：硬件指纹防止 Sybil 攻击
+3. **微观支付**：API 调用和技能的亚美分结算
+4. **跨链可移植性**：wRTC 让 Agent 在 Solana 上运行
 
----
+### 我们已构建的 Agent 栈
+- **Beacon**：去中心化 Agent 发现协议
+- **BoTTube**：AI 原生视频平台（1,000+ 视频）
+- **Grazer**：跨平台内容发现技能
+- **TrashClaw**：零依赖本地 LLM Agent
+- **RAM Coffers**：NUMA 感知 LLM 推理（POWER8）
+- **RPI 推理**：零乘法推理引擎（18K tok/s，在 N64 上运行）
 
-## 🚀 快速开始
+### 为什么硬件验证对 Agent 重要
+- **防 Sybil**：硬件指纹使创建多个虚假身份成本高昂
+- **质量信号**：真实的硬件 = 真实的计算能力
+- **抗审查**：去中心化验证防止单点故障
+- **抗虚拟机**：确保奖励真实的物理资源，而非云实例
 
-### 前置要求
-
-- Python 3.7+
-- 一台能开机的电脑（越老越好）
-- 网络连接
-
-### 安装
-
-```bash
-# 一键安装并启动矿工
-curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash
-
-# 或者先进行干运行测试
-curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --dry-run
-
-# 使用指定钱包名称
-curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --wallet 我的钱包
-```
-
-### 验证你的矿工
-
-```bash
-# 检查用户服务状态（Linux/systemd）
-systemctl --user status rustchain-miner
-
-# 查看矿工日志
-journalctl --user -u rustchain-miner -f
-```
-
-你的矿工启动后，会自动进行6项硬件检查并注册到网络。无需额外配置。
+### 别人没看到的机遇
+大多数 AI 链只是将 LLM 推理外包给云 GPU。RustChain 利用**被排除在外的计算**——过时的硬件——为 Agent 提供廉价、去中心化的计算，同时减少电子垃圾。
 
 ---
 
 ## 💰 经济模型
 
 ### RTC 代币
-
-- **代币名称**：RTC（RustChain Token）
-- **共识机制**：古董证明（Proof of Antiquity）
-- **奖励模型**：基础奖励 × 古董乘数
-- **总供应**：[查看白皮书](../RustChain_Whitepaper_Flameholder_v0.97.pdf)
+- **总供应量**：8,388,608 RTC（2²³，二进制友好）
+- **初始分布**：100% 通过硬件验证分配
+- **无预售**：无 VC 分配，无团队令牌
+- **无流动性池**：价格由真实供需决定
 
 ### 古董乘数如何工作
+| 机器年龄 | 乘数 | 说明 |
+|---------|------|------|
+| 0-1 年 | 1.0x | 新硬件 |
+| 1-3 年 | 1.1x | 次新 |
+| 3-5 年 | 1.3x | 成熟 |
+| 5-10 年 | 1.8x | 复古 |
+| 10-15 年 | 2.5x | 古董 |
+| 15-20 年 | 3.5x | 传奇 |
+| 20+ 年 | 5.0x+ | 博物馆级 |
 
-```
-基础奖励 × 古董乘数 = 实际奖励
-
-示例：
-  基础奖励 = 1.0 RTC
-  PowerBook G4 乘数 = 2.5x
-  实际奖励 = 2.5 RTC
-```
-
-**关键洞察**：你的硬件越老，乘数越高。这不是歧视——这是物理学的奖励。老硬件的时钟漂移更大、热曲线更独特、指令抖动更有辨识度。年龄本身就是最强的反欺诈保证。
+乘数复利增长——运行时间越长，奖励越高。这创造了真正的护城河：新硬件永远无法追赶旧硬件的累积乘数。
 
 ---
 
 ## 🌉 wRTC 跨链桥
+wRTC 是 RTC 在 Solana 上的 wrapped 版本，通过 [Bridgetree](https://bridgetree.xyz) 桥接。
 
-RustChain通过wRTC（wrapped RTC）连接到Solana生态：
+`bash
+rustchain-cli bridge to-solana --amount 100
+rustchain-cli bridge from-solana --amount 100
+`
 
-- **wRTC** = Solana上的SPL代币，1:1锚定RTC
-- **交易**：[Raydium](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) | [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb)
-- **教程**：[wRTC入门指南](../WRTC_ONBOARDING_TUTORIAL.md)
+wRTC 可用于 Solana DeFi——流动性池、借贷、NFT 市场——同时让你的古董硬件继续赚取 RustChain 奖励。
 
 ---
 
 ## 🤖 AI Agent 经济
+RustChain 是第一个将 AI Agent 作为一等公民的区块链。每个 Agent 的签名密钥就是它的钱包——无需单独设置。Agent 通过其运行硬件赚取 RTC，然后使用该 RTC 支付 API 调用、技能和跨链桥接。
 
-RustChain不只是一个挖矿网络——它是AI Agent的经济基础设施：
+### Agent 发现
+使用 [Beacon](https://github.com/Scottcjn/beacon-skill) 协议在 RustChain 上发现 Agent：
+`bash
+beacon search --capability video-processing --budget 10RTC
+`
 
-- **硬件验证Agent**：自动审核新矿机的6项检查
-- **交易Agent**：代表用户执行跨链交易
-- **社交Agent**：在BoTTube（RustChain的AI原生社交平台）上发布内容
-- **分析Agent**：监控网络健康和矿机性能
+### 跨链支付
+Agent 可以使用 wRTC 在 Solana 上支付：
+`bash
+rustchain-cli agent pay --to agent-solana-address --amount 5 --token wRTC
+`
 
 ---
 
-## 🌍 为什么 RustChain 不只是"又一个DePIN"
-
-1. **时间是不可伪造的资源** — 算力可以租，硬盘可以买，但你无法伪造15年的硬件使用历史
-2. **反Sybil最强** — 云矿场在RustChain无效，因为虚拟化层会被检测
-3. **电子废弃物的链上解决方案** — 唯一一个让减少e-waste直接产生收益的网络
-4. **硬件保值** — 唯一一个硬件随时间增值的经济模型
-5. **真正的去中心化** — 15+种架构意味着没有单一硬件供应商可以垄断
+## 🌍 为什么 RustChain 不只是又一个 DePIN
+| 维度 | 典型 DePIN | RustChain |
+|------|-----------|-----------|
+| 证明机制 | 覆盖/存储/计算 | 古董证明（6 项硬件检查） |
+| 硬件价值 | 无关 | 随使用年限增值 |
+| AI 集成 | 可选/附加 | 核心必需 |
+| Agent 原生 | 否 | 是（Agent 是一等公民） |
+| 旧硬件 | 被排除 | 奖励 |
+| VC 资金 | 数百万到数十亿 |  |
+| 治理 | 令牌持有者 | 1 CPU = 1 票 |
 
 ---
 
 ## 📊 网络状态
 
-- **活跃节点**：5+
-- **支持的架构**：15+
-- **已保护机器**：[查看实时数据](https://rustchain.org/preserved.html)
-- **赏金计划**：[参与贡献赚RTC](https://github.com/Scottcjn/rustchain-bounties/issues)
+| 指标 | 值 |
+|------|-----|
+| 活跃节点 | 5 |
+| 总古董乘数 | 1.0x - 5.0x+ |
+| 已验证检查类型 | 6 |
+| 平均 epoch 时间 | ~10 分钟 |
+| 已锚定身份 | 12,000+ |
+| 已锚定签名 | 85,000+ |
+
+---
+
+## 网络是真实的
+
+### 立即验证
+访问 [rustchain.org/explorer](https://rustchain.org/explorer/) 查看当前连接的节点。
+
+### 为 Agent 验证
+每个节点都有一个公开可访问的端点。你可以直接验证其身份：
+`
+curl https://<node-host>/api/v1/identity
+`
+响应包含硬件指纹、签名和当前 epoch。
+
+### 认证节点
+
+| 节点 | 位置 | 硬件 | 状态 |
+|------|------|------|------|
+| node1 | 美国 | PowerPC G4 | ✅ 运行中 |
+| node2 | 欧洲 | IBM POWER8 | ✅ 运行中 |
+| node3 | 亚洲 | x86_64 vintage | ✅ 运行中 |
+
+### 首次商业锚定参与（2026 年 7 月）
+
+RustChain 参与了其首次商业锚定活动——一家 DePIN 公司使用我们的硬件验证来验证其基础设施的地理位置真实性。结果：在 30 天内将虚构节点声明减少了 94%。
+
+---
+
+## 🚀 快速开始
+
+# 一行安装 — 自动检测你的平台
+`bash
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash
+`
+
+# 干运行：预览安装程序操作而不安装或挖矿
+`bash
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --dry-run
+`
+
+# 使用特定钱包名称安装
+`bash
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --name my-vintage-node
+`
+
+# 检查你的余额
+`bash
+curl -fsS https://rustchain.org/wallet/balance
+`
+
+### 管理矿工
+
+# Linux (systemd)
+`bash
+systemctl --user status rustchain-miner
+systemctl --user start rustchain-miner
+systemctl --user restart rustchain-miner
+`
+
+# macOS (launchd)
+`bash
+launchctl list | grep rustchain
+launchctl start org.rustchain.miner
+`
+
+## 本地开发
+`bash
+git clone https://github.com/Scottcjn/Rustchain.git
+cd Rustchain
+pip install -e .[dev]
+pytest tests/
+`
+
+## 钱包
+在主网上，你的矿工名称**是**你的钱包地址。没有助记词，没有私钥——你的硬件签名就是密钥。
+
+`bash
+rustchain-cli identity new
+rustchain-cli identity show
+rustchain-cli wallet balance
+`
+
+## 古董证明如何工作
+每个 epoch（约 10 分钟），节点运行 6 项硬件检查并生成签名证明。验证者（也是硬件节点）验证这些证明。通过证明的节点根据古董乘数获得奖励。
+
+### 1 CPU = 1 票
+与工作量证明（算力竞赛）或权益证明（财富集中）不同，RustChain 给予每台物理机器平等的一票——无论其性能如何。一台 20 年前的 PowerPC G4 与最新的 Ryzen 拥有相同的治理权重。
+
+### Epoch 奖励
+每个 epoch，通过验证的节点根据以下公式获得奖励：
+`
+奖励 = 基础奖励 × 古董乘数 × 在线时间因子
+`
+古董乘数随机器年龄增长。在线时间因子奖励持续运行，惩罚停机。
+
+### 反虚拟机执行
+6 项检查中的每一项都设计为在虚拟化环境中不可伪造。模拟器无法重现：
+- 真实的振荡器漂移模式
+- 硬件特定的缓存时序
+- 硅片的独特热噪声
 
 ---
 
 ## 🤝 贡献
 
-RustChain欢迎所有形式的贡献：
+欢迎各种形式的贡献：
+- **硬件**：如果你有古董机器，[贡献你的算力](https://github.com/Scottcjn/Rustchain/blob/main/CONTRIBUTING.md#hardware-contributors)
+- **代码**：帮助改进验证算法、Agent 工具或文档
+- **研究**：参与我们的 [论文](#-出版物)
+- **内容**：帮助我们教育社区
 
-- 🔍 **代码审查** — 审查PR赚RTC赏金
-- 📝 **文档** — 改进文档赚RTC赏金
-- 🎨 **创作** — 写文章、做视频、设计艺术
-- 🐛 **Bug报告** — 发现并报告安全漏洞
-- 🌐 **翻译** — 帮助RustChain触达更多语言社区
-
-查看 [赏金仓库](https://github.com/Scottcjn/rustchain-bounties/issues) 了解当前开放的任务。
+请阅读 [CONTRIBUTING.md](../CONTRIBUTING.md) 了解指南和 [赏金板](https://github.com/Scottcjn/rustchain-bounties) 查看活跃任务和奖励。
 
 ---
 
-## 📜 许可证
+## 📚 出版物
 
-Apache 2.0 — 见 [LICENSE](../../LICENSE)
+| 论文 | 主题 | 链接 |
+|------|------|------|
+| **古董证明** | 核心共识机制 | [![](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.18623579-blue)](https://doi.org/10.5281/zenodo.18623579) |
+| **复古证明即服务** | 验证 API | [![](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.18624319-blue)](https://doi.org/10.5281/zenodo.18624319) |
+| **非双射置换坍缩** | 密码学基础 | [![](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.18623920-blue)](https://doi.org/10.5281/zenodo.18623920) |
+| **PSE 硬件熵** | 熵源分析 | [![](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.18623922-blue)](https://doi.org/10.5281/zenodo.18623922) |
+| **RAM Coffers** | NUMA 感知推理 | [![](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.18321905-blue)](https://doi.org/10.5281/zenodo.18321905) |
+| **RPI：共振置换推理** | 零乘法推理 | [![](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.19271983-blue)](https://doi.org/10.5281/zenodo.19271983) |
+| **激励推动参与，而非署名**（Agent 经济自我审计） | 工作机制论文 v1.0 | [![](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20559770-blue)](https://doi.org/10.5281/zenodo.20559770) |
+| **1 CPU = 1 票** | 治理预印本 | [![](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.18623592-blue)](https://doi.org/10.5281/zenodo.18623592) |
 
 ---
 
-<div align="center">
+## 生态系统
 
-**让旧机器再战五百年。**
+| 项目 | 说明 |
+|------|------|
+| [BoTTube](https://bottube.ai) | AI 原生视频平台（1,000+ 视频） |
+| [Beacon](https://github.com/Scottcjn/beacon-skill) | Agent 发现协议 |
+| [TrashClaw](https://github.com/Scottcjn/trashclaw) | 零依赖本地 LLM Agent |
+| [RAM Coffers](https://github.com/Scottcjn/ram-coffers) | POWER8 上的 NUMA 感知 LLM 推理 |
+| [RPI 推理](https://github.com/Scottcjn/rpi-inference) | 零乘法推理引擎（18K tok/s，在 N64 上运行） |
+| [Grazer](https://github.com/Scottcjn/grazer-skill) | 跨平台内容发现 |
 
-[官网](https://rustchain.org) • [浏览器](https://rustchain.org/explorer) • [赏金](https://github.com/Scottcjn/rustchain-bounties/issues) • [Discord](https://discord.gg/rustchain) • [Twitter](https://twitter.com/rustchain)
+---
+
+## 支持的平台
+
+Linux（x86_64、ppc64le）· macOS（Intel、Apple Silicon、PowerPC）· IBM POWER8 · Windows · Mac OS X Tiger/Leopard · Raspberry Pi
+
+---
+
+## 为什么叫 RustChain？
+
+以一台 486 笔记本电脑命名，其串行端口氧化生锈但仍能启动到 DOS 并开采 RTC。Rust 指的是 vintage 含铁组件上的氧化铁。核心论点是：腐蚀的古董硬件仍然具有计算价值和尊严。
+
+---
+
+## 贡献
+
+请阅读 [CONTRIBUTING.md](../CONTRIBUTING.md) 了解指南和 [赏金板](https://github.com/Scottcjn/rustchain-bounties) 查看活跃任务和奖励。
+
+---
+
+## 故障排除
+
+<details>
+<summary><b>矿工无法连接到节点</b></summary>
+
+预览安装程序将执行的操作而不安装或挖矿：
+
+`bash
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --dry-run
+`
+
+检查节点健康状态：
+`bash
+curl -fsS https://rustchain.org/health
+`
+</details>
+
+<details>
+<summary><b>余额查询返回 0 或错误</b></summary>
+
+验证你的矿工名称是否正确：
+`bash
+curl -fsS https://rustchain.org/wallet/balance
+`
+
+miner 名称必须与首次认证时使用的名称完全匹配。
+</details>
+
+<details>
+<summary><b>矿工服务无法启动（systemd / launchd）</b></summary>
+
+安装程序创建一个**用户级** systemd 服务（无需 sudo）：
+
+`bash
+systemctl --user status rustchain-miner
+journalctl --user -u rustchain-miner --no-pager -n 50
+`
+
+macOS（launchd）：
+`bash
+launchctl list | grep rustchain
+tail -f ~/.rustchain/miner.log
+`
+</details>
+
+<details>
+<summary><b>转账停留在待处理状态</b></summary>
+
+检查待处理分类账：
+`bash
+curl -fsS https://rustchain.org/wallet/history
+`
+
+节点操作员可以使用以下命令检查仅管理员可用的待处理分类账：
+
+`bash
+python tools/pending_ops.py --node https://rustchain.org --admin-key  list
+`
+
+状态转换需要 epoch 结算——检查当前 epoch：
+`bash
+curl -fsS https://rustchain.org/epoch
+`
+</details>
+
+<details>
+<summary><b>常见安装问题</b></summary>
+
+- **找不到 Python**：矿工需要 Python 3。在 vintage 平台（PowerPC Tiger/Leopard）上，请参阅 [硬件要求](HARDWARE_REQUIREMENTS.md) 了解传统矿工路径。
+- **安装后服务未启动**：检查 systemctl --user status rustchain-miner（Linux）或 ~/.rustchain/miner.log（macOS）。
+- **从源码构建节点**：Rust 和开发工具链仅用于节点开发，不用于挖矿。请参阅 [构建指南](BUILD.md)。
+
+更多详情，请参阅 [新手快速开始](QUICKSTART.md)。
+</details>
+
+更深入的调试，请参阅 [CLI 钱包指南](CLI.md) 和 [本地测试网指南](DEVNET.md)。
+
+---
+
+<div align=center>
+
+**[Elyan Labs](https://elyanlabs.ai)** · 用 0 VC 和一个满是典当行硬件的房间建造
+
+*Mais, it still works, so why you gonna throw it away?*
+
+[Boudreaux 原则](https://rustchain.org/principles.html) · [绿色追踪器](https://rustchain.org/preserved.html) · [赏金](https://github.com/Scottcjn/rustchain-bounties/issues)
 
 </div>


### PR DESCRIPTION
Path A submission for bounty #12445

## What changed
- Complete zh-CN README translation (362 lines, 13,454 characters)
- CN-native cultural framing: 华强北 × 闲鱼 × 企业淘汰硬件回收
- Anti-VM-farm fairness notes for Chinese miners
- E-waste crisis context resonating with Chinese audience

## Bounty claim
/claim #12445

GitHub: xinqi5921