### PR TITLE
fix(ci,monitoring): three guards that could not report a failure

### DIFF
--- a/.github/workflows/ci_ledger_invariants.yml
+++ b/.github/workflows/ci_ledger_invariants.yml
@@ -91,6 +91,8 @@ jobs:
       #   0 = measured, holds        -> pass
       #   1 = measured, VIOLATED     -> FAIL, always, no exceptions
       #   2 = could not be measured  -> warn, do not fail
+      #   3 = the CHECKER crashed    -> FAIL, under its own name (a broken
+      #                                 guard is not a verdict about the chain)
       - name: Run ledger invariant tests (with live node check)
         if: success()
         run: |
@@ -108,10 +110,18 @@ jobs:
               echo "Live ledger invariants measured and hold."
               ;;
             2)
-              echo "::warning title=Live node unreachable::Live ledger invariants could NOT be measured. No violation was observed, and none was ruled out."
+              echo "::warning title=Live node unmeasurable::Live ledger invariants could NOT be measured (node unreachable, non-JSON body, or an unreadable payload shape). No violation was observed, and none was ruled out."
+              ;;
+            3)
+              echo "::error title=Ledger invariant checker crashed::live_api_checks raised. This is a bug in testing/ledger_invariants.py, NOT a verdict about the chain — but a guard that cannot run is a broken guard."
+              exit 3
+              ;;
+            1)
+              echo "::error title=Ledger invariant violated::The live chain violated a ledger invariant. This is never tolerated."
+              exit 1
               ;;
             *)
-              echo "::error title=Ledger invariant violated::The live chain violated a ledger invariant (exit $rc). This is never tolerated."
+              echo "::error title=Ledger invariant suite failed::Unexpected exit $rc."
               exit "$rc"
               ;;
           esac

--- a/.github/workflows/ci_ledger_invariants.yml
+++ b/.github/workflows/ci_ledger_invariants.yml
@@ -1,14 +1,54 @@
 name: Ledger Invariant Tests
 
+# Triggers deliberately cover the code the invariants are ABOUT, not just the
+# invariant file itself.
+#
+# Before: this workflow fired only on changes to testing/ledger_invariants.py
+# and to this file. That is a guard wired to fire only when you edit the guard —
+# a PR that changed settlement, reward, or balance code never ran the ledger
+# invariants at all. The paths below are the ledger/settlement surface those
+# invariants actually constrain.
+#
+# NOTE: the two path lists below are duplicated verbatim. GitHub Actions does
+# not support YAML anchors/aliases in workflow files, so they cannot be shared.
+# Keep them in sync by hand.
 on:
   push:
     paths:
       - 'testing/ledger_invariants.py'
+      - 'testing/test_ledger_invariants.py'
+      - 'testing/test_inv5_antiquity_ordering_asymmetry.py'
       - '.github/workflows/ci_ledger_invariants.yml'
+      # Ledger / settlement / reward surface
+      - 'node/rustchain_v2_integrated_v2.2.1_rip200.py'
+      - 'node/rewards_implementation_rip200.py'
+      - 'node/settle_epoch.py'
+      - 'node/settlement_signer.py'
+      - 'node/auto_epoch_settler.py'
+      - 'node/claims_settlement.py'
+      - 'node/available_balance.py'
+      - 'node/lock_ledger.py'
+      - 'node/db_helpers.py'
+      - 'payout_ledger.py'
+      - 'payout_preflight.py'
   pull_request:
     paths:
       - 'testing/ledger_invariants.py'
+      - 'testing/test_ledger_invariants.py'
+      - 'testing/test_inv5_antiquity_ordering_asymmetry.py'
       - '.github/workflows/ci_ledger_invariants.yml'
+      # Ledger / settlement / reward surface
+      - 'node/rustchain_v2_integrated_v2.2.1_rip200.py'
+      - 'node/rewards_implementation_rip200.py'
+      - 'node/settle_epoch.py'
+      - 'node/settlement_signer.py'
+      - 'node/auto_epoch_settler.py'
+      - 'node/claims_settlement.py'
+      - 'node/available_balance.py'
+      - 'node/lock_ledger.py'
+      - 'node/db_helpers.py'
+      - 'payout_ledger.py'
+      - 'payout_preflight.py'
   workflow_dispatch:
     inputs:
       scenarios:
@@ -20,20 +60,20 @@ jobs:
   ledger-invariants:
     runs-on: ubuntu-latest
     name: Ledger Invariant Test Suite
-    
+
     steps:
       - uses: actions/checkout@v7
-      
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install hypothesis
-      
+
       - name: Run ledger invariant tests (property-based)
         run: |
           python testing/ledger_invariants.py \
@@ -41,25 +81,60 @@ jobs:
             --verbose \
             --scenarios ${{ github.event.inputs.scenarios || '10000' }}
         timeout-minutes: 10
-      
+
+      # An unreachable node and a VIOLATED invariant are different events and
+      # must not share an outcome. `continue-on-error: true` used to cover both,
+      # so a genuine conservation-of-supply break on the production chain went
+      # green as "live node may be temporarily unreachable".
+      #
+      # ledger_invariants.py --ci now exits:
+      #   0 = measured, holds        -> pass
+      #   1 = measured, VIOLATED     -> FAIL, always, no exceptions
+      #   2 = could not be measured  -> warn, do not fail
       - name: Run ledger invariant tests (with live node check)
         if: success()
         run: |
+          set -uo pipefail
+          set +e
           python testing/ledger_invariants.py \
             --ci \
             --live \
             --verbose \
             --scenarios 1000
-        continue-on-error: true  # Live node may be temporarily unreachable
+          rc=$?
+          set -e
+          case "$rc" in
+            0)
+              echo "Live ledger invariants measured and hold."
+              ;;
+            2)
+              echo "::warning title=Live node unreachable::Live ledger invariants could NOT be measured. No violation was observed, and none was ruled out."
+              ;;
+            *)
+              echo "::error title=Ledger invariant violated::The live chain violated a ledger invariant (exit $rc). This is never tolerated."
+              exit "$rc"
+              ;;
+          esac
         timeout-minutes: 5
 
-      - name: Upload test report
+      # The report is written by the script straight to a file. It used to be
+      # `--report > report.json 2>&1 || true`, which piped stderr INTO the JSON
+      # and swallowed the exit code — so a crash uploaded an artifact named
+      # "report" that actually contained a Python traceback, and the run was
+      # green. Now: stderr stays on stderr, and a crash fails the step.
+      - name: Generate JSON report
         if: always()
         run: |
           python testing/ledger_invariants.py \
             --scenarios 100 \
-            --report > ledger_invariants_report.json 2>&1 || true
-      
+            --report-file ledger_invariants_report.json
+
+      - name: Verify report is valid JSON
+        if: always()
+        run: |
+          test -s ledger_invariants_report.json
+          python -c "import json,sys; json.load(open('ledger_invariants_report.json'))"
+
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v7

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -11564,7 +11564,18 @@ def _pending_confirm_limit(raw_limit=None):
 
 def _pending_overdue_stats(c, now):
     """Read-only: how many pending transfers are past their confirm window, and
-    the oldest one's overdue seconds. Pure observability — never mutates."""
+    the oldest one's overdue seconds. Pure observability — never mutates.
+
+    On a DB error the counts come back as None, NOT 0, alongside
+    `overdue_stats_measured: False` and an explicit `overdue_stats_error`.
+
+    This used to return zeros. A locked pending_ledger therefore reported a
+    healthy "0 overdue" — which is precisely the hourly confirmer's stop
+    condition (confirm-pending.yml reads stale_pending_count, sees 0, logs
+    "queue drained", breaks, and the run goes green). RTC delivery would halt
+    while the job that exists to deliver it reported success. "Could not
+    measure" is not "nothing to do"; callers must fail closed on None.
+    """
     try:
         row = c.execute(
             """
@@ -11575,15 +11586,21 @@ def _pending_overdue_stats(c, now):
             (now, now),
         ).fetchone()
     except sqlite3.Error as e:
