### PR TITLE
fix(settlement): never report success for a broadcast that never happened

### DIFF
--- a/node/claims_settlement.py
+++ b/node/claims_settlement.py
@@ -54,6 +54,16 @@ class TransactionFailedError(SettlementError):
     pass
 
 
+class SettlementConfigurationError(SettlementError):
+    """Settlement is not configured to reach the chain.
+
+    Settlement moves real RTC.  A missing treasury key or node URL means no
+    transaction can ever be broadcast, so it is a hard configuration error
+    rather than a condition to silently degrade around at runtime.
+    """
+    pass
+
+
 def _normalize_claim_limit(max_claims: int, default: int = 100) -> int:
     """Return a non-negative SQLite LIMIT value for claim batch queries."""
     try:
@@ -308,89 +318,175 @@ def calculate_settlement_fee(num_outputs: int) -> int:
     return base_fee + (per_output_fee * num_outputs)
 
 
+def compute_local_batch_digest(tx_data: Dict[str, Any]) -> str:
+    """Deterministic *local* identifier for a settlement batch.
+
+    This is a correlation id for logs and retries.  It is **not** a
+    transaction hash and must never be written into a field an auditor reads
+    as an on-chain reference.  It is deliberately returned without a ``0x``
+    prefix so it cannot be mistaken for a chain hash at a glance.
+    """
+    import hashlib
+
+    return hashlib.sha256(
+        f"{tx_data.get('batch_id', '')}"
+        f"-{tx_data.get('total_amount_urtc', 0)}"
+        f"-{tx_data.get('created_at', 0)}".encode()
+    ).hexdigest()
+
+
+def validate_settlement_config() -> None:
+    """Fail fast when settlement cannot reach the chain.
+
+    Call at node startup to surface misconfiguration before any claim is
+    reserved.  ``sign_and_broadcast_transaction`` also calls it, so a
+    misconfigured process can never silently "settle" a batch that was never
+    broadcast.
+
+    Environment variables:
+      TREASURY_KEY_PATH  — path to Ed25519 PEM private key
+      NODE_API_URL       — node broadcast endpoint base URL
+
+    Raises:
+        SettlementConfigurationError: if either variable is unset or blank.
+    """
+    import os
+
+    missing = [
+        name
+        for name in ("TREASURY_KEY_PATH", "NODE_API_URL")
+        if not os.environ.get(name, "").strip()
+    ]
+    if missing:
+        raise SettlementConfigurationError(
+            f"settlement not configured to broadcast: {', '.join(missing)} "
+            f"unset. Claims cannot be marked settled without a confirmed "
+            f"on-chain transaction."
+        )
+
+
 def sign_and_broadcast_transaction(
     tx_data: Dict[str, Any],
     db_path: str
 ) -> Tuple[bool, Optional[str], Optional[str]]:
     """
-    Sign transaction with treasury key and broadcast to network.
+    Sign a settlement batch with the treasury key and broadcast it to the node.
 
-    Uses Ed25519 signing via settlement_signer when a treasury key is
-    available.  Falls back to a deterministic SHA-256 hash of the batch
-    data when no key is configured (test/development mode).
+    Success means exactly one thing: the node answered 2xx and returned a
+    transaction hash.  Every other outcome — unreachable node, rejected
+    broadcast, unreadable response, signing failure — returns
+    ``success=False`` with ``transaction_hash=None`` so the caller leaves the
+    claims unsettled and releases the rewards-pool reservation.
+
+    A locally computed signature or batch digest is NEVER returned in the
+    transaction hash slot; see :func:`compute_local_batch_digest`.  A local
+    Ed25519 signature proves only that *this process* authorized the batch, not
+    that any transaction exists on chain.
 
     Environment variables:
       TREASURY_KEY_PATH  — path to Ed25519 PEM private key
       NODE_API_URL       — node broadcast endpoint base URL
+
+    Raises:
+        SettlementConfigurationError: if broadcast is not configured.
 
     Returns:
         (success: bool, transaction_hash: str or None, error: str or None)
     """
     import os
 
