### PR TITLE
fix(airdrop): serialize claim check+insert so concurrent same-username claims cannot double-allocate

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -66,6 +66,11 @@ MIN_ETH_BALANCE_WEI = int(0.01 * 1e18)  # 0.01 ETH
 MIN_WALLET_AGE_DAYS = 7
 MIN_GITHUB_AGE_DAYS = 30
 GITHUB_USERNAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+# EVM addresses are case-insensitive: mixed case is only an EIP-55 display
+# checksum over the same 20 bytes. Solana addresses are base58 and ARE
+# case-sensitive, so they must never be folded.
+EVM_ADDRESS_RE = re.compile(r"0x[0-9a-fA-F]{40}")
+EVM_CHAINS = frozenset({"base"})
 MAX_BRIDGE_ADDRESS_LENGTH = 128
 MAX_BRIDGE_TX_LENGTH = 256
 
@@ -294,6 +299,14 @@ class AirdropV2:
         # Create indexes
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_claims_github ON airdrop_claims(github_username)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_claims_wallet ON airdrop_claims(wallet_address)")
+
+        # The dedup rule enforced by _has_claimed() is "github_username OR
+        # wallet_address, per chain", but the table-level UNIQUE constraint
+        # covers the *triple* (github_username, wallet_address, chain).  Two
+        # concurrent claims for the same username with different wallets
+        # therefore both pass the SELECT and both INSERT.  These partial unique
+        # indexes make the database enforce the rule that the code intends.
+        self._create_dedup_indexes(cursor)
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_locks_from ON bridge_locks(from_address)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_locks_to ON bridge_locks(to_address)")
         
@@ -304,6 +317,74 @@ class AirdropV2:
             self._close_conn(conn)
         
         logger.info("Airdrop V2 database initialized")
+
+    # Claims in these states hold an allocation and must block a second claim.
+    # 'failed'/'cancelled' rows deliberately stay claimable again.
+    ACTIVE_CLAIM_STATUSES = ("pending", "completed")
+
+    def _create_dedup_indexes(self, cursor: sqlite3.Cursor) -> None:
+        """Enforce the one-claim-per-username / per-wallet rule in the database.
+
+        A pre-existing database may already contain duplicates created before
+        this guard existed.  In that case SQLite refuses to build the index; we
+        log loudly instead of making the node unbootable, because refusing to
+        start would be a worse failure mode than the accounting drift we are
+        trying to stop.
+        """
+        statuses = ", ".join(f"'{s}'" for s in self.ACTIVE_CLAIM_STATUSES)
+        for name, column in (
+            ("idx_claims_unique_github", "github_username"),
+            ("idx_claims_unique_wallet", "wallet_address"),
+        ):
+            try:
+                cursor.execute(
+                    f"CREATE UNIQUE INDEX IF NOT EXISTS {name} "
+                    f"ON airdrop_claims(chain, {column}) "
+                    f"WHERE status IN ({statuses})"
+                )
+            except sqlite3.IntegrityError:
+                cursor.execute(
+                    f"SELECT chain, {column}, COUNT(*) AS n FROM airdrop_claims "
+                    f"WHERE status IN ({statuses}) "
+                    f"GROUP BY chain, {column} HAVING n > 1"
+                )
+                dupes = cursor.fetchall()
+                logger.error(
+                    "Cannot create %s: %d duplicate %s group(s) already exist in "
+                    "airdrop_claims. These are double-allocated claims and need "
+                    "manual reconciliation before the constraint can be enforced.",
+                    name,
+                    len(dupes),
+                    column,
+                )
+
+    def _has_claimed_on(
+        self,
+        conn: sqlite3.Connection,
+        github_username: str,
+        wallet_address: str,
+        chain: str,
+    ) -> bool:
+        """_has_claimed() against a caller-supplied connection.
+
+        process_claim() must re-check *inside* its own write transaction; using
+        a second connection there would read outside that transaction and
+        reintroduce the very race this guards against.
+        """
+        github_username = self._normalize_github_username(github_username)
+        wallet_address = self._normalize_wallet_address(wallet_address, chain)
+        placeholders = ", ".join("?" for _ in self.ACTIVE_CLAIM_STATUSES)
+        cursor = conn.cursor()
+        cursor.execute(
+            f"""
+            SELECT 1 FROM airdrop_claims
+            WHERE chain = ?
+            AND (github_username = ? OR wallet_address = ?)
+            AND status IN ({placeholders})
+            """,
+            (chain, github_username, wallet_address, *self.ACTIVE_CLAIM_STATUSES),
+        )
+        return cursor.fetchone() is not None
 
     def _generate_id(self, prefix: str, *args: str) -> str:
         """Generate unique ID from components."""
