### PR TITLE
fix(hardware-db): substring fallback must anchor to the family minimum, not whichever key matched

### DIFF
--- a/node/rustchain_hardware_database.py
+++ b/node/rustchain_hardware_database.py
@@ -686,10 +686,25 @@ def lookup_hardware(hw_id: str, family: Optional[str] = None) -> Optional[Hardwa
         if norm_id in db:
             return db[norm_id]
 
-        # Try partial matching for common variants
-        for key, entry in db.items():
-            if norm_id in key or key in norm_id:
-                return entry
+        # Try partial matching for common variants. A substring match only
+        # proves the probe belongs to SOME entry's family — it does not
+        # identify which generation. normalize_id("SPARC-T") == "sparc_t"
+        # has no exact key, but IS a superstring of the generic "sparc" entry
+        # (Sun-4, 1987, 3.0x LEGENDARY) and NOT a substring/superstring of
+        # any other sparc_* key, so a naive "return the matched entry" (or
+        # even "return the cheapest of the LITERAL key matches") still
+        # answers with that single 1987 row — a 2013 SPARC T5 grades as
+        # 1987 silicon. Once we know the family, anchor to the lowest
+        # base_multiplier across every entry in that family (e.g. SPARC's
+        # own ultrasparc_iii/iv rows are 2.5x ANCIENT), not just whichever
+        # key happened to substring-match. Same fail-closed principle as
+        # RIP-309b: an unidentified generation must never grade at the
+        # family's most expensive tier.
+        candidates = [entry for key, entry in db.items() if norm_id in key or key in norm_id]
+        if candidates:
+            matched_families = {entry.family for entry in candidates}
+            family_entries = [e for e in db.values() if e.family in matched_families]
+            return min(family_entries, key=lambda e: e.base_multiplier)
 
     return None
 

--- a/node/tests/test_sparc_substring_fallback_conservative_poc.py
+++ b/node/tests/test_sparc_substring_fallback_conservative_poc.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: MIT
+"""Regression test for the SPARC substring-fallback over-reward bug (issue #8237).
+
+``lookup_hardware()``'s partial-match fallback returned the FIRST key that
+literally substring-matched the normalized probe id, with no regard for how
+conservative that entry's multiplier was. ``normalize_id("SPARC-T")`` yields
+``"sparc_t"``, which has no exact key in ``WORKSTATION_DATABASE`` but IS a
+superstring of the generic ``"sparc"`` entry (Sun-4, 1987, 3.0x LEGENDARY) —
+and of no other ``sparc_*`` key. So an unrecognised/newer SPARC generation
+(e.g. a 2013 SPARC T5) graded at the SAME multiplier as 1987 silicon,
+regardless of how modern it actually was.
+
+FAILS on unmodified main: ``lookup_hardware("SPARC-T", "sparc").base_multiplier
+== 3.0`` (the 1987 LEGENDARY row).
+PASSES with the fix: the lookup anchors to the lowest ``base_multiplier``
+across every entry sharing the matched family, which for SPARC is 2.5x
+(ANCIENT, UltraSPARC III/IV) — never the family's priciest tier for hardware
+whose generation wasn't identified.
+"""
+
+import os
+import sys
+import unittest
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if NODE_DIR not in sys.path:
+    sys.path.insert(0, NODE_DIR)
+
+from rustchain_hardware_database import (  # noqa: E402
+    lookup_hardware,
+    calculate_poa_multiplier,
+    WORKSTATION_DATABASE,
+)
+
+
+class TestSparcSubstringFallbackConservative(unittest.TestCase):
+    def test_unidentified_sparc_generation_does_not_grade_at_1987_rate(self):
+        entry = lookup_hardware("SPARC-T", "sparc")
+        self.assertIsNotNone(entry, "SPARC-T should still resolve to *some* SPARC entry")
+        self.assertLess(
+            entry.base_multiplier, 3.0,
+            f"SPARC-T (unidentified generation) graded at {entry.base_multiplier}x — "
+            "the 1987 LEGENDARY rate is only correct for genuinely 1987-era SPARC "
+            "hardware, not an unrecognised/newer probe string.",
+        )
+
+    def test_conservative_match_equals_family_minimum(self):
+        entry = lookup_hardware("SPARC-T", "sparc")
+        family_min = min(
+            e.base_multiplier for e in WORKSTATION_DATABASE.values() if e.family == "sparc"
+        )
+        self.assertEqual(
+            entry.base_multiplier, family_min,
+            "an unidentified SPARC generation must grade at the family's lowest "
+            "known multiplier, not an arbitrary substring-matched one",
+        )
+
+    def test_calculate_poa_multiplier_end_to_end(self):
+        mult, tier, _rarity, _name = calculate_poa_multiplier("sparc", "SPARC-T")
+        self.assertLess(mult, 3.0)
+        self.assertNotEqual(tier, "LEGENDARY")
+
+    def test_exact_generation_match_is_unaffected(self):
+        # A precisely-reported generation must still resolve to its own
+        # entry, not get dragged down to the family minimum.
+        entry = lookup_hardware("ultrasparc_ii", "sparc")
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.name, "UltraSPARC II")
+        self.assertEqual(entry.base_multiplier, 3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes #8237.

`lookup_hardware()`'s partial-match fallback returned the first key that literally substring-matched the normalized probe id. `normalize_id("SPARC-T") == "sparc_t"` has no exact key in `WORKSTATION_DATABASE`, but IS a superstring of the generic `"sparc"` entry (Sun-4, 1987, 3.0x LEGENDARY) and of no other `sparc_*` key -- so an unidentified/newer SPARC generation (e.g. a 2013 SPARC T5) graded at the exact same multiplier as genuine 1987 silicon.

## Fix
Once a substring match tells us the family, anchor to the lowest `base_multiplier` across every entry in that family (SPARC's own `ultrasparc_iii`/`ultrasparc_iv` rows are 2.5x ANCIENT) instead of whichever key happened to match -- same fail-closed principle as RIP-309b: an unidentified generation must never grade at the family's most expensive tier.

## Testing
- Added `node/tests/test_sparc_substring_fallback_conservative_poc.py`: 4 cases
- 3/4 fail on unmodified `main` (SPARC-T grades at 3.0/LEGENDARY), pass with the fix (2.5/ANCIENT); the 4th (exact-generation match unaffected) passes on both, confirming the fix doesn't touch precisely identified hardware

Note: I could not find `lookup_hardware`/`calculate_poa_multiplier` imported anywhere else in this tree (grepped `node/*.py` and the top-level integrated file) -- if this module isn't currently wired into the live node's reward path, the fix is still correct and ready for whenever it is.

/claim
RTC wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`