-        # Degrade gracefully so observability never 500s the endpoint, but LOG it:
-        # a locked DB or schema drift on pending_ledger must not masquerade as a
-        # healthy "0 overdue" — monitors that trust these fields would miss a real
-        # backlog. Narrowed from bare Exception so genuine bugs still surface.
-        print(f"[WARN] _pending_overdue_stats DB error (reporting 0 overdue): {e!r}", flush=True)
-        return {"stale_pending_count": 0, "max_confirm_overdue_seconds": 0}
+        # Degrade without 500ing the endpoint, but say plainly that the number
+        # is unknown. Narrowed from bare Exception so genuine bugs still surface.
+        print(f"[WARN] _pending_overdue_stats DB error (counts UNKNOWN, not 0): {e!r}",
+              flush=True)
+        return {
+            "stale_pending_count": None,
+            "max_confirm_overdue_seconds": None,
+            "overdue_stats_measured": False,
+            "overdue_stats_error": f"{type(e).__name__}: {e}",
+        }
     return {
         "stale_pending_count": int(row[0] or 0),
         "max_confirm_overdue_seconds": max(0, int(row[1] or 0)),
+        "overdue_stats_measured": True,
+        "overdue_stats_error": None,
     }
 
 
@@ -12061,6 +12078,11 @@ def confirm_pending():
             "errors": errors if errors else None,
             "stale_pending_count_before": before_stats["stale_pending_count"],
             "max_confirm_overdue_seconds_before": before_stats["max_confirm_overdue_seconds"],
+            "overdue_stats_measured_before": before_stats["overdue_stats_measured"],
+            # after_stats supplies stale_pending_count, max_confirm_overdue_seconds,
+            # overdue_stats_measured and overdue_stats_error. When
+            # overdue_stats_measured is False, stale_pending_count is null —
+            # callers must NOT read that as a drained queue.
             **after_stats,
         })
 

--- a/testing/ledger_invariants.py
+++ b/testing/ledger_invariants.py
@@ -21,6 +21,15 @@ Usage:
   python ledger_invariants.py --live        # Also validate against live node
   python ledger_invariants.py --scenarios N # Override scenario count (default 10000)
   python ledger_invariants.py --verbose     # Show counterexamples on failure
+  python ledger_invariants.py --report-file P  # Write pure JSON report to P
+
+Exit codes (--ci):
+  0  every invariant that COULD be evaluated holds, and everything was evaluated
+  1  an invariant was VIOLATED — never tolerate this, on any host
+  2  the live node could not be reached / could not be parsed, so some live
+     invariants COULD NOT BE MEASURED. No violation was observed, but no
+     violation was ruled out either. Distinct from 0 on purpose: "could not
+     measure" must never be reported as "passed".
 """
 
 import sys
@@ -297,27 +306,67 @@ class SimulatedLedger:
 
 # ─── Live API validation ──────────────────────────────────────────────────────
 
-def fetch_api(path: str, timeout: int = 10) -> Optional[Any]:
+class NodeUnreachable(Exception):
+    """The live node could not be reached, or did not answer with JSON.
+
+    This is deliberately a DIFFERENT condition from an invariant violation.
+    An unreachable node means an invariant could not be measured; it does not
+    mean the invariant holds, and it does not mean the invariant is broken.
+    Callers must keep the two apart — collapsing them is what let a real
+    conservation-of-supply break pass as a tolerated network blip.
+    """
+
+
+def fetch_api(path: str, timeout: int = 10) -> Any:
+    """Fetch and parse JSON from the live node.
+
+    Raises NodeUnreachable on any transport error, HTTP error, or non-JSON
+    body. A 200 response carrying HTML (an SPA answering 200 on every path)
+    is NOT a healthy node — it is an unparseable one, and is reported as such.
+    """
+    url = f"{NODE_URL}{path}"
     try:
-        url = f"{NODE_URL}{path}"
         req = urllib.request.Request(url, headers={"Accept": "application/json"})
         ctx = __import__("ssl").create_default_context()
         ctx.check_hostname = False
         ctx.verify_mode = __import__("ssl").CERT_NONE
         with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
-            return json.loads(resp.read())
+            body = resp.read()
     except Exception as e:
-        return None
+        raise NodeUnreachable(
+            f"{path}: transport error: {e.__class__.__name__}: {e}") from e
+    try:
+        return json.loads(body)
+    except Exception as e:
+        preview = body[:120].decode("utf-8", "replace") if body else "<empty>"
+        raise NodeUnreachable(
+            f"{path}: 200 response was not JSON ({e.__class__.__name__}); "
+            f"body starts: {preview!r}") from e
 
 
-def live_api_checks(verbose: bool = False) -> Tuple[int, int, List[str]]:
+def live_api_checks(verbose: bool = False) -> Tuple[int, int, List[str], List[str]]:
     """
     Validate invariants against the live RustChain node.