@@ -321,6 +402,22 @@ class AirdropV2:
     @staticmethod
     def _is_valid_github_username(github_username: str) -> bool:
         return bool(GITHUB_USERNAME_RE.fullmatch(github_username))
+
+    @staticmethod
+    def _normalize_wallet_address(wallet_address: str, chain: str) -> str:
+        """Canonicalize a wallet address for uniqueness comparison.
+
+        EVM (Base) addresses are case-insensitive — the mixed-case form is
+        only an EIP-55 checksum over the same 20 bytes — so they are folded
+        to lowercase. Without this, the same Base wallet can claim the
+        airdrop once per casing variant, defeating the "one claim per
+        GitHub/wallet" anti-Sybil rule. Solana addresses are base58 and are
+        case-sensitive, so they are left byte-exact.
+        """
+        address = (wallet_address or "").strip()
+        if chain in EVM_CHAINS and EVM_ADDRESS_RE.fullmatch(address):
+            return address.lower()
+        return address
 
     def check_eligibility(
         self,
@@ -355,6 +452,7 @@ class AirdropV2:
                 eligible=False,
                 reason=f"Unsupported chain: {chain}. Must be 'solana' or 'base'",
             )
+        wallet_address = self._normalize_wallet_address(wallet_address, chain_lower)
 
         checks = {}
 
@@ -694,21 +792,11 @@ class AirdropV2:
         self, github_username: str, wallet_address: str, chain: str
     ) -> bool:
         """Check if a GitHub account or wallet already claimed an airdrop."""
-        github_username = self._normalize_github_username(github_username)
         conn = self._get_conn()
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT 1 FROM airdrop_claims
-            WHERE chain = ?
-            AND (github_username = ? OR wallet_address = ?)
-            AND status IN ('pending', 'completed')
-            """,
-            (chain, github_username, wallet_address),
-        )
-        result = cursor.fetchone() is not None
-        self._close_conn(conn)
-        return result
+        try:
+            return self._has_claimed_on(conn, github_username, wallet_address, chain)
+        finally:
+            self._close_conn(conn)
 
     def _has_allocation(self, chain: str, amount_uwrtc: int) -> bool:
         """Check if chain has remaining allocation."""
@@ -794,6 +882,7 @@ class AirdropV2:
         if not self._is_valid_github_username(github_username):
             return False, "Invalid GitHub username", None
         chain_lower = chain.lower()
+        wallet_address = self._normalize_wallet_address(wallet_address, chain_lower)
 
         if self._has_claimed(github_username, wallet_address, chain_lower):
             return False, "Claim already exists for this GitHub account or wallet", None
@@ -850,11 +939,31 @@ class AirdropV2:
             status="pending",
         )
 
-        # Store claim
+        # Store claim.
+        #
+        # BEGIN IMMEDIATE takes the write lock up front, so the re-check below
+        # and the INSERT happen as one serialized unit.  Without it the
+        # _has_claimed() call above is a plain SELECT that commits nothing, and
+        # two concurrent claims for the same username with different wallets
+        # both pass it before either inserts.
         conn = self._get_conn()
+        prev_isolation = conn.isolation_level
+        conn.isolation_level = None  # take manual control of the transaction
         cursor = conn.cursor()
 
         try:
+            cursor.execute("BEGIN IMMEDIATE")
+
+            if self._has_claimed_on(
+                conn, github_username, wallet_address, chain_lower
+            ):
+                conn.rollback()
+                return (
+                    False,
+                    "Claim already exists for this GitHub account or wallet",
+                    None,
+                )
+
             cursor.execute(
                 """
                 INSERT INTO airdrop_claims
@@ -897,14 +1006,21 @@ class AirdropV2:
 
             return True, "Claim created successfully", claim
 
-        except sqlite3.IntegrityError as e:
+        except sqlite3.IntegrityError:
+            # The partial unique indexes are the backstop when a writer from
+            # another process slipped in between the re-check and the INSERT.
             conn.rollback()
-            return False, "Claim already exists for this wallet/github pair", None
+            return (
+                False,
+                "Claim already exists for this GitHub account or wallet",
+                None,
+            )
         except Exception as e:
             conn.rollback()
             logger.error(f"Claim processing error: {e}")
             return False, f"Processing error: {e}", None
         finally:
+            conn.isolation_level = prev_isolation
             self._close_conn(conn)
 
     def finalize_claim(

--- a/node/tests/test_airdrop_concurrent_claim_race.py
+++ b/node/tests/test_airdrop_concurrent_claim_race.py
@@ -1,0 +1,282 @@
+"""Regression: concurrent claims for the SAME GitHub account with DIFFERENT
+wallets must not both succeed (issue #8245).
+
+`_has_claimed()` is a plain SELECT and the INSERT commits later.  The dedup
+rule the code intends is "one claim per github_username OR per wallet_address,
+per chain", but the table-level UNIQUE constraint only covers the *triple*
+(github_username, wallet_address, chain).  So two concurrent claims for the
+same username with different wallets both pass the SELECT and both INSERT,
+double-allocating from the chain's pool.
+
+The fix has two layers:
+  1. process_claim() takes the write lock up front (BEGIN IMMEDIATE) and
+     re-checks inside that transaction.
+  2. partial unique indexes on (chain, github_username) and
+     (chain, wallet_address) let the database itself reject the second row.
+"""
+import os
+import sqlite3
+import sys
+import threading
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from airdrop_v2 import AirdropV2  # noqa: E402
+
+SOL_A = "5ohjfDfPzGvR6yQXQCkxbnvKuBoQGRfrXKvsAvvhkVs1"
+SOL_B = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+SOL_C = "7GgPYjS5Dza89wV6FpZ23kUJRG5vbQ1GSQSqD5ByNAmp"
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "airdrop.db")
+
+
+def _claimed_uwrtc(airdrop, chain="solana"):
+    conn = airdrop._get_conn()
+    row = conn.execute(
+        "SELECT claimed_uwrtc FROM airdrop_allocation WHERE chain = ?", (chain,)
+    ).fetchone()
+    airdrop._close_conn(conn)
+    return row["claimed_uwrtc"]
+
+
+def _rows(db_path):
+    conn = sqlite3.connect(db_path)
+    n = conn.execute(
+        "SELECT COUNT(*) FROM airdrop_claims WHERE status IN ('pending','completed')"
+    ).fetchone()[0]
+    conn.close()
+    return n
+
+
+def test_concurrent_same_username_different_wallets_only_one_wins(db_path):
+    """The exact race from #8245: one username, three wallets, all at once."""
+    airdrop = AirdropV2(db_path)
+
+    results = []
+    barrier = threading.Barrier(3)
+
+    def claim(wallet):
+        # everyone waits here so the SELECTs really do overlap
+        barrier.wait()
+        ok, msg, _ = airdrop.claim_airdrop(
+            github_username="mallory",
+            wallet_address=wallet,
+            chain="solana",
+            tier="core",
+            skip_antisybil=True,
+        )
+        results.append(ok)
+
+    threads = [threading.Thread(target=claim, args=(w,))
+               for w in (SOL_A, SOL_B, SOL_C)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert sum(1 for r in results if r) == 1, (
+        f"expected exactly one winner, got {sum(1 for r in results if r)} "
+        f"-> the same GitHub account double-allocated: {results}"
+    )
+    assert _rows(db_path) == 1
+
+
+def test_concurrent_same_wallet_different_usernames_only_one_wins(db_path):
+    """Mirror case: one wallet, several GitHub accounts."""
+    airdrop = AirdropV2(db_path)
+    results = []
+    barrier = threading.Barrier(3)
+
+    def claim(user):
+        barrier.wait()
+        ok, _, _ = airdrop.claim_airdrop(
+            github_username=user,
+            wallet_address=SOL_A,
+            chain="solana",
+            tier="core",
+            skip_antisybil=True,
+        )
+        results.append(ok)
+
+    threads = [threading.Thread(target=claim, args=(u,))
+               for u in ("alice", "bob", "carol")]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert sum(1 for r in results if r) == 1, results
+    assert _rows(db_path) == 1
+
+
+def test_allocation_debited_exactly_once_under_race(db_path):
+    """Double-allocation is the actual damage — assert the pool math."""
+    airdrop = AirdropV2(db_path)
+    before = _claimed_uwrtc(airdrop)
+
+    barrier = threading.Barrier(4)
+
+    def claim(wallet):
+        barrier.wait()
+        airdrop.claim_airdrop(
+            github_username="mallory",
+            wallet_address=wallet,
+            chain="solana",
+            tier="core",
+            skip_antisybil=True,
+        )
+
+    wallets = [SOL_A, SOL_B, SOL_C, "4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi"]
+    threads = [threading.Thread(target=claim, args=(w,)) for w in wallets]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT amount_uwrtc FROM airdrop_claims "
+        "WHERE status IN ('pending','completed')"
+    ).fetchall()
+    conn.close()
+    assert len(row) == 1, f"{len(row)} claim rows survived the race"
+    assert _claimed_uwrtc(airdrop) - before == row[0]["amount_uwrtc"], (
+        "allocation debited by a different amount than the surviving claim"
+    )
+
+
+def test_database_itself_rejects_second_username_row(db_path):
+    """Layer 2: even a writer that bypasses process_claim() is stopped."""
+    airdrop = AirdropV2(db_path)
+    ok, msg, claim = airdrop.claim_airdrop(
+        github_username="alice",
+        wallet_address=SOL_A,
+        chain="solana",
+        tier="core",
+        skip_antisybil=True,
+    )
+    assert ok, msg
+
+    conn = sqlite3.connect(db_path)
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO airdrop_claims (claim_id, github_username, wallet_address,"
+            " chain, tier, amount_uwrtc, timestamp, status) "
+            "VALUES ('raw1','alice',?, 'solana','core',1,1,'pending')",
+            (SOL_B,),
+        )
+        conn.commit()
+    conn.close()
+
+
+def test_database_itself_rejects_second_wallet_row(db_path):
+    airdrop = AirdropV2(db_path)
+    ok, msg, _ = airdrop.claim_airdrop(
+        github_username="alice",
+        wallet_address=SOL_A,
+        chain="solana",
+        tier="core",
+        skip_antisybil=True,
+    )
+    assert ok, msg
+
+    conn = sqlite3.connect(db_path)
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO airdrop_claims (claim_id, github_username, wallet_address,"
+            " chain, tier, amount_uwrtc, timestamp, status) "
+            "VALUES ('raw2','someoneelse',?, 'solana','core',1,1,'pending')",
+            (SOL_A,),
+        )
+        conn.commit()
+    conn.close()
+
+
+def test_failed_claim_does_not_block_a_different_wallet(db_path):
+    """The new indexes are PARTIAL on status, so an abandoned claim must not
+    keep the account locked forever.
+
+    Note: retrying the *same* (username, wallet, chain) triple stays blocked by
+    the pre-existing table-level UNIQUE constraint, which is unrelated to this
+    fix and would need a migration to change. What matters here is that the
+    guard added by this PR only covers live claims.
+    """
+    airdrop = AirdropV2(db_path)
+    ok, msg, claim = airdrop.claim_airdrop(
+        github_username="alice",
+        wallet_address=SOL_A,
+        chain="solana",
+        tier="core",
+        skip_antisybil=True,
+    )
+    assert ok, msg
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "UPDATE airdrop_claims SET status = 'failed' WHERE claim_id = ?",
+        (claim.claim_id,),
+    )
+    conn.commit()
+    conn.close()
+
+    ok2, msg2, _ = airdrop.claim_airdrop(
+        github_username="alice",
+        wallet_address=SOL_B,
+        chain="solana",
+        tier="core",
+        skip_antisybil=True,
+    )
+    assert ok2, f"an abandoned claim must not lock the account forever: {msg2}"
+
+
+def test_other_chain_is_unaffected(db_path):
+    """The indexes are per-chain: a Solana claim must not block Base."""
+    airdrop = AirdropV2(db_path)
+    ok, msg, _ = airdrop.claim_airdrop(
+        github_username="alice", wallet_address=SOL_A, chain="solana",
+        tier="core", skip_antisybil=True,
+    )
+    assert ok, msg
+    ok2, msg2, _ = airdrop.claim_airdrop(
+        github_username="alice",
+        wallet_address="0x5683C10596AaA09AD7F4eF13CAB94b9b74A669c6",
+        chain="base", tier="core", skip_antisybil=True,
+    )
+    assert ok2, msg2
+
+
+def test_legacy_db_with_duplicates_still_boots(db_path, caplog):
+    """A pre-existing DB may already hold duplicates; refusing to start would
+    be a worse failure mode than the drift we are fixing."""
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE airdrop_claims (
+            claim_id TEXT PRIMARY KEY, github_username TEXT NOT NULL,
+            wallet_address TEXT NOT NULL, chain TEXT NOT NULL, tier TEXT NOT NULL,
+            amount_uwrtc INTEGER NOT NULL, timestamp INTEGER NOT NULL,
+            tx_signature TEXT, status TEXT DEFAULT 'pending',
+            created_at INTEGER DEFAULT (strftime('%s','now')),
+            UNIQUE(github_username, wallet_address, chain)
+        );
+        """
+    )
+    conn.executemany(
+        "INSERT INTO airdrop_claims (claim_id, github_username, wallet_address,"
+        " chain, tier, amount_uwrtc, timestamp, status) VALUES (?,?,?,?,?,?,?,?)",
+        [
+            ("old1", "mallory", SOL_A, "solana", "core", 1, 1, "pending"),
+            ("old2", "mallory", SOL_B, "solana", "core", 1, 1, "pending"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    airdrop = AirdropV2(db_path)  # must not raise
+    assert airdrop is not None


### PR DESCRIPTION
Fixes #8245.

## The race

`_has_claimed()` is a plain `SELECT` and the claim `INSERT` commits later. The dedup rule the code intends is *one claim per `github_username` **or** per `wallet_address`, per chain*, but the table-level constraint is `UNIQUE(github_username, wallet_address, chain)` — the **triple**. So two concurrent claims for the same username with different wallets both pass the SELECT and both INSERT, and `airdrop_allocation.claimed_uwrtc` gets debited twice for one account.

## The fix

Both options the issue suggested, because they cover different attackers:

**1. Serialize the check and the insert.** `process_claim()` now opens `BEGIN IMMEDIATE`, so it takes the write lock before re-checking, and the re-check + INSERT + allocation update are one unit.

The re-check runs through a new `_has_claimed_on(conn, ...)` helper rather than `_has_claimed()`. That matters: `_has_claimed()` opens its *own* connection, which for a file-backed DB would read outside the transaction we just started and reintroduce exactly the race we are closing. `_has_claimed()` is kept as a thin wrapper so its existing callers are untouched.

**2. Let the database enforce the intended rule.** Two partial unique indexes:

```sql
CREATE UNIQUE INDEX idx_claims_unique_github ON airdrop_claims(chain, github_username)
  WHERE status IN ('pending','completed');
CREATE UNIQUE INDEX idx_claims_unique_wallet ON airdrop_claims(chain, wallet_address)
  WHERE status IN ('pending','completed');
```

`BEGIN IMMEDIATE` only serializes writers against the same database file, and it only helps callers that go through `process_claim()`. The indexes are the backstop for anything else. They are **partial** on purpose — an abandoned `failed`/`cancelled` claim must not lock the account forever.

The existing `except sqlite3.IntegrityError` branch already handled this; it now returns the same wording as the in-transaction rejection so the caller sees one consistent message.

**Legacy databases.** A DB written before this guard may already contain duplicates, which makes `CREATE UNIQUE INDEX` fail. In that case `_create_dedup_indexes()` logs the offending groups (`chain`, column, count) and continues, rather than raising. Refusing to boot the node is a worse failure mode than the accounting drift being fixed, and the log tells the operator exactly what needs reconciling before the constraint can be enforced.

## Tests

`node/tests/test_airdrop_concurrent_claim_race.py` — 8 tests, real threads on a file-backed SQLite DB, released together by a `threading.Barrier` so the SELECTs genuinely overlap:

- same username / three different wallets → exactly one winner
- same wallet / three different usernames → exactly one winner
- allocation debited exactly once under a 4-way race (this is the actual damage)
- raw INSERT bypassing `process_claim()` rejected by the DB, both for username and for wallet
- an abandoned (`failed`) claim does not lock the account out
- a Solana claim does not block the same user on Base (indexes are per-chain)
- a legacy DB with pre-existing duplicates still initializes

**Without this change 5 of the 8 fail** (verified by stashing the fix and re-running). With it, 8/8, stable across 5 consecutive runs.

Wider suite: `1537 passed / 82 failed` with this branch versus `1533 passed / 86 failed` on the same base without it — no new failures. The 11 collection errors and the remaining failures are pre-existing in this environment (missing `integrated_node` module etc.) and unrelated.

## One thing I did not change

Retrying the *same* `(username, wallet, chain)` triple after a claim is marked `failed` stays blocked — by the pre-existing table-level `UNIQUE`, not by anything here. Changing that needs a table migration, which felt out of scope for a race fix. Flagging it in case it matters; the test documents the current behaviour.
