### PR TITLE
fix: repair the 4 red tests on main

### DIFF
--- a/tests/test_claims_integration.py
+++ b/tests/test_claims_integration.py
@@ -32,6 +32,7 @@ from claims_submission import (
     update_claim_status
 )
 
+import claims_settlement
 from claims_settlement import (
     get_pending_claims,
     process_claims_batch,
@@ -175,8 +176,17 @@ def setup_test_miner(db, miner_id, device_arch, wallet_address, current_ts, epoc
 class TestEndToEndClaimFlow:
     """Test complete claim flow from eligibility to settlement"""
     
-    def test_full_claim_lifecycle(self, integration_db, current_ts, current_slot):
+    def test_full_claim_lifecycle(self, integration_db, current_ts, current_slot, monkeypatch):
         """Test: Setup → Eligibility → Submit → Approve → Settle"""
+
+        # claims_settlement no longer fabricates a tx hash when no node is
+        # configured (#8231): success now requires a real 2xx broadcast.
+        # Stand in for the node at the module seam instead.
+        monkeypatch.setattr(
+            claims_settlement,
+            "sign_and_broadcast_transaction",
+            lambda tx_data, db_path: (True, "0x" + "ab" * 32, None),
+        )
         
         # Use an old epoch that should be settled
         test_epoch = max(0, current_slot // 144 - 3)
@@ -344,8 +354,17 @@ class TestEndToEndClaimFlow:
         # Should still show pending claim exists (rejected claims don't block)
         # This depends on business logic - adjust as needed
     
-    def test_multiple_miners_batch_settlement(self, integration_db, current_ts, current_slot):
+    def test_multiple_miners_batch_settlement(self, integration_db, current_ts, current_slot, monkeypatch):
         """Test batch settlement with multiple miners"""
+
+        # claims_settlement no longer fabricates a tx hash when no node is
+        # configured (#8231): success now requires a real 2xx broadcast.
+        # Stand in for the node at the module seam instead.
+        monkeypatch.setattr(
+            claims_settlement,
+            "sign_and_broadcast_transaction",
+            lambda tx_data, db_path: (True, "0x" + "ab" * 32, None),
+        )
         
         test_epoch = max(0, current_slot // 144 - 3)
         
@@ -516,8 +535,17 @@ class TestClaimHistoryAndStats:
         assert len(epochs_result["epochs"]) > 0
         assert epochs_result["total_unclaimed_urtc"] >= 0
     
-    def test_settlement_statistics(self, integration_db, current_ts, current_slot):
+    def test_settlement_statistics(self, integration_db, current_ts, current_slot, monkeypatch):
         """Test settlement statistics calculation"""
+
+        # claims_settlement no longer fabricates a tx hash when no node is
+        # configured (#8231): success now requires a real 2xx broadcast.
+        # Stand in for the node at the module seam instead.
+        monkeypatch.setattr(
+            claims_settlement,
+            "sign_and_broadcast_transaction",
+            lambda tx_data, db_path: (True, "0x" + "ab" * 32, None),
+        )
         
         test_epoch = max(0, current_slot // 144 - 3)
         

--- a/tests/test_health_monitor.py
+++ b/tests/test_health_monitor.py
@@ -241,7 +241,10 @@ class TestGetNetworkHealth(unittest.TestCase):
         ]
         health = self.monitor.get_network_health(statuses)
         self.assertEqual(health.nodes_online, 3)
-        self.assertEqual(health.total_miners, 13)
+        # Nodes are replicas of one shared ledger (#8008): total_miners is the
+        # agreed network-wide count (max, robust to a mid-sync node reporting
+        # fewer), not the sum of per-replica reports.
+        self.assertEqual(health.total_miners, 6)
         self.assertTrue(health.consensus_ok)
         self.assertFalse(health.split_brain)
         self.assertEqual(health.alerts, [])


### PR DESCRIPTION
## Summary

Main's CI `test` job fails with exactly 4 tests (3878 pass otherwise). All four are **stale test expectations** left behind by two deliberate code fixes merged 8/20 — the code is behaving as intended, so the tests were updated, not the code.

## Per-test root cause

| Test | Broke when | Code bug or stale test? | Fix |
|---|---|---|---|
| `test_claims_integration.py::TestEndToEndClaimFlow::test_full_claim_lifecycle` | 4bc535b (#8231, 8/20) | **Stale test** — it relied on `sign_and_broadcast_transaction()` fabricating `success=True` + a synthetic tx hash when `TREASURY_KEY_PATH`/`NODE_API_URL` were unset (the exact fund-safety bug #8231 fixed) | Monkeypatch `claims_settlement.sign_and_broadcast_transaction` to simulate a confirmed 2xx broadcast |
| `test_claims_integration.py::TestEndToEndClaimFlow::test_multiple_miners_batch_settlement` | 4bc535b (#8231) | **Stale test** (same reliance) | Same monkeypatch |
| `test_claims_integration.py::TestClaimHistoryAndStats::test_settlement_statistics` | 4bc535b (#8231) | **Stale test** — `settled_claims` stayed 0 because settlement correctly no longer 'succeeds' without a real broadcast | Same monkeypatch |
| `test_health_monitor.py::TestGetNetworkHealth::test_all_healthy` | 12e3f12 (#8008, 8/20) | **Stale test** — nodes are replicas of one shared ledger; #8008 changed `total_miners` from sum (inflated Nx) to the agreed value (max, robust to a mid-sync node). Test still expected the sum: 4+3+6=13 vs code's 6 | Expectation updated 13 → 6 with an explanatory comment |

Note: #8242 (`/wallet/transfer` reason+idempotency) was investigated and is **not** involved — the claims path fails at the broadcast seam, before any transfer.

## Verification

Full CI-equivalent run (`pytest tests/ --ignore=test_epoch_settlement_formal.py --ignore=test_rip201_bucket_spoof.py`, same env as ci.yml):

```
3882 passed, 45 skipped, 2 xfailed, 100 subtests passed in 56.30s
```

(was 3878 passed / 4 failed; skip count unchanged)

Why fix the tests, not the code: #8231 closed a fund-theft/audit hazard (claims marked settled with a fake on-chain hash) and #8008 fixed an Nx-inflated operator metric. Both changes are correct; the tests encoded the old broken behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)