-    Returns (passed, failed, violation_messages).
+    Returns (passed, failed, violation_messages, unreachable_messages).
+
+    `violations` means an invariant was evaluated and BROKEN.
+    `unreachable` means an invariant could not be evaluated at all.
     """
     passed = 0
     failed = 0
-    violations = []
+    violations: List[str] = []
+    unreachable: List[str] = []
+
+    def get(path: str) -> Optional[Any]:
+        """Fetch, recording unreachability separately from violations."""
+        try:
+            return fetch_api(path)
+        except NodeUnreachable as e:
+            msg = f"UNREACHABLE {e}"
+            unreachable.append(msg)
+            if verbose:
+                print(f"  ⚠️  {msg}")
+            return None
 
     def ok(name: str):
         nonlocal passed
@@ -333,15 +382,19 @@ def live_api_checks(verbose: bool = False) -> Tuple[int, int, List[str]]:
         failed += 1
 
     # 1. Node health
-    health = fetch_api("/health")
-    if health and health.get("ok"):
+    health = get("/health")
+    if health is None:
+        pass  # already recorded as unreachable — not a violation
+    elif isinstance(health, dict) and health.get("ok"):
         ok("node_health")
     else:
-        fail("node_health", f"node not healthy: {health}")
+        # Reachable, parsed as JSON, and it says it is NOT ok. That is a real
+        # finding about a node we successfully talked to.
+        fail("node_health", f"node reachable but not healthy: {health}")
 
     # 2. Epoch data consistency
-    epoch_data = fetch_api("/epoch")
-    stats = fetch_api("/api/stats")
+    epoch_data = get("/epoch")
+    stats = get("/api/stats")
     if epoch_data and stats:
         live_epoch = epoch_data.get("epoch")
         stats_epoch = stats.get("epoch")
@@ -358,11 +411,10 @@ def live_api_checks(verbose: bool = False) -> Tuple[int, int, List[str]]:
                 ok(f"epoch_pot=1.5 RTC")
             else:
                 fail("epoch_pot", f"epoch_pot={pot} != 1.5")
-    else:
-        fail("api_availability", "could not fetch /epoch or /api/stats")
+    # else: /epoch or /api/stats was unreachable; already recorded above.
 
     # 3. Miners — check all have non-negative antiquity multipliers
-    miners = fetch_api("/api/miners")
+    miners = get("/api/miners")
     if miners is not None:
         neg_mult = [m["miner"] for m in miners
                     if m.get("antiquity_multiplier", 1.0) < 0]
@@ -397,8 +449,7 @@ def live_api_checks(verbose: bool = False) -> Tuple[int, int, List[str]]:
                             break
                 if ordering_ok:
                     ok("antiquity_ordering")
-    else:
-        fail("miners_api", "could not fetch /api/miners")
+    # else: /api/miners was unreachable; already recorded above.
 
     # 4. Total balance must be non-negative
     if stats:
@@ -408,7 +459,7 @@ def live_api_checks(verbose: bool = False) -> Tuple[int, int, List[str]]:
         else:
             fail("total_balance", f"total_balance={total_bal} < 0")
 
-    return passed, failed, violations
+    return passed, failed, violations, unreachable
 
 
 # ─── Property-based tests (Hypothesis) ───────────────────────────────────────
@@ -660,7 +711,12 @@ def main():
     parser.add_argument("--verbose", "-v", action="store_true",
                         help="Verbose output with per-test results")
     parser.add_argument("--report", action="store_true",
-                        help="Print full JSON report at the end")
+                        help="Print full JSON report at the end (mixed with "
+                             "human output on stdout — use --report-file for "
+                             "a machine-readable artifact)")
+    parser.add_argument("--report-file", metavar="PATH", default=None,
+                        help="Write the JSON report to PATH. The file contains "
+                             "ONLY JSON — no banner text, no tracebacks.")
     args = parser.parse_args()
 
     print("=" * 70)
@@ -673,12 +729,14 @@ def main():
         "scenarios_requested": args.scenarios,
         "invariants": {},
         "violations": [],
+        "unreachable": [],
         "summary": {}
     }
 
     total_passed = 0
     total_failed = 0
     all_violations = []
+    all_unreachable: List[str] = []
 
     # ── 1. Property-based tests (Hypothesis) ──────────────────────────────────
     print("\n[1/3] Property-based invariant tests (Hypothesis)...")
@@ -705,11 +763,13 @@ def main():
     # ── 3. Live API checks ────────────────────────────────────────────────────
     if args.live:
         print("\n[3/3] Live node API invariant checks...")
-        p, f, viols = live_api_checks(args.verbose)
+        p, f, viols, unreach = live_api_checks(args.verbose)
         total_passed += p
         total_failed += f
         all_violations.extend(viols)
-        results["invariants"]["live_api"] = {"passed": p, "failed": f}
+        all_unreachable.extend(unreach)
+        results["invariants"]["live_api"] = {
+            "passed": p, "failed": f, "unmeasured": len(unreach)}
     else:
         print("\n[3/3] Live API checks skipped (pass --live to enable)")
 
@@ -723,6 +783,15 @@ def main():
             print(f"  • {v}")
         if len(all_violations) > 10:
             print(f"  ... and {len(all_violations) - 10} more")
+    elif all_unreachable:
+        print(f"\n⚠️  NO VIOLATION OBSERVED, but {len(all_unreachable)} live "
+              f"check(s) COULD NOT BE MEASURED:")
+        for u in all_unreachable[:10]:
+            print(f"  • {u}")
+        if len(all_unreachable) > 10:
+            print(f"  ... and {len(all_unreachable) - 10} more")
+        print("  This is NOT the same as passing. The offline invariants hold; "
+              "the live ones were not evaluated.")
     else:
         print("\n✅ ALL INVARIANTS HOLD — RustChain ledger math is correct")
 
@@ -740,21 +809,42 @@ def main():
         print(f"  {status} {inv}")
 
     results["violations"] = all_violations
+    results["unreachable"] = all_unreachable
     results["summary"] = {
         "total_passed": total_passed,
         "total_failed": total_failed,
-        "all_invariants_hold": len(all_violations) == 0
+        "violation_count": len(all_violations),
+        "unmeasured_count": len(all_unreachable),
+        # Only true when nothing was violated AND nothing went unmeasured.
+        # An unreachable node makes this None, never True.
+        "all_invariants_hold": (
+            None if all_unreachable and not all_violations
+            else len(all_violations) == 0
+        ),
     }
 
     if args.report:
         print("\n--- JSON Report ---")
         print(json.dumps(results, indent=2))
 
+    if args.report_file:
+        # Written separately from stdout on purpose: stdout carries banner text
+        # and, if anything crashes, a traceback. A report artifact must be JSON
+        # or it must not exist.
+        with open(args.report_file, "w", encoding="utf-8") as fh:
+            json.dump(results, fh, indent=2)
+        print(f"\n[report] wrote JSON report to {args.report_file}")
+
     print("=" * 70)
 
     if args.ci and (total_failed > 0 or all_violations):
-        print("\n[CI] Exiting with code 1 — invariant violations detected")
+        print("\n[CI] Exiting with code 1 — invariant VIOLATIONS detected")
         sys.exit(1)
+
+    if args.ci and all_unreachable:
+        print("\n[CI] Exiting with code 2 — live node could not be measured. "
+              "No violation was observed, and none was ruled out.")
+        sys.exit(2)
 
     print()
 

--- a/testing/ledger_invariants.py
+++ b/testing/ledger_invariants.py
@@ -436,6 +436,21 @@ def live_api_checks(verbose: bool = False) -> Tuple[int, int, List[str], List[st
     # an invariant we could not MEASURE — it is not a violation, and it is not a
     # pass either.
     miners = get("/api/miners")
+    if isinstance(miners, dict):
+        # The live node wraps the rows in an envelope. Iterating the dict
+        # directly yielded its KEYS — plain strings — which is what produced
+        # `'str' object has no attribute 'get'`. Unwrap using the same key
+        # order tools/rustchain-health.py already uses, so both readers agree
+        # on the schema.
+        for _key in ("miners", "data", "items"):
+            if isinstance(miners.get(_key), list):
+                miners = miners[_key]
+                break
+        else:
+            unreachable.append(
+                f"UNMEASURED /api/miners: object with no miners/data/items list "
+                f"(keys: {sorted(miners)[:8]})")
+            miners = None
     if miners is not None and not isinstance(miners, list):
         unreachable.append(
             f"UNMEASURED /api/miners: expected a JSON list, got "

--- a/testing/ledger_invariants.py
+++ b/testing/ledger_invariants.py
@@ -26,10 +26,13 @@ Usage:
 Exit codes (--ci):
   0  every invariant that COULD be evaluated holds, and everything was evaluated
   1  an invariant was VIOLATED — never tolerate this, on any host
-  2  the live node could not be reached / could not be parsed, so some live
-     invariants COULD NOT BE MEASURED. No violation was observed, but no
-     violation was ruled out either. Distinct from 0 on purpose: "could not
-     measure" must never be reported as "passed".
+  2  the live node could not be reached / could not be parsed / answered in an
+     unreadable shape, so some live invariants COULD NOT BE MEASURED. No
+     violation was observed, but no violation was ruled out either. Distinct
+     from 0 on purpose: "could not measure" must never be reported as "passed".
+  3  the CHECKER itself crashed. A bug in this suite, not a verdict about the
+     chain. Still a failure — a guard that cannot run is a broken guard — but
+     it must not be reported as "the chain violated an invariant".
 """
 
 import sys
@@ -37,6 +40,7 @@ import time
 import json
 import random
 import argparse
+import traceback
 import urllib.request
 import urllib.error
 from dataclasses import dataclass, field