-    key_path = os.environ.get("TREASURY_KEY_PATH", "")
-    node_url = os.environ.get("NODE_API_URL", "").rstrip("/")
+    validate_settlement_config()
 
-    if key_path:
-        # ── Real Ed25519 signing path ──────────────────────────────
-        try:
-            from settlement_signer import sign_settlement_batch
+    key_path = os.environ["TREASURY_KEY_PATH"].strip()
+    node_url = os.environ["NODE_API_URL"].strip().rstrip("/")
+    batch_id = tx_data.get("batch_id", "?")
+    digest = compute_local_batch_digest(tx_data)
 
-            success, tx_hash, error = sign_settlement_batch(tx_data, key_path)
-            if not success:
-                return False, None, error
-
-            print(f"[SETTLEMENT] Signed batch {tx_data.get('batch_id', '?')}: "
-                  f"{len(tx_data.get('outputs', []))} outputs, "
-                  f"{tx_data.get('total_amount_urtc', 0)} uRTC")
-
-            if node_url and tx_hash:
-                # Broadcast to node
-                import requests
-                try:
-                    resp = requests.post(
-                        f"{node_url}/api/tx/submit",
-                        json={
-                            "batch_id": tx_data.get("batch_id"),
-                            "claim_ids": [c for c in tx_data.get("claim_ids", [])],
-                            "outputs": tx_data.get("outputs", []),
-                            "fee_urtc": tx_data.get("fee_urtc", 0),
-                            "signature": tx_hash,
-                        },
-                        timeout=30,
-                    )
-                    if resp.status_code in (200, 201):
-                        result = resp.json()
-                        on_chain_hash = result.get("tx_hash", tx_hash)
-                        print(f"[SETTLEMENT] Broadcast confirmed: {on_chain_hash}")
-                        return True, on_chain_hash, None
-                    else:
-                        print(f"[SETTLEMENT] Broadcast returned {resp.status_code}, "
-                              f"using signature as tx_hash")
-                except Exception as e:
-                    print(f"[SETTLEMENT] Broadcast failed ({e}), "
-                          f"using signature as tx_hash")
-
-            return True, tx_hash, None
-
-        except Exception as e:
-            print(f"[SETTLEMENT] Signing module error ({e}), "
-                  f"falling back to hash")
-
-    # ── Fallback: SHA-256 hash of batch data ──────────────────────
-    # Used when no treasury key is configured (test/dev).
-    import hashlib
     print(f"[SETTLEMENT] Constructing transaction with "
           f"{len(tx_data.get('outputs', []))} outputs")
     print(f"[SETTLEMENT] Total amount: {tx_data.get('total_amount_urtc', 0)} uRTC")
     print(f"[SETTLEMENT] Fee: {tx_data.get('fee_urtc', 0)} uRTC")
 
