### PR TITLE
ci(falsegreen): install pytest before the linter self-test

### DIFF
--- a/.github/workflows/falsegreen.yml
+++ b/.github/workflows/falsegreen.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install pytest
+        run: python3 -m pip install --quiet pytest
+
       - name: Self-test the linter
         run: python3 -m pytest tools/falsegreen/test_falsegreen.py -q
 


### PR DESCRIPTION
The falsegreen job calls pytest on a bare setup-python env, so **every PR touching a .py/.yml file fails** with `No module named pytest` before the linter runs (bit #8242 among others). One step added: `pip install pytest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)