### PR TITLE
fix(airdrop): require GitHub ownership proof on claim (fixes #8175)

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -790,6 +790,44 @@ class AirdropV2:
     # Claim Processing
     # ========================================================================
 
+    def _verify_github_ownership(
+        self, github_username: str, token: str
+    ) -> Tuple[bool, str]:
+        """Verify the caller controls `github_username` via a GitHub token.
+
+        Closes #8175 (cross-user airdrop claim theft): the claim endpoint
+        previously accepted any `github_username` and only checked that the
+        account EXISTS (via the GitHub API), never that the caller controls it.
+        An attacker could claim on behalf of any qualifying GitHub user and
+        redirect the airdrop to their own wallet.
+
+        We require a GitHub token whose authenticated `login` matches the
+        claimed username. Returns (True, "") on success, else (False, reason).
+        """
+        try:
+            import requests
+
+            resp = requests.get(
+                "https://api.github.com/user",
+                headers={
+                    "Authorization": f"token {token}",
+                    "Accept": "application/vnd.github.v3+json",
+                },
+                timeout=10,
+            )
+            if resp.status_code != 200:
+                return False, f"GitHub token invalid (status {resp.status_code})"
+            login = (resp.json().get("login") or "").lower()
+            if login != github_username.lower():
+                return (
+                    False,
+                    f"GitHub token owner '{login}' does not match claimed "
+                    f"username '{github_username}'",
+                )
+            return True, ""
+        except requests.RequestException as e:
+            return False, f"GitHub ownership check failed: {e}"
+
     def claim_airdrop(
         self,
         github_username: str,
@@ -818,6 +856,21 @@ class AirdropV2:
             return False, "Invalid GitHub username", None
         chain_lower = chain.lower()
         wallet_address = self._normalize_wallet_address(wallet_address, chain_lower)
+
+        # GitHub account ownership verification (closes #8175: cross-user
+        # airdrop claim theft). Without this, anyone could claim on behalf of
+        # any qualifying GitHub username and redirect tokens to their wallet.
+        # Testing mode (skip_antisybil) bypasses this, as do the unit tests.
+        if not skip_antisybil:
+            if not github_token:
+                return (
+                    False,
+                    "GitHub ownership verification required: provide a GitHub token",
+                    None,
+                )
+            owned, owner_msg = self._verify_github_ownership(github_username, github_token)
+            if not owned:
+                return False, owner_msg, None
 
         if self._has_claimed(github_username, wallet_address, chain_lower):
             return False, "Claim already exists for this GitHub account or wallet", None

--- a/node/test_airdrop_v2.py
+++ b/node/test_airdrop_v2.py
@@ -195,6 +195,62 @@ class TestEligibilityChecks(unittest.TestCase):
         self.assertFalse(result.eligible)
         self.assertIn("Already claimed", result.reason)
 
+    @patch("requests.get")
+    def test_verify_github_ownership_matches(self, mock_get):
+        """A token whose login matches the claimed user verifies ownership."""
+        mock_user = Mock()
+        mock_user.status_code = 200
+        mock_user.json.return_value = {"login": "testuser"}
+        mock_get.return_value = mock_user
+
+        ok, msg = self.airdrop._verify_github_ownership("testuser", "tok")
+        self.assertTrue(ok)
+        self.assertEqual(msg, "")
+
+    @patch("requests.get")
+    def test_verify_github_ownership_mismatch(self, mock_get):
+        """A token owned by a different account must be rejected (#8175)."""
+        mock_user = Mock()
+        mock_user.status_code = 200
+        mock_user.json.return_value = {"login": "attacker"}
+        mock_get.return_value = mock_user
+
+        ok, msg = self.airdrop._verify_github_ownership("testuser", "tok")
+        self.assertFalse(ok)
+        self.assertIn("does not match", msg)
+
+    @patch("requests.get")
+    def test_verify_github_ownership_invalid_token(self, mock_get):
+        """An invalid/expired token must be rejected."""
+        mock_user = Mock()
+        mock_user.status_code = 401
+        mock_user.json.return_value = {}
+        mock_get.return_value = mock_user
+
+        ok, msg = self.airdrop._verify_github_ownership("testuser", "tok")
+        self.assertFalse(ok)
+        self.assertIn("invalid", msg)
+
+    def test_claim_requires_github_ownership_token(self):
+        """Regression for #8175: a claim without a GitHub token is rejected.
+
+        Anyone could previously claim on behalf of any qualifying GitHub user
+        and redirect the airdrop to their own wallet. Production claims
+        (skip_antisybil=False) must now supply a token whose login matches the
+        claimed username.
+        """
+        success, message, claim = self.airdrop.claim_airdrop(
+            github_username="testuser",
+            wallet_address="RTC1234567890123456789012345678901234567890",
+            chain="base",
+            tier="contributor",
+            github_token=None,
+            skip_antisybil=False,
+        )
+        self.assertFalse(success)
+        self.assertIn("ownership verification required", message)
+        self.assertIsNone(claim)
+
     def test_duplicate_github_with_different_wallet_rejected(self):
         """A GitHub account cannot claim again with a different wallet."""
         success, _, _ = self.airdrop.claim_airdrop(


### PR DESCRIPTION
## Summary

The `/api/airdrop/claim` endpoint (`node/airdrop_v2.py`, `claim_airdrop`) accepted any `github_username` and only verified the account **EXISTS** via the GitHub API — never that the caller **controls** it. An attacker could submit a claim for ANY qualifying GitHub user and redirect the airdrop to their own wallet; the real user is then permanently locked out by the `_has_claimed()` dedup (`github_username = ? OR wallet_address = ?`). CRITICAL fund-theft (see #8175).

## Fix

- Add `_verify_github_ownership(github_username, token)`: `GET https://api.github.com/user` with the supplied token and assert `login == github_username`.
- Gate `claim_airdrop()` on it for **production** claims (`skip_antisybil=False`):
  - No `github_token` → rejected with `"GitHub ownership verification required: provide a GitHub token"`.
  - Token owner mismatch / invalid → rejected.
- The existing API route already forwards `github_token` from the request body, so no contract change on the route side; callers must now supply it.
- `skip_antisybil=True` (testing) bypasses the check, so existing tests are unaffected.

## Verification

- Added 4 regression tests in `test_airdrop_v2.py`:
  - `test_verify_github_ownership_matches` — token login matches → verified.
  - `test_verify_github_ownership_mismatch` — token owned by someone else → rejected.
  - `test_verify_github_ownership_invalid_token` — 401 token → rejected.
  - `test_claim_requires_github_ownership_token` — claim without token is rejected (regression for #8175).
- Full suite: `python -m unittest test_airdrop_v2` — **36 passed** (was 32; +4 new).

Fixes #8175.