-    tx_hash = hashlib.sha256(
-        f"{tx_data.get('batch_id', '')}"
-        f"-{tx_data.get('total_amount_urtc', 0)}"
-        f"-{tx_data.get('created_at', 0)}".encode()
-    ).hexdigest()
-    return True, "0x" + tx_hash, None
+    # ── Sign ───────────────────────────────────────────────────────────
+    try:
+        from settlement_signer import sign_settlement_batch
+
+        signed, signature, sign_error = sign_settlement_batch(tx_data, key_path)
+    except Exception as e:
+        return False, None, (
+            f"settlement signer unavailable ({e!r}); batch {batch_id} was not "
+            f"signed and not broadcast (local_batch_digest={digest})"
+        )
+
+    if not signed or not signature:
+        return False, None, (
+            sign_error
+            or f"signing failed for batch {batch_id} (local_batch_digest={digest})"
+        )
+
+    print(f"[SETTLEMENT] Signed batch {batch_id}: "
+          f"{len(tx_data.get('outputs', []))} outputs, "
+          f"{tx_data.get('total_amount_urtc', 0)} uRTC")
+
+    # ── Broadcast ──────────────────────────────────────────────────────
+    try:
+        import requests
+
+        resp = requests.post(
+            f"{node_url}/api/tx/submit",
+            json={
+                "batch_id": tx_data.get("batch_id"),
+                "claim_ids": [c for c in tx_data.get("claim_ids", [])],
+                "outputs": tx_data.get("outputs", []),
+                "fee_urtc": tx_data.get("fee_urtc", 0),
+                "signature": signature,
+            },
+            timeout=30,
+        )
+    except Exception as e:
+        # The request may or may not have reached the node.  Report failure so
+        # the claims stay unsettled; an operator must confirm on-chain state
+        # before this batch is retried.
+        return False, None, (
+            f"broadcast to {node_url} failed ({e!r}); batch {batch_id} is NOT "
+            f"confirmed on chain (local_batch_digest={digest})"
+        )
+
+    if resp.status_code not in (200, 201):
+        return False, None, (
+            f"broadcast rejected with HTTP {resp.status_code}; batch "
+            f"{batch_id} is NOT on chain (local_batch_digest={digest})"
+        )
+
+    try:
+        body = resp.json()
+    except Exception as e:
+        return False, None, (
+            f"broadcast returned HTTP {resp.status_code} with an unreadable "
+            f"body ({e!r}); on-chain state of batch {batch_id} is UNKNOWN "
+            f"(local_batch_digest={digest})"
+        )
+
+    # A 2xx carrying an application-level failure is still a failure — the
+    # same shape as the #16390 bounty-payout fix.
+    if not isinstance(body, dict) or not body.get("ok", True):
+        reported = body.get("error") if isinstance(body, dict) else body
+        return False, None, (
+            f"node returned HTTP {resp.status_code} but reported failure "
+            f"({reported!r}); batch {batch_id} is NOT on chain "
+            f"(local_batch_digest={digest})"
+        )
+
+    on_chain_hash = body.get("tx_hash")
+    if not on_chain_hash:
+        return False, None, (
+            f"node returned HTTP {resp.status_code} without a tx_hash; batch "
+            f"{batch_id} cannot be recorded as settled "
+            f"(local_batch_digest={digest})"
+        )
+
+    print(f"[SETTLEMENT] Broadcast confirmed: {on_chain_hash}")
+    return True, on_chain_hash, None
 
 
 def reserve_claims_for_settlement(
@@ -670,7 +766,8 @@ def process_claims_batch(
             "claims_count": int,
             "total_amount_urtc": int,
             "total_amount_rtc": float,
-            "transaction_hash": str or None,
+            "transaction_hash": str or None,   # confirmed on-chain hash ONLY
+            "local_batch_digest": str or None,  # local correlation id, NOT a tx hash
             "success_count": int,
             "failed_count": int,
             "error": str or None
@@ -682,7 +779,10 @@ def process_claims_batch(
         "claims_count": 0,
         "total_amount_urtc": 0,
         "total_amount_rtc": 0.0,
+        # Set only from a node-confirmed broadcast.  Never a local signature
+        # or digest — an auditor reads this field as an on-chain reference.
         "transaction_hash": None,
+        "local_batch_digest": None,
         "success_count": 0,
         "failed_count": 0,
         "error": None
@@ -805,6 +905,20 @@ def process_claims_batch(
         # wallet/client/network failures; reserved rows must not remain stuck
         # in 'settling' if that happens before a success response is returned.
         success, tx_hash, error = sign_and_broadcast_transaction(tx_data, db_path)
+    except SettlementConfigurationError as exc:
+        # Nothing was signed and nothing left this process, so these claims are
+        # untouched and provably safe to retry.  Return them to 'approved'
+        # rather than burning good claims as 'failed' over a missing env var.
+        release_rewards_pool_funds(db_path, required_amount)
+        error = str(exc)
+        result["released_count"] = release_reserved_claims_for_settlement(
+            db_path,
+            [c["claim_id"] for c in claims_to_process],
+            batch_id,
+            error,
+        )
+        result["error"] = error
+        return result
     except Exception as exc:
         release_rewards_pool_funds(db_path, required_amount)
         error = str(exc) or exc.__class__.__name__
@@ -819,6 +933,11 @@ def process_claims_batch(
     
     if not success:
         release_rewards_pool_funds(db_path, required_amount)
+        # No confirmed transaction exists, so transaction_hash stays None.
+        # Record the local digest in a field of its own so this batch can be
+        # correlated across logs and retries without ever being mistaken for
+        # an on-chain reference.
+        result["local_batch_digest"] = compute_local_batch_digest(tx_data)
         # Mark claims as failed
         failed_count = update_claims_failed(
             db_path,

--- a/node/tests/test_claims_settlement.py
+++ b/node/tests/test_claims_settlement.py
@@ -31,6 +31,9 @@ from claims_settlement import (
     SettlementError,
     InsufficientFundsError,
     TransactionFailedError,
+    SettlementConfigurationError,
+    compute_local_batch_digest,
+    validate_settlement_config,
     _normalize_claim_limit,
     get_pending_claims,
     get_verifying_claims,
@@ -495,69 +498,219 @@ class TestCalculateSettlementFee:
 # 10. sign_and_broadcast_transaction
 # ═══════════════════════════════════════════════════════════════════════
 
+def _tx(batch_id="batch_2025_01_01_001", **over):
+    tx = {
+        "batch_id": batch_id,
+        "total_amount_urtc": 5000,
+        "outputs": [{"address": "RTCaaa", "amount_urtc": 5000}],
+        "fee_urtc": 1100,
+        "claim_ids": ["c-1"],
+        "created_at": 1700000000,
+    }
+    tx.update(over)
+    return tx
+
+
+def _configure_settlement(monkeypatch, tmp_path):
+    """Point settlement at a treasury key path and a node URL."""
+    key = tmp_path / "treasury.pem"
+    key.write_text("not-a-real-key")
+    monkeypatch.setenv("TREASURY_KEY_PATH", str(key))
+    monkeypatch.setenv("NODE_API_URL", "http://node.invalid:8099")
+
+
+def _stub_signer(monkeypatch, signature="0x" + "ab" * 64):
+    """Make signing succeed so broadcast behaviour is what is under test."""
+    import settlement_signer
+
+    monkeypatch.setattr(
+        settlement_signer,
+        "sign_settlement_batch",
+        lambda tx_data, key_path=None: (True, signature, None),
+    )
+
+
+class _Resp:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):  # noqa: F811 - mimics requests.Response.json
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+def _stub_post(monkeypatch, resp):
+    """Stub requests.post with a canned response, or an exception to raise."""
+    import requests
+
+    def fake_post(*args, **kwargs):
+        if isinstance(resp, Exception):
+            raise resp
+        return resp
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+
+class TestComputeLocalBatchDigest:
+    """The digest is a local correlation id — never an on-chain reference."""
+
+    def test_is_not_0x_prefixed(self):
+        digest = compute_local_batch_digest(_tx())
+        assert not digest.startswith("0x")
+        assert len(digest) == 64
+
+    def test_deterministic_same_input(self):
+        assert compute_local_batch_digest(_tx()) == compute_local_batch_digest(_tx())
+
+    def test_different_input_different_digest(self):
+        assert compute_local_batch_digest(_tx("batch_a")) != compute_local_batch_digest(
+            _tx("batch_b")
+        )
+
+
+class TestValidateSettlementConfig:
+    def test_raises_when_both_unset(self, monkeypatch):
+        monkeypatch.delenv("TREASURY_KEY_PATH", raising=False)
+        monkeypatch.delenv("NODE_API_URL", raising=False)
+        with pytest.raises(SettlementConfigurationError) as exc:
+            validate_settlement_config()
+        assert "TREASURY_KEY_PATH" in str(exc.value)
+        assert "NODE_API_URL" in str(exc.value)
+
+    def test_raises_when_node_url_unset(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TREASURY_KEY_PATH", str(tmp_path / "k.pem"))
+        monkeypatch.delenv("NODE_API_URL", raising=False)
+        with pytest.raises(SettlementConfigurationError):
+            validate_settlement_config()
+
+    def test_blank_is_treated_as_unset(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TREASURY_KEY_PATH", str(tmp_path / "k.pem"))
+        monkeypatch.setenv("NODE_API_URL", "   ")
+        with pytest.raises(SettlementConfigurationError):
+            validate_settlement_config()
+
+    def test_passes_when_configured(self, monkeypatch, tmp_path):
+        _configure_settlement(monkeypatch, tmp_path)
+        validate_settlement_config()  # must not raise
+
+
 class TestSignAndBroadcastTransaction:
-    def test_returns_success_with_deterministic_hash(self):
-        tx = {
-            "batch_id": "batch_2025_01_01_001",
-            "total_amount_urtc": 5000,
-            "outputs": [{"address": "A", "amount_urtc": 5000}],
-            "fee_urtc": 1100,
-            "claim_ids": ["c-1"],
-            "created_at": 1700000000,
-        }
-        success, tx_hash, error = sign_and_broadcast_transaction(tx, ":memory:")
+    """Regression cover for #8230.
+
+    Every one of these cases previously returned ``success=True`` with a
+    fabricated ``0x…`` hash while nothing reached the chain.
+    """
+
+    def test_missing_config_is_a_hard_error(self, monkeypatch):
+        monkeypatch.delenv("TREASURY_KEY_PATH", raising=False)
+        monkeypatch.delenv("NODE_API_URL", raising=False)
+        with pytest.raises(SettlementConfigurationError):
+            sign_and_broadcast_transaction(_tx(), ":memory:")
+
+    def test_signer_unavailable_returns_failure(self, monkeypatch, tmp_path):
+        _configure_settlement(monkeypatch, tmp_path)
+        import builtins
+
+        real_import = builtins.__import__
+
+        def no_signer(name, *args, **kwargs):
+            if name == "settlement_signer":
+                raise ImportError("no module named settlement_signer")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", no_signer)
+        success, tx_hash, error = sign_and_broadcast_transaction(_tx(), ":memory:")
+        assert success is False
+        assert tx_hash is None
+        assert "not signed" in error
+
+    def test_signing_failure_returns_failure(self, monkeypatch, tmp_path):
+        _configure_settlement(monkeypatch, tmp_path)
+        import settlement_signer
+
+        monkeypatch.setattr(
+            settlement_signer,
+            "sign_settlement_batch",
+            lambda tx_data, key_path=None: (False, None, "bad treasury key"),
+        )
+        success, tx_hash, error = sign_and_broadcast_transaction(_tx(), ":memory:")
+        assert success is False
+        assert tx_hash is None
+        assert "bad treasury key" in error
+
+    def test_unreachable_node_returns_failure(self, monkeypatch, tmp_path):
+        _configure_settlement(monkeypatch, tmp_path)
+        _stub_signer(monkeypatch)
+        _stub_post(monkeypatch, ConnectionError("connection refused"))
+        success, tx_hash, error = sign_and_broadcast_transaction(_tx(), ":memory:")
+        assert success is False
+        assert tx_hash is None
+        assert "NOT confirmed on chain" in error
+
+    def test_non_2xx_returns_failure(self, monkeypatch, tmp_path):
+        _configure_settlement(monkeypatch, tmp_path)
+        _stub_signer(monkeypatch)
+        _stub_post(monkeypatch, _Resp(503, {}))
+        success, tx_hash, error = sign_and_broadcast_transaction(_tx(), ":memory:")
+        assert success is False
+        assert tx_hash is None
+        assert "503" in error
+
+    def test_2xx_with_unreadable_body_returns_failure(self, monkeypatch, tmp_path):
+        _configure_settlement(monkeypatch, tmp_path)
+        _stub_signer(monkeypatch)
+        _stub_post(monkeypatch, _Resp(200, ValueError("not json")))
+        success, tx_hash, error = sign_and_broadcast_transaction(_tx(), ":memory:")
+        assert success is False
+        assert tx_hash is None
+        assert "UNKNOWN" in error
+
+    def test_2xx_with_ok_false_returns_failure(self, monkeypatch, tmp_path):
+        """HTTP 200 carrying an application-level failure is still a failure."""
+        _configure_settlement(monkeypatch, tmp_path)
+        _stub_signer(monkeypatch)
+        _stub_post(monkeypatch, _Resp(200, {"ok": False, "error": "bad signature"}))
+        success, tx_hash, error = sign_and_broadcast_transaction(_tx(), ":memory:")
+        assert success is False
+        assert tx_hash is None
+        assert "bad signature" in error
+
+    def test_2xx_without_tx_hash_returns_failure(self, monkeypatch, tmp_path):
+        """A 2xx with no hash must not fall back to the local signature."""
+        _configure_settlement(monkeypatch, tmp_path)
+        signature = "0x" + "ab" * 64
+        _stub_signer(monkeypatch, signature=signature)
+        _stub_post(monkeypatch, _Resp(200, {"ok": True}))
+        success, tx_hash, error = sign_and_broadcast_transaction(_tx(), ":memory:")
+        assert success is False
+        assert tx_hash is None
+        assert signature not in (error or "")
+
+    def test_never_returns_the_local_signature_as_tx_hash(self, monkeypatch, tmp_path):
+        signature = "0x" + "cd" * 64
+        for resp in (
+            ConnectionError("down"),
+            _Resp(500, {}),
+            _Resp(200, {"ok": True}),
+            _Resp(200, ValueError("not json")),
+        ):
+            _configure_settlement(monkeypatch, tmp_path)
+            _stub_signer(monkeypatch, signature=signature)
+            _stub_post(monkeypatch, resp)
+            success, tx_hash, _ = sign_and_broadcast_transaction(_tx(), ":memory:")
+            assert success is False
+            assert tx_hash is None
+
+    def test_confirmed_broadcast_returns_node_hash(self, monkeypatch, tmp_path):
+        _configure_settlement(monkeypatch, tmp_path)
+        _stub_signer(monkeypatch)
+        _stub_post(monkeypatch, _Resp(200, {"ok": True, "tx_hash": "0xrealchainhash"}))
+        success, tx_hash, error = sign_and_broadcast_transaction(_tx(), ":memory:")
         assert success is True
-        assert tx_hash.startswith("0x")
-        assert len(tx_hash) == 66  # 0x + 64 hex chars
+        assert tx_hash == "0xrealchainhash"
         assert error is None
-
-    def test_deterministic_hash_same_input(self):
-        tx = {
-            "batch_id": "batch_2025_01_01_001",
-            "total_amount_urtc": 5000,
-            "outputs": [],
-            "fee_urtc": 1000,
-            "claim_ids": ["c-1"],
-            "created_at": 1700000000,
-        }
-        _, h1, _ = sign_and_broadcast_transaction(tx, ":memory:")
-        _, h2, _ = sign_and_broadcast_transaction(tx, ":memory:")
-        assert h1 == h2  # deterministic
-
-    def test_different_input_different_hash(self):
-        tx1 = {
-            "batch_id": "batch_a",
-            "total_amount_urtc": 1000,
-            "outputs": [],
-            "fee_urtc": 1000,
-            "claim_ids": ["c-1"],
-            "created_at": 1,
-        }
-        tx2 = {
-            "batch_id": "batch_b",
-            "total_amount_urtc": 1000,
-            "outputs": [],
-            "fee_urtc": 1000,
-            "claim_ids": ["c-1"],
-            "created_at": 1,
-        }
-        _, h1, _ = sign_and_broadcast_transaction(tx1, ":memory:")
-        _, h2, _ = sign_and_broadcast_transaction(tx2, ":memory:")
-        assert h1 != h2
-
-    def test_outputs_printed_but_not_critical(self, capsys):
-        tx = {
-            "batch_id": "batch_2025_01_01_001",
-            "total_amount_urtc": 5000,
-            "outputs": [{"address": "RTCaaa", "amount_urtc": 5000}],
-            "fee_urtc": 1100,
-            "claim_ids": ["c-1"],
-            "created_at": 1700000000,
-        }
-        sign_and_broadcast_transaction(tx, ":memory:")
-        captured = capsys.readouterr()
-        assert "Constructing transaction with 1 outputs" in captured.out
-        assert "Total amount: 5000" in captured.out
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -904,6 +1057,78 @@ class TestProcessClaimsBatch:
                 "SELECT status FROM claims WHERE claim_id = 'c-1'"
             ).fetchone()
         assert row[0] == "failed"
+
+    # ── #8230 regression: no fabricated settlement ────────────────────
+    # These exercise the REAL sign_and_broadcast_transaction. Before the fix
+    # both marked the claim 'settled' against a hash that never existed.
+
+    def test_unconfigured_settlement_does_not_settle_claims(self, tmp_path, monkeypatch):
+        """Missing config must not settle anything; claims stay retryable."""
+        monkeypatch.delenv("TREASURY_KEY_PATH", raising=False)
+        monkeypatch.delenv("NODE_API_URL", raising=False)
+
+        db = str(tmp_path / "test.db")
+        _init_db(db, FULL_SCHEMA)
+        now = int(time.time())
+        _insert_claim(db, "c-1", reward_urtc=1000, submitted_at=now - 10)
+        _seed_rewards_pool(db, 100000)
+
+        result = process_claims_batch(
+            db, max_claims=10, min_batch_size=1, max_wait_seconds=30
+        )
+
+        assert result["processed"] is False
+        assert result["transaction_hash"] is None
+        assert "TREASURY_KEY_PATH" in result["error"]
+
+        with sqlite3.connect(db) as conn:
+            status = conn.execute(
+                "SELECT status FROM claims WHERE claim_id = 'c-1'"
+            ).fetchone()[0]
+            pool = conn.execute(
+                "SELECT balance_urtc FROM rewards_pool WHERE pool_name = 'epoch_rewards'"
+            ).fetchone()[0]
+
+        # Nothing was signed or sent, so the claim is returned for a retry.
+        assert status == "approved"
+        assert pool == 100000  # reservation released, not consumed
+
+    def test_unreachable_node_does_not_settle_claims(self, tmp_path, monkeypatch):
+        """A node that never answers must not produce a settled claim."""
+        _configure_settlement(monkeypatch, tmp_path)
+        _stub_signer(monkeypatch)
+        _stub_post(monkeypatch, ConnectionError("connection refused"))
+
+        db = str(tmp_path / "test.db")
+        _init_db(db, FULL_SCHEMA)
+        now = int(time.time())
+        _insert_claim(db, "c-1", reward_urtc=1000, submitted_at=now - 10)
+        _seed_rewards_pool(db, 100000)
+
+        result = process_claims_batch(
+            db, max_claims=10, min_batch_size=1, max_wait_seconds=30
+        )
+
+        assert result["processed"] is False
+        assert result["transaction_hash"] is None
+        assert result["failed_count"] == 1
+        assert "NOT confirmed on chain" in result["error"]
+
+        # The batch digest is retained, but in its own field and never
+        # 0x-prefixed, so it cannot be read as an on-chain reference.
+        assert result["local_batch_digest"] is not None
+        assert not result["local_batch_digest"].startswith("0x")
+
+        with sqlite3.connect(db) as conn:
+            status = conn.execute(
+                "SELECT status FROM claims WHERE claim_id = 'c-1'"
+            ).fetchone()[0]
+            pool = conn.execute(
+                "SELECT balance_urtc FROM rewards_pool WHERE pool_name = 'epoch_rewards'"
+            ).fetchone()[0]
+
+        assert status != "settled"
+        assert pool == 100000  # reservation released, not consumed
 
     def test_successful_batch_updates_result(self, tmp_path, monkeypatch):
         db = str(tmp_path / "test.db")


### PR DESCRIPTION
Fixes #8230

## What was wrong

`sign_and_broadcast_transaction()` returned `success=True` with a synthetic `tx_hash` along five paths where nothing reached the chain. `process_claims_batch()` does not re-verify, so it marked the claims `settled`, permanently consumed the rewards-pool reservation, and recorded a `0x…` value indistinguishable at audit time from a real on-chain hash.

## What changed

Success now means exactly one thing: **the node answered 2xx and returned a `tx_hash`.**

- **Every non-confirmed outcome returns `(False, None, error)`.** The caller's `if not success:` branch already released the pool reservation and left the claims unsettled and retryable — that path is now actually reachable. The caller's failure handling is deliberately unchanged.
- **Nothing is ever synthesized into the `transaction_hash` slot.** The batch digest moves to `compute_local_batch_digest()` and is surfaced in a distinct result field, `local_batch_digest`, deliberately **without** a `0x` prefix so it cannot be read as a chain reference. A local Ed25519 signature proves only that this process authorized the batch, not that a transaction exists.
- **Missing `TREASURY_KEY_PATH` / `NODE_API_URL` is a hard `SettlementConfigurationError`** via `validate_settlement_config()`, which is callable at startup. Nothing is signed or sent in that case, so the batch is returned to `approved` for retry rather than burned as `failed` over a missing env var.

### Two extra fabrication paths, not in the original report

While reading the call path I found two more:

1. `on_chain_hash = result.get("tx_hash", tx_hash)` — a 2xx whose body **omits** `tx_hash` silently fell back to the local signature.
2. A 2xx carrying an application-level failure (`{"ok": false}`) was treated as confirmed — the exact shape called out in the #16390 bounty-payout fix.

Both now fail closed.

### A deliberate non-change

Non-confirmed batches still go to `failed` (with `retry_scheduled: True`), not back to `approved`. A broadcast that raised mid-flight may or may not have reached the node; auto-releasing those rows to `approved` would turn a timeout into a double-payment. Only the config-error path, where provably nothing was sent, releases for automatic retry. The error strings say plainly when on-chain state is UNKNOWN.

## Tests

The suite specified the bug: `test_returns_success_with_deterministic_hash` called the function with no key and no node and asserted `success is True` and `tx_hash.startswith("0x")`. Those assertions are replaced with per-failure-path cover. The determinism tests were preserved, retargeted onto `compute_local_batch_digest()` where determinism is actually the contract. The failure tests at the old `:867`/`:893` monkeypatch the function out, so they were unaffected and still make sense — they cover the caller, not the broadcaster.

Added two end-to-end regression tests through `process_claims_batch` that exercise the **real** `sign_and_broadcast_transaction` and assert claims are not settled and the pool is not consumed.

## Verified

- **Regression tests fail on old code.** Ran the new tests against `origin/main`'s `claims_settlement.py` (new symbols shimmed in so imports resolve, broadcaster left original): **10 failed, 2 passed**. Captured stdout on the old code shows the defect verbatim:
  ```
  [SETTLEMENT] Broadcast failed (connection refused), using signature as tx_hash
  [SETTLEMENT] Batch batch_2026_08_19_001 processed:
    Claims: 1
    TX Hash: 0xababab…abab
  ```
  Direct call with no key and no node on old code returned `success=True`, `tx_hash=0xa6f492d6…`, `error=None`.
- **Settlement tests pass.** `test_claims_settlement.py`, `test_claims_settlement_reservation.py`, `test_wt1_dry_run_mutates_verifying.py`, `test_settlement_integrity.py`: **108 passed** (baseline on unmodified main was 93; +15 new tests).
- **No regressions in the full node suite.** Ran `node/tests/` before and after and diffed the failure sets: **identical, 96 pre-existing failures, zero introduced, zero fixed.** Those 96 are in unrelated modules (p2p, rate limits, bridge, tx validation); none touch settlement. Note the total failure count is mildly flaky run-to-run (one run showed 95), which is why the comparison is on the failure *set*, not the count.
- **Lint parity.** `ruff` reports 10 findings before and 10 after on the two changed files — all pre-existing. One new finding I introduced (`_Resp.json` shadowing the module-level `json` import) is silenced with a targeted `# noqa: F811`.

## NOT verified

- **No runtime reproduction against a live node.** No node was stood up; no real batch was broadcast. The confirmed-broadcast path is exercised only against a stubbed `requests.post`, so the real node's response shape at `/api/tx/submit` is **assumed, not observed** — specifically that a successful submit returns a body containing `tx_hash`. If the production node does not return `tx_hash` on success, this change will correctly refuse to settle, and the node's response contract needs to be confirmed before deploy.
- **Signing is stubbed in all tests.** `settlement_signer.sign_settlement_batch` is monkeypatched; no real Ed25519 key was loaded or used.
- **Deployment impact not measured.** Any environment currently running without `TREASURY_KEY_PATH` / `NODE_API_URL` was silently fabricating settlements and will now raise at startup. That is the intended outcome, but it is a behavioural break for such environments and should be checked before deploying to any node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)