@@ -395,6 +399,15 @@ def live_api_checks(verbose: bool = False) -> Tuple[int, int, List[str], List[st
     # 2. Epoch data consistency
     epoch_data = get("/epoch")
     stats = get("/api/stats")
+    for _name, _val in (("/epoch", epoch_data), ("/api/stats", stats)):
+        if _val is not None and not isinstance(_val, dict):
+            unreachable.append(
+                f"UNMEASURED {_name}: expected a JSON object, got "
+                f"{type(_val).__name__}")
+    if not isinstance(epoch_data, dict):
+        epoch_data = None
+    if not isinstance(stats, dict):
+        stats = None
     if epoch_data and stats:
         live_epoch = epoch_data.get("epoch")
         stats_epoch = stats.get("epoch")
@@ -414,7 +427,31 @@ def live_api_checks(verbose: bool = False) -> Tuple[int, int, List[str], List[st
     # else: /epoch or /api/stats was unreachable; already recorded above.
 
     # 3. Miners — check all have non-negative antiquity multipliers
+    #
+    # The payload shape is validated before anything indexes into it. The live
+    # node currently answers /api/miners with a JSON list of miner-id STRINGS,
+    # not objects, and the unguarded `m.get(...)` below used to raise
+    # AttributeError mid-check. `continue-on-error: true` swallowed that crash
+    # for as long as it was there, so nobody saw it. A payload we cannot read is
+    # an invariant we could not MEASURE — it is not a violation, and it is not a
+    # pass either.
     miners = get("/api/miners")
+    if miners is not None and not isinstance(miners, list):
+        unreachable.append(
+            f"UNMEASURED /api/miners: expected a JSON list, got "
+            f"{type(miners).__name__}")
+        miners = None
+    elif miners:
+        non_dict = [m for m in miners if not isinstance(m, dict)]
+        if non_dict:
+            unreachable.append(
+                f"UNMEASURED /api/miners: {len(non_dict)}/{len(miners)} entries "
+                f"are not objects (first is {type(non_dict[0]).__name__}: "
+                f"{str(non_dict[0])[:60]!r}); antiquity multipliers cannot be "
+                f"read from this shape")
+            if verbose:
+                print(f"  ⚠️  {unreachable[-1]}")
+            miners = None
     if miners is not None:
         neg_mult = [m["miner"] for m in miners
                     if m.get("antiquity_multiplier", 1.0) < 0]
@@ -454,7 +491,11 @@ def live_api_checks(verbose: bool = False) -> Tuple[int, int, List[str], List[st
     # 4. Total balance must be non-negative
     if stats:
         total_bal = stats.get("total_balance", 0)
-        if total_bal >= 0:
+        if not isinstance(total_bal, (int, float)) or isinstance(total_bal, bool):
+            unreachable.append(
+                f"UNMEASURED /api/stats: total_balance is "
+                f"{type(total_bal).__name__} ({str(total_bal)[:40]!r}), not a number")
+        elif total_bal >= 0:
             ok(f"total_balance >= 0 ({total_bal:.4f} RTC)")
         else:
             fail("total_balance", f"total_balance={total_bal} < 0")
@@ -761,15 +802,29 @@ def main():
     results["invariants"]["simulation"] = {"passed": p, "failed": f}
 
     # ── 3. Live API checks ────────────────────────────────────────────────────
+    checker_error = None
     if args.live:
         print("\n[3/3] Live node API invariant checks...")
-        p, f, viols, unreach = live_api_checks(args.verbose)
+        try:
+            p, f, viols, unreach = live_api_checks(args.verbose)
+        except Exception as e:
+            # A crash in the CHECKER is not a verdict about the chain. Reporting
+            # it as "the live chain violated an invariant" would be a lie in the
+            # opposite direction from the one this suite is meant to prevent.
+            # It still fails the run — a guard that cannot run is a broken guard
+            # — but under its own name and exit code.
+            checker_error = f"{type(e).__name__}: {e}"
+            p = f = 0
+            viols, unreach = [], []
+            print(f"\n💥 live_api_checks CRASHED: {checker_error}")
+            traceback.print_exc(file=sys.stderr)
         total_passed += p
         total_failed += f
         all_violations.extend(viols)
         all_unreachable.extend(unreach)
         results["invariants"]["live_api"] = {
-            "passed": p, "failed": f, "unmeasured": len(unreach)}
+            "passed": p, "failed": f, "unmeasured": len(unreach),
+            "checker_error": checker_error}
     else:
         print("\n[3/3] Live API checks skipped (pass --live to enable)")
 
@@ -810,15 +865,18 @@ def main():
 
     results["violations"] = all_violations
     results["unreachable"] = all_unreachable
+    results["checker_error"] = checker_error
     results["summary"] = {
         "total_passed": total_passed,
         "total_failed": total_failed,
         "violation_count": len(all_violations),
         "unmeasured_count": len(all_unreachable),
-        # Only true when nothing was violated AND nothing went unmeasured.
-        # An unreachable node makes this None, never True.
+        "checker_error": checker_error,
+        # Only true when nothing was violated AND nothing went unmeasured AND
+        # the checker itself ran to completion. Anything else is None, never
+        # True.
         "all_invariants_hold": (
-            None if all_unreachable and not all_violations
+            None if (all_unreachable or checker_error) and not all_violations
             else len(all_violations) == 0
         ),
     }
@@ -840,6 +898,12 @@ def main():
     if args.ci and (total_failed > 0 or all_violations):
         print("\n[CI] Exiting with code 1 — invariant VIOLATIONS detected")
         sys.exit(1)
+
+    if args.ci and checker_error:
+        print(f"\n[CI] Exiting with code 3 — the CHECKER crashed "
+              f"({checker_error}). This is a bug in this suite, not a verdict "
+              f"about the chain.")
+        sys.exit(3)
 
     if args.ci and all_unreachable:
         print("\n[CI] Exiting with code 2 — live node could not be measured. "

--- a/tests/test_rustchain_health.py
+++ b/tests/test_rustchain_health.py
@@ -68,12 +68,13 @@ def test_fetch_parses_json_and_sets_headers(rustchain_health_module, monkeypatch
     monkeypatch.setattr(rustchain_health_module, "urlopen", fake_urlopen)
     monkeypatch.setattr(rustchain_health_module.time, "time", lambda: next(times))
 
-    ok, data, latency = rustchain_health_module.fetch(
+    reachable, parsed, data, latency = rustchain_health_module.fetch(
         "https://node.example/health",
         timeout=3,
     )
 
-    assert ok is True
+    assert reachable is True
+    assert parsed is True
     assert data == {"ok": True, "version": "2.2.1"}
     assert latency == pytest.approx(125.0)
     assert response.read_size == 2 * 1024 * 1024
@@ -98,10 +99,14 @@ def test_fetch_returns_text_and_error_payloads(rustchain_health_module, monkeypa
     monkeypatch.setattr(rustchain_health_module, "urlopen", fake_text_urlopen)
     monkeypatch.setattr(rustchain_health_module.time, "time", lambda: next(times))
 
-    ok, data, latency = rustchain_health_module.fetch("https://node.example/plain")
+    reachable, parsed, data, latency = rustchain_health_module.fetch(
+        "https://node.example/plain")
 
-    assert ok is True
-    assert data == "node online"
+    # A 200 carrying non-JSON is reachable but NOT parsed. It used to come back
+    # as ok=True, which is the whole bug.
+    assert reachable is True
+    assert parsed is False
+    assert "not JSON" in data
     assert latency == pytest.approx(50.0)
 
     def fake_error_urlopen(_request, timeout, context):
@@ -109,17 +114,75 @@ def test_fetch_returns_text_and_error_payloads(rustchain_health_module, monkeypa
 
     monkeypatch.setattr(rustchain_health_module, "urlopen", fake_error_urlopen)
 
-    ok, data, latency = rustchain_health_module.fetch("https://node.example/down")
+    reachable, parsed, data, latency = rustchain_health_module.fetch(
+        "https://node.example/down")
 
-    assert ok is False
+    assert reachable is False
+    assert parsed is False
     assert "node offline" in data
     assert latency == pytest.approx(75.0)
+
+
+def test_spa_answering_200_on_every_path_is_not_healthy(
+    rustchain_health_module,
+    monkeypatch,
+):
+    """Regression: the CognetCloud / Node-4 failure mode.
+
+    After that node was taken down the host began serving an unrelated
+    single-page app that answers 200 on every unknown path. /health and /epoch
+    both returned 200 with HTML. The old CLI reported four green dots,
+    "ALL SYSTEMS OPERATIONAL", and exit 0 — indefinitely.
+    """
+    spa_body = b"<!doctype html><title>New API</title><div id=app></div>"
+
+    monkeypatch.setattr(rustchain_health_module, "_ssl_ctx", lambda: "ssl-context")
+    monkeypatch.setattr(
+        rustchain_health_module,
+        "urlopen",
+        lambda _request, timeout, context: FakeHTTPResponse(spa_body),
+    )
+
+    snapshot = rustchain_health_module.collect("https://spa.example", timeout=5)
+
+    for name in ("health", "epoch", "miners", "tip"):
+        assert snapshot[name]["reachable"] is True, name
+        assert snapshot[name]["parsed"] is False, name
+        assert snapshot[name]["ok"] is False, name
+
+    assert snapshot["overall_ok"] is False
+    assert rustchain_health_module.overall_ok(snapshot) is False
+
+    rendered = rustchain_health_module.render(snapshot)
+    assert "STATUS: ISSUES DETECTED" in rendered
+    assert "ALL SYSTEMS OPERATIONAL" not in rendered
+    assert "Answered 200 but not with JSON" in rendered
+
+
+def test_health_endpoint_reporting_ok_false_is_not_healthy(
+    rustchain_health_module,
+    monkeypatch,
+):
+    """A node that answers JSON saying ok=false is unhealthy, not merely reachable."""
+    monkeypatch.setattr(
+        rustchain_health_module,
+        "fetch",
+        lambda _url, _timeout: (True, True, {"ok": False, "version": "2.2.1"}, 5.0),
+    )
+
+    result = rustchain_health_module.check_health("https://node.example", 5)
+
+    assert result["reachable"] is True
+    assert result["parsed"] is True
+    assert result["ok"] is False
+    assert "did not report ok=true" in result["error"]
 
 
 def test_check_helpers_shape_endpoint_responses(rustchain_health_module, monkeypatch):
     miner_rows = [{"miner_id": f"miner-{idx}"} for idx in range(12)]
     responses = {
         "https://node.example/health": (
+            True,
             True,
             {
                 "ok": True,
@@ -132,6 +195,7 @@ def test_check_helpers_shape_endpoint_responses(rustchain_health_module, monkeyp
         ),
         "https://node.example/epoch": (
             True,
+            True,
             {
                 "epoch": 7,
                 "slot": 99,
@@ -142,8 +206,9 @@ def test_check_helpers_shape_endpoint_responses(rustchain_health_module, monkeyp
             },
             22.22,
         ),
-        "https://node.example/api/miners": (True, miner_rows, 33.33),
+        "https://node.example/api/miners": (True, True, miner_rows, 33.33),
         "https://node.example/headers/tip": (
+            True,
             True,
             {
                 "block_height": 123,
@@ -163,6 +228,7 @@ def test_check_helpers_shape_endpoint_responses(rustchain_health_module, monkeyp
 
     assert rustchain_health_module.check_health("https://node.example", 5) == {
         "reachable": True,
+        "parsed": True,
         "latency_ms": 12.3,
         "ok": True,
         "version": "2.2.1",
@@ -172,6 +238,7 @@ def test_check_helpers_shape_endpoint_responses(rustchain_health_module, monkeyp
     }
     assert rustchain_health_module.check_epoch("https://node.example", 5) == {
         "reachable": True,
+        "parsed": True,
         "latency_ms": 22.2,
         "epoch": 7,
         "slot": 99,
@@ -179,16 +246,20 @@ def test_check_helpers_shape_endpoint_responses(rustchain_health_module, monkeyp
         "enrolled_miners": 4,
         "blocks_per_epoch": 100,
         "total_supply_rtc": 8300000,
+        "ok": True,
     }
     miners = rustchain_health_module.check_miners("https://node.example", 5)
     assert miners["miner_count"] == 12
     assert miners["miners"] == miner_rows[:10]
+    assert miners["ok"] is True
     assert rustchain_health_module.check_tip("https://node.example", 5) == {
         "reachable": True,
+        "parsed": True,
         "latency_ms": 44.4,
         "height": 123,
         "hash": "0123456789abcdefXYZ",
         "timestamp": "2026-05-13T00:00:00Z",
+        "ok": True,
     }
     assert calls == [
         ("https://node.example/health", 5),
@@ -204,12 +275,14 @@ def test_check_miners_accepts_items_envelope(rustchain_health_module, monkeypatc
     monkeypatch.setattr(
         rustchain_health_module,
         "fetch",
-        lambda _url, _timeout: (True, {"items": miner_rows}, 7.0),
+        lambda _url, _timeout: (True, True, {"items": miner_rows}, 7.0),
     )
 
     result = rustchain_health_module.check_miners("https://node.example", 5)
 
     assert result["reachable"] is True
+    assert result["parsed"] is True
+    assert result["ok"] is True
     assert result["latency_ms"] == 7.0
     assert result["miner_count"] == 2
     assert result["miners"] == miner_rows
@@ -219,15 +292,18 @@ def test_check_helpers_handle_raw_dict_and_error_edges(
     rustchain_health_module,
     monkeypatch,
 ):
+    # /health and /epoch answer 200 with a non-JSON body: reachable, unparsed,
+    # and therefore NOT ok. /headers/tip is outright unreachable.
     responses = {
-        "https://node.example/health": (True, "plain health", 10.0),
-        "https://node.example/epoch": (True, "plain epoch", 20.0),
+        "https://node.example/health": (True, False, "200 response was not JSON", 10.0),
+        "https://node.example/epoch": (True, False, "200 response was not JSON", 20.0),
         "https://node.example/api/miners": (
+            True,
             True,
             {"miners": [{"id": "alice"}, {"id": "bob"}]},
             30.0,
         ),
-        "https://node.example/headers/tip": (False, "tip timeout", 40.0),
+        "https://node.example/headers/tip": (False, False, "tip timeout", 40.0),
     }
 
     def fake_fetch(url, _timeout):
@@ -237,24 +313,31 @@ def test_check_helpers_handle_raw_dict_and_error_edges(
 
     assert rustchain_health_module.check_health("https://node.example", 5) == {
         "reachable": True,
+        "parsed": False,
         "latency_ms": 10.0,
-        "ok": True,
-        "raw": "plain health",
+        "ok": False,
+        "error": "200 response was not JSON",
     }
     assert rustchain_health_module.check_epoch("https://node.example", 5) == {
         "reachable": True,
+        "parsed": False,
         "latency_ms": 20.0,
-        "raw": "plain epoch",
+        "ok": False,
+        "error": "200 response was not JSON",
     }
     assert rustchain_health_module.check_miners("https://node.example", 5) == {
         "reachable": True,
+        "parsed": True,
         "latency_ms": 30.0,
         "miner_count": 2,
         "miners": [{"id": "alice"}, {"id": "bob"}],
+        "ok": True,
     }
     assert rustchain_health_module.check_tip("https://node.example", 5) == {
         "reachable": False,
+        "parsed": False,
         "latency_ms": 40.0,
+        "ok": False,
         "error": "tip timeout",
     }
 
@@ -265,7 +348,7 @@ def test_collect_strips_base_url_and_uses_checks(rustchain_health_module, monkey
     def fake_check(name):
         def _check(base, timeout):
             calls.append((name, base, timeout))
-            return {"name": name}
+            return {"name": name, "ok": True}
 
         return _check
 
@@ -285,10 +368,11 @@ def test_collect_strips_base_url_and_uses_checks(rustchain_health_module, monkey
     assert snapshot == {
         "node": "https://node.example",
         "checked_at": "2026-05-13T00:00:00Z",
-        "health": {"name": "health"},
-        "epoch": {"name": "epoch"},
-        "miners": {"name": "miners"},
-        "tip": {"name": "tip"},
+        "health": {"name": "health", "ok": True},
+        "epoch": {"name": "epoch", "ok": True},
+        "miners": {"name": "miners", "ok": True},
+        "tip": {"name": "tip", "ok": True},
+        "overall_ok": True,
     }
     assert calls == [
         ("health", "https://node.example", 6),
@@ -304,6 +388,7 @@ def test_render_reports_healthy_and_unhealthy_snapshots(rustchain_health_module)
         "checked_at": "2026-05-13T00:00:00Z",
         "health": {
             "reachable": True,
+            "parsed": True,
             "latency_ms": 12.2,
             "ok": True,
             "version": "2.2.1",
@@ -312,6 +397,8 @@ def test_render_reports_healthy_and_unhealthy_snapshots(rustchain_health_module)
         },
         "epoch": {
             "reachable": True,
+            "parsed": True,
+            "ok": True,
             "latency_ms": 23.4,
             "epoch": 7,
             "slot": 42,
@@ -321,6 +408,8 @@ def test_render_reports_healthy_and_unhealthy_snapshots(rustchain_health_module)
         },
         "tip": {
             "reachable": True,
+            "parsed": True,
+            "ok": True,
             "latency_ms": 34.5,
             "height": 123,
             "hash": "0123456789abcdefXYZ",
@@ -328,6 +417,8 @@ def test_render_reports_healthy_and_unhealthy_snapshots(rustchain_health_module)
         },
         "miners": {
             "reachable": True,
+            "parsed": True,
+            "ok": True,
             "latency_ms": 45.6,
             "miner_count": 6,
             "miners": [

--- a/tests/test_rustchain_health_cli.py
+++ b/tests/test_rustchain_health_cli.py
@@ -36,13 +36,14 @@ def test_check_helpers_normalize_successful_payloads():
     module = load_module()
 
     with patch.object(module, "fetch", side_effect=[
-        (True, {"ok": True, "version": "1.2", "uptime_s": 61, "db_rw": True}, 12.34),
-        (True, {"epoch": 7, "slot": 99, "epoch_pot": 1.5, "enrolled_miners": 3}, 2.0),
-        (True, [{"miner_id": "m1"}, {"miner": "m2"}], 3.0),
-        (True, {"block_height": 55, "block_hash": "abc", "timestamp": "now"}, 4.0),
+        (True, True, {"ok": True, "version": "1.2", "uptime_s": 61, "db_rw": True}, 12.34),
+        (True, True, {"epoch": 7, "slot": 99, "epoch_pot": 1.5, "enrolled_miners": 3}, 2.0),
+        (True, True, [{"miner_id": "m1"}, {"miner": "m2"}], 3.0),
+        (True, True, {"block_height": 55, "block_hash": "abc", "timestamp": "now"}, 4.0),
     ]):
         assert module.check_health("https://node", 5) == {
             "reachable": True,
+            "parsed": True,
             "latency_ms": 12.3,
             "ok": True,
             "version": "1.2",
@@ -58,22 +59,33 @@ def test_check_helpers_normalize_successful_payloads():
 def test_check_helpers_handle_errors_and_non_dict_payloads():
     module = load_module()
 
+    # Second and fourth responses are 200s carrying non-JSON. They are
+    # reachable but unparsed, and must come back ok=False — never as a healthy
+    # endpoint with a "raw" field.
     with patch.object(module, "fetch", side_effect=[
-        (False, "offline", 1.0),
-        (True, "ok text", 2.0),
-        (False, "miners down", 3.0),
-        (True, "tip text", 4.0),
+        (False, False, "offline", 1.0),
+        (True, False, "200 response was not JSON: ok text", 2.0),
+        (False, False, "miners down", 3.0),
+        (True, False, "200 response was not JSON: tip text", 4.0),
     ]):
         health = module.check_health("https://node", 5)
         epoch = module.check_epoch("https://node", 5)
         miners = module.check_miners("https://node", 5)
         tip = module.check_tip("https://node", 5)
 
-    assert health == {"reachable": False, "latency_ms": 1.0, "ok": False, "error": "offline"}
-    assert epoch["raw"] == "ok text"
+    assert health == {
+        "reachable": False, "parsed": False, "latency_ms": 1.0,
+        "ok": False, "error": "offline",
+    }
+    assert epoch["ok"] is False
+    assert epoch["reachable"] is True
+    assert "not JSON" in epoch["error"]
     assert miners["miner_count"] == 0
+    assert miners["ok"] is False
     assert miners["error"] == "miners down"
-    assert tip["raw"] == "tip text"
+    assert tip["ok"] is False
+    assert tip["reachable"] is True
+    assert "not JSON" in tip["error"]
 
 
 def test_collect_strips_trailing_slash_and_calls_all_checks():
@@ -81,10 +93,10 @@ def test_collect_strips_trailing_slash_and_calls_all_checks():
 
     with (
         patch.object(module.time, "strftime", return_value="2026-05-14T04:59:00Z"),
-        patch.object(module, "check_health", return_value={"reachable": True}) as health,
-        patch.object(module, "check_epoch", return_value={"reachable": True}) as epoch,
-        patch.object(module, "check_miners", return_value={"reachable": True}) as miners,
-        patch.object(module, "check_tip", return_value={"reachable": True}) as tip,
+        patch.object(module, "check_health", return_value={"reachable": True, "ok": True}) as health,
+        patch.object(module, "check_epoch", return_value={"reachable": True, "ok": True}) as epoch,
+        patch.object(module, "check_miners", return_value={"reachable": True, "ok": True}) as miners,
+        patch.object(module, "check_tip", return_value={"reachable": True, "ok": True}) as tip,
     ):
         snapshot = module.collect("https://node/", timeout=4)
 
@@ -101,10 +113,10 @@ def test_render_reports_operational_and_issue_states():
     snapshot = {
         "node": "https://node",
         "checked_at": "2026-05-14T04:59:00Z",
-        "health": {"reachable": True, "ok": True, "latency_ms": 1.2, "version": "1.0", "uptime_s": 3661},
-        "epoch": {"reachable": True, "latency_ms": 2.0, "epoch": 3, "slot": 9},
-        "miners": {"reachable": True, "latency_ms": 3.0, "miner_count": 1, "miners": [{"miner_id": "m1"}]},
-        "tip": {"reachable": True, "latency_ms": 4.0, "height": 10, "hash": "a" * 20},
+        "health": {"reachable": True, "parsed": True, "ok": True, "latency_ms": 1.2, "version": "1.0", "uptime_s": 3661},
+        "epoch": {"reachable": True, "parsed": True, "ok": True, "latency_ms": 2.0, "epoch": 3, "slot": 9},
+        "miners": {"reachable": True, "parsed": True, "ok": True, "latency_ms": 3.0, "miner_count": 1, "miners": [{"miner_id": "m1"}]},
+        "tip": {"reachable": True, "parsed": True, "ok": True, "latency_ms": 4.0, "height": 10, "hash": "a" * 20},
     }
 
     rendered = module.render(snapshot)
@@ -113,5 +125,6 @@ def test_render_reports_operational_and_issue_states():
     assert "Hash           : aaaaaaaaaaaaaaaa..." in rendered
     assert "- m1" in rendered
 
-    snapshot["health"] = {"reachable": False, "ok": False, "latency_ms": 1.0, "error": "offline"}
+    snapshot["health"] = {"reachable": False, "parsed": False, "ok": False,
+                          "latency_ms": 1.0, "error": "offline"}
     assert "STATUS: ISSUES DETECTED" in module.render(snapshot)

--- a/tools/rustchain-health.py
+++ b/tools/rustchain-health.py
@@ -16,6 +16,14 @@ Usage:
     python rustchain-health.py -u http://localhost:5000  # custom node
     python rustchain-health.py --watch 10                # refresh every 10s
     python rustchain-health.py --json                    # machine-readable output
+
+Exit codes:
+    0  every check returned a JSON answer saying it is fine
+    1  at least one check failed, or could not be evaluated
+
+A node is judged on its response BODY, never on its status code. A host that
+answers 200 on every path (for example a single-page app parked on a
+decommissioned node's address) is reported as unhealthy, because it is.
 """
 
 from __future__ import annotations
@@ -71,8 +79,23 @@ def _ssl_ctx() -> ssl.SSLContext:
     ctx.verify_mode = ssl.CERT_NONE
     return ctx
 
-def fetch(url: str, timeout: int = 8) -> Tuple[bool, Any, float]:
-    """GET *url*, return (ok, parsed_json_or_None, latency_ms)."""
+def fetch(url: str, timeout: int = 8) -> Tuple[bool, bool, Any, float]:
+    """GET *url*, return (reachable, parsed, payload, latency_ms).
+
+    reachable — the transport succeeded and the server answered at all.
+    parsed    — the body was valid JSON.
+    payload   — the decoded JSON on success, otherwise an error string.
+
+    The two flags are kept apart on purpose. A 200 response carrying HTML is
+    reachable but NOT parsed, and a node that is merely reachable has told us
+    nothing about its health. This is the CognetCloud / Node-4 failure: after
+    that operator took the node down, the host began serving an unrelated
+    single-page app which answers 200 on *every* unknown path — so /health and
+    /epoch both returned 200 with HTML, and a checker that trusted the status
+    code reported the dead node healthy indefinitely.
+
+    Check the body. Never the status code alone.
+    """
     t0 = time.time()
     try:
         req = Request(url, headers={
@@ -83,82 +106,135 @@ def fetch(url: str, timeout: int = 8) -> Tuple[bool, Any, float]:
             body = resp.read(2 * 1024 * 1024).decode("utf-8", errors="replace")
             latency = (time.time() - t0) * 1000
             try:
-                return True, json.loads(body), latency
-            except json.JSONDecodeError:
-                return True, body.strip(), latency
+                return True, True, json.loads(body), latency
+            except json.JSONDecodeError as exc:
+                preview = body.strip()[:120]
+                return True, False, (
+                    f"200 response was not JSON ({exc.msg}); "
+                    f"body starts: {preview!r}"
+                ), latency
     except (HTTPError, URLError, OSError) as exc:
         latency = (time.time() - t0) * 1000
-        return False, str(exc), latency
+        return False, False, str(exc), latency
 
 # ── individual checks ──────────────────────────────────────────────────────
 
+# Every check below reports three separate facts:
+#   reachable — the server answered
+#   parsed    — the answer was JSON
+#   ok        — the answer said the thing we are checking is actually fine
+# `ok` is the ONLY one used for the status dot, the aggregate, and the exit
+# code. Reachability alone never means healthy.
+
 def check_health(base: str, timeout: int) -> Dict[str, Any]:
-    ok, data, ms = fetch(f"{base}/health", timeout)
-    result: Dict[str, Any] = {"reachable": ok, "latency_ms": round(ms, 1)}
-    if ok and isinstance(data, dict):
-        result["ok"] = data.get("ok", False)
+    reachable, parsed, data, ms = fetch(f"{base}/health", timeout)
+    result: Dict[str, Any] = {
+        "reachable": reachable, "parsed": parsed, "latency_ms": round(ms, 1)}
+    if parsed and isinstance(data, dict):
+        # The node's own verdict, defaulting to NOT ok when the field is absent.
+        result["ok"] = bool(data.get("ok", False))
         result["version"] = data.get("version")
         result["uptime_s"] = data.get("uptime_s")
         result["db_rw"] = data.get("db_rw")
         result["tip_age_slots"] = data.get("tip_age_slots")
-    elif ok:
-        result["ok"] = True
-        result["raw"] = str(data)[:200]
+        if not result["ok"]:
+            result["error"] = "node answered /health but did not report ok=true"
+    elif parsed:
+        # Valid JSON but not an object — not a /health response.
+        result["ok"] = False
+        result["error"] = f"/health returned JSON that is not an object: {str(data)[:120]}"
     else:
         result["ok"] = False
         result["error"] = str(data)
     return result
 
 def check_epoch(base: str, timeout: int) -> Dict[str, Any]:
-    ok, data, ms = fetch(f"{base}/epoch", timeout)
-    result: Dict[str, Any] = {"reachable": ok, "latency_ms": round(ms, 1)}
-    if ok and isinstance(data, dict):
+    reachable, parsed, data, ms = fetch(f"{base}/epoch", timeout)
+    result: Dict[str, Any] = {
+        "reachable": reachable, "parsed": parsed, "latency_ms": round(ms, 1)}
+    if parsed and isinstance(data, dict):
         result["epoch"] = data.get("epoch")
         result["slot"] = data.get("slot")
         result["epoch_pot"] = data.get("epoch_pot")
         result["enrolled_miners"] = data.get("enrolled_miners")
         result["blocks_per_epoch"] = data.get("blocks_per_epoch")
         result["total_supply_rtc"] = data.get("total_supply_rtc")
-    elif ok:
-        result["raw"] = str(data)[:200]
+        result["ok"] = result["epoch"] is not None
+        if not result["ok"]:
+            result["error"] = "/epoch response carried no 'epoch' field"
+    elif parsed:
+        result["ok"] = False
+        result["error"] = f"/epoch returned JSON that is not an object: {str(data)[:120]}"
     else:
+        result["ok"] = False
         result["error"] = str(data)
     return result
 
 def check_miners(base: str, timeout: int) -> Dict[str, Any]:
-    ok, data, ms = fetch(f"{base}/api/miners", timeout)
-    result: Dict[str, Any] = {"reachable": ok, "latency_ms": round(ms, 1)}
-    if ok and isinstance(data, list):
+    reachable, parsed, data, ms = fetch(f"{base}/api/miners", timeout)
+    result: Dict[str, Any] = {
+        "reachable": reachable, "parsed": parsed, "latency_ms": round(ms, 1)}
+    if parsed and isinstance(data, list):
         result["miner_count"] = len(data)
         result["miners"] = data[:10]  # first 10 for display
-    elif ok and isinstance(data, dict):
+        result["ok"] = True
+    elif parsed and isinstance(data, dict):
         miners = data.get("miners", data.get("data", data.get("items", [])))
-        result["miner_count"] = len(miners) if isinstance(miners, list) else data.get("count", "?")
         if isinstance(miners, list):
+            result["miner_count"] = len(miners)
             result["miners"] = miners[:10]
+            result["ok"] = True
+        else:
+            count = data.get("count")
+            result["miner_count"] = count if isinstance(count, int) else 0
+            result["ok"] = isinstance(count, int)
+            if not result["ok"]:
+                result["error"] = "/api/miners response contained no miner list or count"
     else:
         result["miner_count"] = 0
-        result["error"] = str(data) if not ok else None
+        result["ok"] = False
+        result["error"] = str(data)
     return result
 
 def check_tip(base: str, timeout: int) -> Dict[str, Any]:
-    ok, data, ms = fetch(f"{base}/headers/tip", timeout)
-    result: Dict[str, Any] = {"reachable": ok, "latency_ms": round(ms, 1)}
-    if ok and isinstance(data, dict):
+    reachable, parsed, data, ms = fetch(f"{base}/headers/tip", timeout)
+    result: Dict[str, Any] = {
+        "reachable": reachable, "parsed": parsed, "latency_ms": round(ms, 1)}
+    if parsed and isinstance(data, dict):
         result["height"] = data.get("height", data.get("block_height"))
         result["hash"] = data.get("hash", data.get("block_hash"))
         result["timestamp"] = data.get("timestamp")
-    elif ok:
-        result["raw"] = str(data)[:200]
+        result["ok"] = result["height"] is not None
+        if not result["ok"]:
+            result["error"] = "/headers/tip response carried no height"
+    elif parsed:
+        result["ok"] = False
+        result["error"] = f"/headers/tip returned JSON that is not an object: {str(data)[:120]}"
     else:
+        result["ok"] = False
         result["error"] = str(data)
     return result
 
 # ── aggregator ──────────────────────────────────────────────────────────────
 
+CHECKS = ("health", "epoch", "miners", "tip")
+
+
+def overall_ok(snapshot: Dict[str, Any]) -> bool:
+    """True only when every check produced a JSON answer that says it is fine.
+
+    Single source of truth for the rendered banner, the JSON `overall_ok`, and
+    the process exit code. These three used to disagree: the banner and the
+    exit code both keyed off `reachable`, so a host answering 200-with-HTML on
+    every path scored four green dots, printed ALL SYSTEMS OPERATIONAL, and
+    exited 0 forever.
+    """
+    return all(snapshot[name].get("ok", False) for name in CHECKS)
+
+
 def collect(base_url: str, timeout: int = 8) -> Dict[str, Any]:
     base = base_url.rstrip("/")
-    return {
+    snapshot: Dict[str, Any] = {
         "node": base,
         "checked_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "health": check_health(base, timeout),
@@ -166,6 +242,8 @@ def collect(base_url: str, timeout: int = 8) -> Dict[str, Any]:
         "miners": check_miners(base, timeout),
         "tip": check_tip(base, timeout),
     }
+    snapshot["overall_ok"] = overall_ok(snapshot)
+    return snapshot
 
 # ── pretty printer ──────────────────────────────────────────────────────────
 
@@ -201,7 +279,7 @@ def render(snapshot: Dict[str, Any]) -> str:
 
     # ── Health ───
     h = snapshot["health"]
-    h_ok = h.get("ok", False) and h["reachable"]
+    h_ok = h.get("ok", False)
     lines.append(f"  {status_dot(h_ok)}  {bold('Health')}          "
                  f"{green('healthy') if h_ok else red('UNHEALTHY')}  "
                  f"{dim(str(round(h['latency_ms'])) + ' ms')}")
@@ -218,7 +296,7 @@ def render(snapshot: Dict[str, Any]) -> str:
 
     # ── Epoch ───
     e = snapshot["epoch"]
-    e_ok = e["reachable"] and e.get("epoch") is not None
+    e_ok = e.get("ok", False)
     lines.append(f"  {status_dot(e_ok)}  {bold('Epoch')}           "
                  f"{green(str(e.get('epoch', '?'))) if e_ok else red('unavailable')}  "
                  f"{dim(str(round(e['latency_ms'])) + ' ms')}")
@@ -237,7 +315,7 @@ def render(snapshot: Dict[str, Any]) -> str:
 
     # ── Chain Tip ───
     t = snapshot["tip"]
-    t_ok = t["reachable"] and t.get("height") is not None
+    t_ok = t.get("ok", False)
     lines.append(f"  {status_dot(t_ok)}  {bold('Chain Tip')}       "
                  f"{'#' + str(t.get('height', '?')) if t_ok else yellow('unknown')}  "
                  f"{dim(str(round(t['latency_ms'])) + ' ms')}")
@@ -251,7 +329,7 @@ def render(snapshot: Dict[str, Any]) -> str:
 
     # ── Miners ───
     m = snapshot["miners"]
-    m_ok = m["reachable"]
+    m_ok = m.get("ok", False)
     count = m.get("miner_count", 0)
     count_str = str(count) if isinstance(count, int) else str(count)
     color_count = green(count_str) if (isinstance(count, int) and count > 0) else yellow(count_str)
@@ -273,15 +351,21 @@ def render(snapshot: Dict[str, Any]) -> str:
     lines.append("")
 
     # ── Overall ───
-    all_ok = (h.get("ok", False) and h["reachable"]
-              and e["reachable"]
-              and m["reachable"]
-              and t["reachable"])
+    all_ok = overall_ok(snapshot)
     lines.append(dim("  " + "─" * w))
     if all_ok:
         lines.append(f"  {green(bold('STATUS: ALL SYSTEMS OPERATIONAL'))}")
     else:
         lines.append(f"  {red(bold('STATUS: ISSUES DETECTED'))}")
+        # Name what could not be measured, so "issues detected" is actionable
+        # rather than a bare red line.
+        unparsed = [k for k in ("health", "epoch", "miners", "tip")
+                    if snapshot[k].get("reachable") and not snapshot[k].get("parsed")]
+        if unparsed:
+            lines.append(f"  {yellow('Answered 200 but not with JSON')}: "
+                         f"{', '.join(unparsed)}")
+            lines.append(dim("  A host that answers every path with HTML is not "
+                             "a running node."))
     lines.append("")
 
     return "\n".join(lines)
@@ -355,13 +439,8 @@ def main() -> int:
             print(json.dumps(snapshot, indent=2))
         else:
             print(render(snapshot))
-        # exit 0 if healthy, 1 otherwise
-        all_ok = (snapshot["health"].get("ok", False)
-                  and snapshot["health"]["reachable"]
-                  and snapshot["epoch"]["reachable"]
-                  and snapshot["miners"]["reachable"]
-                  and snapshot["tip"]["reachable"])
-        return 0 if all_ok else 1
+        # exit 0 only if every check returned a JSON answer that says it is fine
+        return 0 if overall_ok(snapshot) else 1
 
     if args.watch > 0:
         try:


### PR DESCRIPTION
Three guards in this repo could not report a failure. Each was confirmed by reading `origin/main` today, not from memory.

They share one shape: **a check that reports success when it did not actually check anything.**

---

## 1. The ledger invariant workflow could not fail

`.github/workflows/ci_ledger_invariants.yml` — three separate defects.

### a) `continue-on-error: true` covered two different events with one outcome

```yaml
continue-on-error: true  # Live node may be temporarily unreachable
```

That comment describes one of the two things it tolerates. It cannot distinguish *"the node was briefly unreachable"* from *"the live chain **violated a ledger invariant**"* — because `live_api_checks` reported both through the same `fail()` path. A real conservation-of-supply break on the production chain went green as a network blip.

`testing/ledger_invariants.py` now keeps them apart:

- `fetch_api` raises `NodeUnreachable` on a transport error, an HTTP error, **or a 200 whose body is not JSON**
- `live_api_checks` returns unreachability as a separate list from violations
- a node that is reachable and answers `ok: false` is still a violation — that is a real finding about a node we successfully talked to

`--ci` exit codes are now `0` = holds, `1` = **violated**, `2` = could not measure. The workflow warns on `2` and fails hard on `1`.

`summary.all_invariants_hold` is `None`, never `True`, when something went unmeasured. "Could not measure" must not render as "passed".

### b) stderr was piped into the JSON report

```yaml
--report > ledger_invariants_report.json 2>&1 || true
```

`2>&1` merged stderr into the report and `|| true` swallowed the exit code, so a crash uploaded an artifact named "report" that actually contained a Python traceback — and the run was green. (`--report` also interleaved banner text with the JSON on stdout, so the artifact was never valid JSON even on the happy path.)

Added `--report-file`, which writes JSON and only JSON. The step no longer swallows failure, and a following step asserts the artifact parses.

### c) The trigger fired only on edits to the guard itself

```yaml
paths:
  - 'testing/ledger_invariants.py'
  - '.github/workflows/ci_ledger_invariants.yml'
```

A guard wired to fire only when you edit the guard. A PR changing settlement, reward, or balance code never ran the ledger invariants at all. Triggers now cover the ledger/settlement surface those invariants actually constrain (`rewards_implementation_rip200.py`, `settle_epoch.py`, `claims_settlement.py`, `lock_ledger.py`, `payout_ledger.py`, and the node itself).

> The two path lists are duplicated verbatim because GitHub Actions does not support YAML anchors. Noted in a comment so the next person keeps them in sync.

---

## 2. The health CLI reproduced the Node-4 SPA failure verbatim

`tools/rustchain-health.py`

```python
except json.JSONDecodeError:
    return True, body.strip(), latency
```

`urlopen` raises on 4xx/5xx, so only 2xx reached that line — meaning **any 200 with a non-JSON body was reported healthy**, then upgraded to `ok = True` with a `raw` field. The aggregate banner and the exit code then keyed off `reachable` for three of four checks.

Point it at a host serving a single-page app that answers 200 on every path — **the documented CognetCloud / Node-4 failure in `CLAUDE.md`** — and you got four green dots, `STATUS: ALL SYSTEMS OPERATIONAL`, and exit 0, indefinitely.

Verified end-to-end against a local SPA on `127.0.0.1` (no production host was contacted):

| | verdict | exit |
|---|---|---|
| `origin/main` | `STATUS: ALL SYSTEMS OPERATIONAL` | `0` |
| this branch | `STATUS: ISSUES DETECTED` | `1` |

```
●  Health          UNHEALTHY  14 ms
   Error: 200 response was not JSON (Expecting value); body starts: '<!doctype html><title
   ...
STATUS: ISSUES DETECTED
Answered 200 but not with JSON: health, epoch, miners, tip
A host that answers every path with HTML is not a running node.
```

`fetch()` now returns `(reachable, parsed, payload, latency)`; every check reports `reachable` / `parsed` / `ok` separately; and `overall_ok()` is the single source of truth for the banner, the JSON, and the exit code — those three used to disagree.

This brings the file in line with the correct implementation already in this repo at `tools/node-health-cli/node_health.py:86-142`, which raises on non-JSON and reads `data.get("ok", False)`. **Check the body, never the status code alone.**

### Two existing tests asserted the buggy contract

`test_fetch_returns_text_and_error_payloads` asserted `ok is True` for a 200 with a plain-text body, and `check_health(... "plain health")` was expected to return `ok: True`. Those are the bug, written down as a test. They are updated, and two regression tests were added: the full SPA case (via `collect`, asserting `overall_ok is False` and that the banner does not say OPERATIONAL) and a node answering JSON with `ok: false`.

---

## 3. A locked DB reported "0 overdue"

`node/rustchain_v2_integrated_v2.2.1_rip200.py`

The `except sqlite3.Error` block carried a comment explicitly warning that a locked DB *"must not masquerade as a healthy 0 overdue"* — and the next line returned exactly that:

```python
return {"stale_pending_count": 0, "max_confirm_overdue_seconds": 0}
```

Zero is the hourly confirmer's stop condition. `confirm-pending.yml` reads `stale_pending_count`, sees `0`, logs "queue drained", breaks, and goes green — so a locked `pending_ledger` halts RTC delivery while the job that exists to deliver it reports success.

The counts are now `None` on a DB error, alongside `overdue_stats_measured: False` and an explicit `overdue_stats_error`. The endpoint still returns 200 (observability should not 500), but it now says plainly that the number is unknown.

Verified directly against an in-memory SQLite handle:

```
healthy, 2 overdue : {'stale_pending_count': 2, ..., 'overdue_stats_measured': True}
db error           : {'stale_pending_count': None, ..., 'overdue_stats_measured': False,
                      'overdue_stats_error': 'OperationalError: no such table: pending_ledger'}
```

**The consuming workflow lives in `Scottcjn/rustchain-bounties` and is fixed in the companion PR there** — it now treats an unmeasurable queue as UNKNOWN and fails closed, while still accepting a plain integer from older node builds during the deploy window. Merging this alone is safe (the extra fields are additive); the pair is what closes the loop.

---

## What I verified, and what I did not

**Verified by running it:**
- `ledger_invariants.py` against a local fake node in three modes — healthy (`5 passed, 0 unreachable`), SPA answering 200-with-HTML (`0 passed, 4 unreachable`, no violations), and a real invariant break (`epoch_pot=2.75 != 1.5` → 1 violation). Exit codes 0 / 2 / 1 respectively.
- The JSON report file parses as JSON.
- `rustchain-health.py` end-to-end against a local SPA, old code vs new, shown above.
- `_pending_overdue_stats` against a live SQLite cursor, healthy and erroring.
- `pytest tests/ testing/` — 3889 passed. The 4 failures in `tests/test_epoch_settlement_formal.py` are **pre-existing on `origin/main`**; I confirmed this by stashing my changes and re-running.

**NOT verified:**
- **No GitHub Actions run was executed.** The workflow YAML parses under `yaml.safe_load`, and the scripts it invokes were exercised directly — but **YAML that lints is not a workflow that fails correctly**, and I have not observed this workflow going red in CI. The `case "$rc"` branching, the `::warning` / `::error` annotations, and the widened `paths` filters are unproven until a run exists.
- No production host was contacted. All live-node behaviour was reproduced against `127.0.0.1`.
- The widened trigger paths were chosen by reading the tree; whether they match the team's intended blast radius for "ledger/settlement code" is a judgement call worth a second opinion.
