### PR TITLE
feat: /wallet/transfer requires reason + idempotency_key (Phase 1+2, live on prod) + faucet caller fix

### DIFF
--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -823,12 +823,26 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
                     logger.error("RC_ADMIN_KEY not set, cannot perform real drip")
                     return jsonify({'ok': False, 'error': 'Faucet configuration error'}), 500
 
+                # Phase-2 hardening (2026-08-22): the node requires `reason`
+                # (audit attribution) and an `idempotency_key`. The key is
+                # stable per (ip, wallet, rate-limit window) so a retried or
+                # duplicated request inside one window replays to the SAME
+                # pending row instead of dripping twice.
+                window_seconds = int(config.get('rate_limit', {}).get('window_seconds', 86400)) or 86400
+                window_bucket = int(time.time()) // window_seconds
+                drip_key = (
+                    "faucet:drip:"
+                    + hashlib.sha256(f"{ip}:{wallet}".encode()).hexdigest()[:16]
+                    + f":{window_bucket}"
+                )
                 response = requests.post(
                     f"{node_url}/wallet/transfer",
                     json={
                         "from_miner": faucet_wallet,
                         "to_miner": wallet,
                         "amount_rtc": amount,
+                        "reason": f"faucet:drip:{wallet}:{datetime.utcnow().strftime('%Y-%m-%d')}",
+                        "idempotency_key": drip_key,
                     },
                     headers={"X-Admin-Key": admin_key},
                     timeout=10
@@ -1290,15 +1304,25 @@ def _perform_faucet_transfer(
     if not admin_key:
         raise RuntimeError('RC_ADMIN_KEY not set, cannot perform real drip')
 
+    # Phase-2 hardening (2026-08-22): the node requires both fields. Callers
+    # that supplied none get deterministic defaults scoped to the rate-limit
+    # window, so a duplicated claim inside one window cannot pay twice.
+    if not idempotency_key:
+        window_seconds = int(dist.get('window_seconds') or config.get('rate_limit', {}).get('window_seconds', 86400)) or 86400
+        idempotency_key = (
+            "faucet:event:"
+            + hashlib.sha256(f"{faucet_wallet}:{wallet}:{amount}".encode()).hexdigest()[:16]
+            + f":{int(time.time()) // window_seconds}"
+        )
+    if not reason:
+        reason = f"faucet:event:{wallet}:{datetime.utcnow().strftime('%Y-%m-%d')}"
     payload = {
         "from_miner": faucet_wallet,
         "to_miner": wallet,
         "amount_rtc": amount,
+        "idempotency_key": idempotency_key,
+        "reason": reason,
     }
-    if idempotency_key:
-        payload["idempotency_key"] = idempotency_key
-    if reason:
-        payload["reason"] = reason
 
     response = requests.post(
         f"{node_url}/wallet/transfer",

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -11401,15 +11401,42 @@ def wallet_transfer_v2():
     to_miner = pre.details["to_miner"]
     amount_rtc = pre.details["amount_rtc"]
     amount_i64 = int(pre.details["amount_i64"])
-    reason = str((data or {}).get('reason', 'admin_transfer'))
-    idempotency_key = ""
+    # AUDIT HARDENING (2026-08-20, live on both prod nodes): `reason` is
+    # REQUIRED (`memo` accepted as fallback attribution). 86% of historical
+    # payouts carried no attribution because the silent default
+    # "admin_transfer" was accepted.
+    raw_reason = (data or {}).get("reason") or (data or {}).get("memo")
+    if not isinstance(raw_reason, str) or not raw_reason.strip():
+        return jsonify({
+            "error": "reason_required",
+            "hint": "Pass a non-empty `reason` (or `memo`), e.g. bounty:12444:poa-vs-storage:2026-08-22"
+        }), 400
+    reason = raw_reason.strip()
+    if len(reason) > 500:
+        # Explicit rejection instead of silent truncation - a truncated
+        # reason is a corrupted audit record.
+        return jsonify({"error": "reason_too_long", "max_chars": 500}), 400
+
+    # PHASE-2 HARDENING (2026-08-22, live on both prod nodes):
+    # `idempotency_key` is REQUIRED. A keyless admin transfer is a caller that
+    # double-pays on retry, so it is rejected rather than silently accepted.
+    # Every first-party payer sends a stable key (bounty_payout, auto-pay,
+    # award_rtc, rtc-reward, rtc-pay, node_rewards, github_tip_bot, ut99,
+    # otc bridge, minecraft bridge, faucet). Error split: missing/empty ->
+    # idempotency_key_required; present-but-malformed -> invalid_idempotency_key.
     raw_idempotency_key = (data or {}).get("idempotency_key")
-    if raw_idempotency_key not in (None, ""):
-        if not isinstance(raw_idempotency_key, str):
-            return jsonify({"error": "invalid_idempotency_key"}), 400
-        idempotency_key = raw_idempotency_key.strip()
-        if not re.fullmatch(r"[A-Za-z0-9._:-]{1,128}", idempotency_key):
-            return jsonify({"error": "invalid_idempotency_key"}), 400
+    if raw_idempotency_key is None or raw_idempotency_key == "":
+        return jsonify({
+            "error": "idempotency_key_required",
+            "hint": "Pass a stable `idempotency_key` ([A-Za-z0-9._:-]{1,128}) unique to this "
+                    "payment, e.g. bounty:12444:poa-vs-storage:2026-08-22. A retry with the "
+                    "same key returns the existing pending row instead of paying twice."
+        }), 400
+    if not isinstance(raw_idempotency_key, str):
+        return jsonify({"error": "invalid_idempotency_key"}), 400
+    idempotency_key = raw_idempotency_key.strip()
+    if not re.fullmatch(r"[A-Za-z0-9._:-]{1,128}", idempotency_key):
+        return jsonify({"error": "invalid_idempotency_key"}), 400
     
     now = int(time.time())
     confirms_at = now + CONFIRMATION_DELAY_SECONDS
@@ -11441,13 +11468,30 @@ def wallet_transfer_v2():
                 if (
                     existing_from != from_miner or
                     existing_to != to_miner or
-                    int(existing_amount) != amount_i64 or
-                    str(existing_reason or "") != reason
+                    int(existing_amount) != amount_i64
                 ):
+                    # reason deliberately NOT compared: from/to/amount is the
+                    # money-relevant triple, and legacy rows stored the old
+                    # default reason "admin_transfer" - comparing it would
+                    # 409 legitimate replays of pre-hardening payments and
+                    # invite a manual re-pay under a fresh key (double-pay).
                     conn.rollback()
                     return jsonify({
                         "error": "idempotency_key_conflict",
                         "tx_hash": tx_hash,
+                    }), 409
+
+                if str(status or "") == "voided":
+                    # A voided transfer must not replay as success. Callers
+                    # that check only `ok` would read the void as "paid".
+                    # Re-issuing after a void is a deliberate act: new key.
+                    conn.rollback()
+                    return jsonify({
+                        "ok": False,
+                        "error": "idempotency_key_voided",
+                        "phase": "voided",
+                        "tx_hash": tx_hash,
+                        "hint": "This key's transfer was voided. Use a new idempotency_key to intentionally re-issue."
                     }), 409
 
                 conn.rollback()

--- a/tests/test_wallet_transfer_admin_idempotency.py
+++ b/tests/test_wallet_transfer_admin_idempotency.py
@@ -52,6 +52,9 @@ def admin_transfer_client(monkeypatch):
 
     monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
     monkeypatch.setattr(integrated_node, "current_slot", lambda: 12345)
+    # The admin per-IP rate limiter (12/min) is exercised elsewhere; here it
+    # would 429 the parametrized negative cases before the gate under test.
+    monkeypatch.setattr(integrated_node, "ADMIN_RATE_LIMIT_MAX", 0)
     monkeypatch.setenv("RC_ADMIN_KEY", "a" * 32)
 
     integrated_node.app.config["TESTING"] = True
@@ -79,6 +82,7 @@ def test_admin_transfer_idempotency_key_reuses_pending_transfer(admin_transfer_c
         "from_miner": "founder_community",
         "to_miner": "contributor",
         "amount_rtc": 1.0,
+        "reason": "bounty:123:test-payment:2026-08-22",
         "idempotency_key": "owner-repo-123-payment",
     }
 
@@ -120,6 +124,8 @@ def test_admin_transfer_uses_preflight_amount_i64_without_float_loss(admin_trans
             "from_miner": "founder_community",
             "to_miner": "contributor",
             "amount_rtc": "0.000249",
+            "reason": "test:float-loss",
+            "idempotency_key": "test-float-loss",
         },
         headers={"X-Admin-Key": "a" * 32},
     )
@@ -147,6 +153,7 @@ def test_admin_transfer_idempotency_key_rejects_changed_transfer(admin_transfer_
         "from_miner": "founder_community",
         "to_miner": "contributor",
         "amount_rtc": 1.0,
+        "reason": "bounty:123:test-payment:2026-08-22",
         "idempotency_key": "owner-repo-123-payment",
     }
 
@@ -166,3 +173,127 @@ def test_admin_transfer_idempotency_key_rejects_changed_transfer(admin_transfer_
 
     assert pending_count == 1
     assert pending_total == 1_000_000
+
+
+def _fund(db_path, amount_i64=3_000_000):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+            ("founder_community", amount_i64),
+        )
+        conn.commit()
+
+
+def _pending_count(db_path):
+    with sqlite3.connect(db_path) as conn:
+        return conn.execute("SELECT COUNT(*) FROM pending_ledger").fetchone()[0]
+
+
+_BASE = {"from_miner": "founder_community", "to_miner": "contributor", "amount_rtc": 1.0}
+_HDR = {"X-Admin-Key": "a" * 32}
+
+
+@pytest.mark.parametrize(
+    "key_field, expected_error",
+    [
+        pytest.param({}, "idempotency_key_required", id="missing"),
+        pytest.param({"idempotency_key": None}, "idempotency_key_required", id="null"),
+        pytest.param({"idempotency_key": ""}, "idempotency_key_required", id="empty"),
+        pytest.param({"idempotency_key": "   "}, "invalid_idempotency_key", id="whitespace-only"),
+        pytest.param({"idempotency_key": 123}, "invalid_idempotency_key", id="non-string"),
+        pytest.param({"idempotency_key": "bad key!"}, "invalid_idempotency_key", id="bad-charset"),
+        pytest.param({"idempotency_key": "bounty:<number>:<slug>:<date>"}, "invalid_idempotency_key", id="angle-brackets"),
+        pytest.param({"idempotency_key": "k" * 129}, "invalid_idempotency_key", id="too-long"),
+    ],
+)
+def test_admin_transfer_requires_well_formed_idempotency_key(admin_transfer_client, key_field, expected_error):
+    """Phase-2 hardening: a keyless admin transfer can double-pay on retry, so it is
+    rejected before any pending row is written. Missing/empty -> required;
+    present-but-malformed -> invalid (the two are distinct so monitors can classify)."""
+    client, db_path = admin_transfer_client
+    _fund(db_path)
+
+    payload = {**_BASE, "reason": "bounty:1:negative-test:2026-08-22", **key_field}
+    response = client.post("/wallet/transfer", json=payload, headers=_HDR)
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["error"] == expected_error
+    if expected_error == "idempotency_key_required":
+        # The hint must itself be a VALID key example (a copy-pasted hint
+        # that the regex rejects is a trap).
+        import re
+        example = body["hint"].split("e.g. ", 1)[1].split(".")[0].rstrip(".")
+        assert re.fullmatch(r"[A-Za-z0-9._:-]{1,128}", example), example
+    assert _pending_count(db_path) == 0
+
+
+def test_admin_transfer_requires_reason_but_accepts_memo_fallback(admin_transfer_client):
+    """Phase-1 hardening: attribution is mandatory; `memo` is accepted as the
+    legacy field name so existing payers keep working."""
+    client, db_path = admin_transfer_client
+    _fund(db_path)
+
+    no_reason = client.post(
+        "/wallet/transfer", json={**_BASE, "idempotency_key": "no-reason"}, headers=_HDR
+    )
+    assert no_reason.status_code == 400
+    assert no_reason.get_json()["error"] == "reason_required"
+
+    too_long = client.post(
+        "/wallet/transfer",
+        json={**_BASE, "idempotency_key": "too-long", "reason": "x" * 501},
+        headers=_HDR,
+    )
+    assert too_long.status_code == 400
+    assert too_long.get_json()["error"] == "reason_too_long"
+
+    memo_only = client.post(
+        "/wallet/transfer",
+        json={**_BASE, "idempotency_key": "memo-only", "memo": "legacy memo attribution"},
+        headers=_HDR,
+    )
+    assert memo_only.status_code == 200
+    assert memo_only.get_json()["ok"] is True
+
+    with sqlite3.connect(db_path) as conn:
+        (stored_reason,) = conn.execute("SELECT reason FROM pending_ledger").fetchone()
+    assert stored_reason == "legacy memo attribution"
+    assert _pending_count(db_path) == 1
+
+
+def test_admin_transfer_replay_ignores_reason_but_refuses_voided(admin_transfer_client):
+    """Replay semantics (live on prod since 2026-08-20): the money-relevant
+    triple (from, to, amount) decides conflict — a changed `reason` on a
+    replay is NOT a conflict (legacy rows carry "admin_transfer"). But a
+    replay of a VOIDED row must not come back `ok: true`."""
+    import hashlib
+
+    client, db_path = admin_transfer_client
+    _fund(db_path)
+
+    payload = {**_BASE, "reason": "bounty:9:first:2026-08-22", "idempotency_key": "replay-semantics"}
+    first = client.post("/wallet/transfer", json=payload, headers=_HDR)
+    assert first.status_code == 200
+    pending_id = first.get_json()["pending_id"]
+
+    # Same key, same triple, different reason -> same row, no conflict.
+    replay = client.post(
+        "/wallet/transfer", json={**payload, "reason": "bounty:9:retry-wording:2026-08-22"}, headers=_HDR
+    )
+    assert replay.status_code == 200
+    assert replay.get_json()["pending_id"] == pending_id
+    assert _pending_count(db_path) == 1
+
+    # Void the row out-of-band (admin void path), then replay the key.
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE pending_ledger SET status = 'voided' WHERE id = ?", (pending_id,))
+        conn.commit()
+
+    voided = client.post("/wallet/transfer", json=payload, headers=_HDR)
+    assert voided.status_code == 409
+    body = voided.get_json()
+    assert body["ok"] is False
+    assert body["error"] == "idempotency_key_voided"
+    assert body["tx_hash"] == hashlib.sha256(b"wallet_transfer_idempotency:replay-semantics").hexdigest()[:32]
+    assert _pending_count(db_path) == 1  # nothing re-issued


### PR DESCRIPTION
Brings `main` into line with what is **already running on both prod nodes** (.131 and .153), and fixes the one in-repo caller that would break under it.

## Node (`node/rustchain_v2_integrated_v2.2.1_rip200.py`)
**Phase 1 (deployed 2026-08-20):** `reason` REQUIRED (`memo` accepted as fallback attribution); >500 chars → `reason_too_long`; replay conflict compares the money triple only (from/to/amount — not `reason`, which legacy rows stored as `admin_transfer`); replay of a **voided** row → `409 idempotency_key_voided` instead of `ok:true`.

**Phase 2 (deployed 2026-08-22):** `idempotency_key` REQUIRED. Error split: missing/null/`""` → `idempotency_key_required` (hint carries a *valid* example); present-but-malformed (non-string, whitespace, bad charset, >128) → `invalid_idempotency_key`.

Why: a keyless admin transfer double-pays on retry. The caller inventory was measured on both nodes and the ops box before the flip — every live first-party payer (bounty_payout, auto-pay ×2, award_rtc, rtc-reward, rtc-pay, node_rewards, github_tip_bot, ut99, otc bridge, minecraft bridge) sends a stable key. Tonight's Sunday `node_rewards.py` cron paid through the hardened endpoint (pending 4054/4055).

## Faucet (`faucet_service/faucet_service.py`)
The real-drip path sent neither field → now `reason=faucet:drip:<wallet>:<date>`, key `faucet:drip:<sha256(ip:wallet)[:16]>:<window_bucket>` (a retry inside one rate-limit window replays to the same row). Event path gets deterministic defaults.

## Tests
- `tests/test_wallet_transfer_admin_idempotency.py`: **13 pass** — 8 parametrized negatives (including *the hint's own example must satisfy the regex*: the first cut used `bounty:<number>:<slug>:<date>`, which the regex rejects; tri-brain review caught it), reason/memo fallback, replay-ignores-reason + voided-replay-409. Fixture disables the admin rate limiter (12/min would 429 the burst before the gate under test).
- `faucet_service/test_faucet_service.py`: 61 pass.
- All 7 test files touching `/wallet/transfer`: 84/85 — the one failure (`test_admin_endpoint_returns_401_with_wrong_key[GET-/pending/integrity]` → 429) is a **pre-existing** cross-file rate-limit-bucket ordering flake: it fails identically with this branch's test file excluded and passes when run alone.

## Review
Tri-brain (Codex GPT-5.6 + Grok) on the endpoint diff: both BLOCKING findings were "keyless callers not evidenced in-tree" — addressed by the inventory above and the negative tests; both SHOULD-FIX items (invalid hint example, error-code split) applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
