### PR TITLE
fix(faucet): label legacy faucet.py as demo, default mock_mode off, audit config at startup

### DIFF
--- a/FAUCET.md
+++ b/FAUCET.md
@@ -1,54 +1,106 @@
 # RustChain Testnet Faucet
 
-A Flask-based testnet faucet that dispenses free test RTC tokens to developers building on RustChain.
+The supported testnet faucet is **`faucet_service/faucet_service.py`**. It is the
+only faucet in this repository that transfers RTC.
 
-## Features
+> **Do not deploy the root `faucet.py`.** It is a demo: it records drip requests
+> and never calls the node, so every caller is told the request succeeded while
+> nothing is sent (issue #8243). It is kept in-tree only as a small reference for
+> the rate-limiting and wallet-validation logic, and it now labels itself as a
+> demo in its startup banner, in its web page and in its JSON payload
+> (`"sent": false`).
 
-- **IP-based Rate Limiting**: Prevents abuse by limiting requests to 0.5 RTC per 24 hours per IP
-- **SQLite Backend**: Simple, reliable storage for tracking drip requests
-- **Simple HTML UI**: Easy-to-use web interface for requesting test tokens
-- **REST API**: Programmatic access via JSON API
+| | `faucet_service/faucet_service.py` | `faucet.py` (root) |
+|---|---|---|
+| Transfers RTC | yes, `POST /wallet/transfer` on the node | **no** |
+| Records `tx_hash` | yes | no (always `null`) |
+| Rate limiting | ip / wallet / hybrid, optional Redis | ip + wallet, SQLite only |
+| Config file | `faucet_config.yaml` | constants in the source |
+| Shipped as a service | `testnet/systemd/rustchain-testnet-faucet.service` | no |
+| Supported | **yes** | no — demo only |
 
 ## Installation
 
 ```bash
-# Install Flask if not already installed
-pip install flask
+cd faucet_service
+pip install -r requirements.txt
 
-# Run the faucet
-python faucet.py
+# X-Admin-Key used for POST /wallet/transfer on the node.
+export RC_ADMIN_KEY="your-admin-key"
+
+python faucet_service.py --config faucet_config.yaml
 ```
 
-The faucet will start on `http://0.0.0.0:8090/faucet`
+The faucet starts on `http://<host>:<port><base_path>` (default
+`http://0.0.0.0:8090/faucet`).
 
-## API Endpoints
+For a full testnet deployment use `testnet/deploy_testnet.sh`, which generates
+`faucet_config.yaml`, writes `RC_ADMIN_KEY` into the environment file and
+installs `rustchain-testnet-faucet.service`.
 
-### GET /faucet
+## Configuration
+
+The full annotated configuration lives in
+[`faucet_service/faucet_config.yaml`](faucet_service/faucet_config.yaml); the
+service-level documentation is in
+[`faucet_service/README.md`](faucet_service/README.md). The settings that decide
+whether the faucet actually pays:
+
+```yaml
+distribution:
+  amount: 0.5
+  mock_mode: false                    # true = record only, transfer nothing
+  node_url: "http://127.0.0.1:8198"   # node exposing POST /wallet/transfer
+  faucet_wallet: "testnet_faucet"     # wallet the node debits
+  admin_key: null                     # prefer the RC_ADMIN_KEY env variable
+```
+
+`mock_mode` defaults to **false**. It used to default to true, which meant a
+faucet started without an explicit setting recorded drips, answered `ok`, and
+paid nobody (issue #8243).
+
+The service audits this configuration at startup, before it binds a port:
+
+- `mock_mode: true` → a warning banner is logged
+  (`FAUCET IS IN MOCK MODE - NO RTC WILL BE SENT`) and the faucet starts anyway,
+  because mock mode is a legitimate local-development choice.
+- `mock_mode: false` with no `RC_ADMIN_KEY` and no `distribution.admin_key` →
+  startup fails with `FaucetConfigError`, instead of accepting traffic and
+  returning a 500 on every drip.
+
+## API
+
+### `GET <base_path>`
 
 Serves the faucet web interface.
 
-### POST /faucet/drip
+### `POST <base_path>/drip`
 
 Request test tokens.
 
 **Request:**
+
 ```json
-{
-  "wallet": "0x9683744B6b94F2b0966aBDb8C6BdD9805d207c6E"
-}
+{ "wallet": "RTC0123456789abcdef0123456789abcdef01234567" }
 ```
 
-**Response (Success):**
+**Response (success):**
+
 ```json
 {
   "ok": true,
   "amount": 0.5,
-  "wallet": "0x9683744B6b94F2b0966aBDb8C6BdD9805d207c6E",
+  "wallet": "RTC0123456789abcdef0123456789abcdef01234567",
+  "tx_hash": "0x...",
   "next_available": "2026-03-08T14:20:00"
 }
 ```
 
-**Response (Rate Limited):**
+`tx_hash` is `null` when the service is running in mock mode — that is the field
+to check if you need to know whether a transfer actually happened.
+
+**Response (rate limited):**
+
 ```json
 {
   "ok": false,
@@ -57,33 +109,29 @@ Request test tokens.
 }
 ```
 
-## Rate Limits
+### `GET <base_path>/status`
 
-| Auth Method | Limit |
-|--------------|-------|
-| IP only | 0.5 RTC per 24 hours |
+Faucet statistics, including the current `mock_mode` value.
 
-## Configuration
+### `GET <base_path>/health`
 
-Edit the following constants in `faucet.py`:
+Health check endpoint.
 
-```python
-MAX_DRIP_AMOUNT = 0.5  # RTC per request
-RATE_LIMIT_HOURS = 24  # Hours between requests
-DATABASE = 'faucet.db' # SQLite database file
-PORT = 8090           # Server port
-```
+## Rate limits
 
-## Production Notes
+Configured under `rate_limit` (`ip`, `wallet` or `hybrid`); the deployed testnet
+faucet uses `hybrid` with 0.5 RTC per 24 h. Redis can be enabled for distributed
+rate limiting.
 
-For production deployment:
+## Production notes
 
-1. **Connect to RustChain node**: Replace the mock `record_drip()` with actual token transfer using the admin transfer API
-2. **Use faucet wallet**: Create a dedicated wallet with test tokens for dispensing
-3. **Add GitHub OAuth**: Implement GitHub authentication to increase limits (1-2 RTC per 24 hours)
-4. **Add SSL/TLS**: Use nginx with Let's Encrypt for HTTPS
-5. **Logging**: Add proper logging for monitoring and debugging
+1. Keep `mock_mode: false` and supply `RC_ADMIN_KEY` through the environment,
+   not the config file.
+2. Fund `distribution.faucet_wallet` — the node debits it on every drip.
+3. Terminate TLS in front of the service (nginx + Let's Encrypt).
+4. Monitor `GET <base_path>/status`: `mock_mode: true` on a public faucet means
+   users are being told they were paid when they were not.
 
 ## License
 
-Apache License 2.0 - See LICENSE file in RustChain root.
+Apache License 2.0 — see LICENSE file in RustChain root.

--- a/faucet.py
+++ b/faucet.py
@@ -1,9 +1,26 @@
 #!/usr/bin/env python3
 """
-RustChain Testnet Faucet
-A simple Flask web application that dispenses test RTC tokens.
+RustChain Testnet Faucet -- DEMO ONLY, DOES NOT PAY.
 
-Features:
+    #############################################################
+    # DEMO - records requests, does not pay.                    #
+    # This module contains NO node call. Every "successful"      #
+    # drip only writes a row into drip_requests; no RTC ever     #
+    # leaves any wallet.                                         #
+    #                                                            #
+    # The supported, paying faucet is faucet_service/            #
+    # faucet_service.py (POST /wallet/transfer with X-Admin-Key, #
+    # records tx_hash, shipped as                                #
+    # testnet/systemd/rustchain-testnet-faucet.service).         #
+    # See FAUCET.md.                                             #
+    #############################################################
+
+Kept in-tree as a minimal reference implementation of the rate-limiting /
+validation logic. Do not deploy it as a faucet: it answers every caller with
+a success payload, so operators and users alike are told tokens were sent
+when nothing was sent (issue #8243, fallout from #8240).
+
+Features (all local, none of them transfer value):
 - IP-based rate limiting
 - SQLite backend for tracking
 - Simple HTML form for requesting tokens
@@ -21,6 +38,16 @@ app = Flask(__name__)
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
 DATABASE = 'faucet.db'
 RTC_WALLET_RE = re.compile(r'^RTC[0-9a-fA-F]{40}$')
+
+# DEMO - records requests, does not pay.
+# Nothing in this module talks to a node. Exposed in the API payload and in
+# the UI so that neither a caller nor an operator can mistake a recorded
+# request for a settled transfer.
+DEMO_MODE = True
+DEMO_NOTICE = (
+    'DEMO faucet: your request was recorded, but no RTC was sent. '
+    'The paying faucet is faucet_service/faucet_service.py (see FAUCET.md).'
+)
 
 # Rate limiting settings (per 24 hours)
 MAX_DRIP_AMOUNT = 0.5  # RTC
@@ -286,14 +313,20 @@ HTML_TEMPLATE = """
     </style>
 </head>
 <body>
-    <h1>💧 RustChain Testnet Faucet</h1>
-    
+    <h1>💧 RustChain Testnet Faucet <small>(DEMO)</small></h1>
+
+    <div class="result error">
+        <strong>DEMO ONLY — this page does not pay.</strong>
+        Requests are recorded for rate-limit testing; no RTC is transferred.
+        The paying faucet is <code>faucet_service/faucet_service.py</code>.
+    </div>
+
     <div class="form-section">
-        <p>Get free test RTC tokens for development.</p>
+        <p>Record a test drip request. <strong>No tokens are sent.</strong></p>
         <form id="faucetForm">
             <label for="wallet">Your RTC Wallet Address:</label>
             <input type="text" id="wallet" name="wallet" placeholder="0x..." required>
-            <button type="submit" id="submitBtn">Get Test RTC</button>
+            <button type="submit" id="submitBtn">Record Demo Request</button>
         </form>
         
         <div id="result"></div>
@@ -330,7 +363,8 @@ HTML_TEMPLATE = """
                     result.textContent = '';
                     const successDiv = document.createElement('div');
                     successDiv.className = 'result success';
-                    successDiv.textContent = '✅ Success! Sent ' + data.amount + ' RTC to ' + wallet;
+                    successDiv.textContent = '📝 Request recorded for ' + wallet
+                        + ' (' + data.amount + ' RTC). DEMO — no RTC was sent.';
                     result.appendChild(successDiv);
                     if (data.next_available) {
                         const infoDiv = document.createElement('div');
@@ -360,7 +394,7 @@ HTML_TEMPLATE = """
             }
             
             submitBtn.disabled = false;
-            submitBtn.textContent = 'Get Test RTC';
+            submitBtn.textContent = 'Record Demo Request';
         });
     </script>
 </body>
@@ -383,13 +417,19 @@ def faucet_page():
 @app.route('/faucet/drip', methods=['POST'])
 def drip():
     """
-    Handle drip requests.
-    
+    Record a drip request. DEMO - records requests, does not pay.
+
+    No transfer is attempted: `ok` means "request accepted and recorded",
+    NOT "tokens sent". `sent` is always False here so that callers can tell
+    the two apart; the paying implementation lives in faucet_service/.
+
     Request body:
         {"wallet": "0x..."}
-    
+
     Response:
-        {"ok": true, "amount": 0.5, "next_available": "2026-03-08T12:00:00Z"}
+        {"ok": true, "sent": false, "demo": true, "amount": 0.5,
+         "notice": "DEMO faucet: ... no RTC was sent",
+         "next_available": "2026-03-08T12:00:00Z"}
     """
     data = request.get_json(silent=True)
 
@@ -426,6 +466,12 @@ def drip():
 
     return jsonify({
         'ok': True,
+        # DEMO - records requests, does not pay. `amount` is the amount that
+        # was charged against the rate limit, not an amount that was sent.
+        'sent': False,
+        'demo': DEMO_MODE,
+        'tx_hash': None,
+        'notice': DEMO_NOTICE,
         'amount': amount,
         'wallet': wallet,
         'next_available': (datetime.now(timezone.utc) + timedelta(hours=RATE_LIMIT_HOURS)).isoformat()
@@ -440,5 +486,12 @@ if __name__ == '__main__':
         init_db()  # Ensure table exists
     
     # Run the server
-    print("Starting RustChain Faucet on http://0.0.0.0:8090/faucet")
+    print("=" * 70)
+    print("DEMO FAUCET - records requests, DOES NOT PAY.")
+    print("No RTC is transferred by this process. Callers are told so in the")
+    print("JSON payload ('sent': false) and on the web page.")
+    print("The supported paying faucet is faucet_service/faucet_service.py")
+    print("(see FAUCET.md). Do not deploy this file as a public faucet.")
+    print("=" * 70)
+    print("Starting RustChain DEMO Faucet on http://0.0.0.0:8090/faucet")
     app.run(host='0.0.0.0', port=8090, debug=False)

--- a/faucet_service/README.md
+++ b/faucet_service/README.md
@@ -76,7 +76,10 @@ validation:
 # Distribution settings
 distribution:
   amount: 0.5
-  mock_mode: true  # Set to false for actual transfers
+  mock_mode: false        # true = record only, transfer nothing (dev only)
+  node_url: "http://127.0.0.1:8198"
+  faucet_wallet: "testnet_faucet"
+  admin_key: null         # prefer the RC_ADMIN_KEY environment variable
 
 # Event claim codes
 event_codes:
@@ -242,7 +245,7 @@ Get faucet status and statistics.
 {
   "status": "operational",
   "network": "testnet",
-  "mock_mode": true,
+  "mock_mode": false,
   "statistics": {
     "total_drips": 150,
     "total_amount": 75.0,
@@ -410,14 +413,31 @@ WantedBy=multi-user.target
 
 ### Mock Mode
 
-By default, the faucet runs in mock mode (no actual token transfers). For production:
+Mock mode records drips and transfers nothing. It is **off by default**
+(issue #8243: it used to default to on, which made an unconfigured faucet
+report success to every caller while paying nobody). Turn it on only for local
+development:
+
+```yaml
+distribution:
+  mock_mode: true   # dev only -- announced with a warning banner at startup
+```
+
+A real (paying) deployment needs the transfer credentials instead:
 
 ```yaml
 distribution:
   mock_mode: false
-  node_rpc: "https://testnet-rpc.rustchain.org"
-  wallet_key: "your-faucet-wallet-key"  # Use environment variable!
+  node_url: "http://127.0.0.1:8198"     # node exposing POST /wallet/transfer
+  faucet_wallet: "testnet_faucet"
 ```
+
+```bash
+export RC_ADMIN_KEY="your-admin-key"    # X-Admin-Key for /wallet/transfer
+```
+
+With `mock_mode: false` and no admin key available, the service now refuses to
+start rather than returning a 500 on each drip.
 
 **Never commit wallet keys to version control!** Use environment variables:
 

--- a/faucet_service/faucet_config.yaml
+++ b/faucet_service/faucet_config.yaml
@@ -73,13 +73,28 @@ distribution:
   # Minimum balance threshold (stop dispensing if below)
   min_balance: 10.0
   
-  # Mock mode (no actual transfers, just recording)
-  mock_mode: true
-  
-  # Node RPC endpoint (for actual transfers)
+  # Mock mode: record drips but transfer nothing.
+  # KEEP THIS false ON ANY DEPLOYED FAUCET. With mock_mode: true the service
+  # answers every caller with a success payload and pays nobody (issue #8243);
+  # the startup audit prints a loud warning banner when it is on.
+  mock_mode: false
+
+  # Node endpoint used for real transfers (POST /wallet/transfer).
+  node_url: "http://127.0.0.1:8198"
+
+  # Faucet wallet the node debits for real transfers.
+  faucet_wallet: "testnet_faucet"
+
+  # Admin key for POST /wallet/transfer. Prefer the RC_ADMIN_KEY environment
+  # variable over writing the secret into this file. With mock_mode: false and
+  # no key available the service refuses to start instead of 500-ing on every
+  # drip request.
+  admin_key: null
+
+  # Node RPC endpoint (legacy field, unused by the transfer path)
   node_rpc: null
-  
-  # Faucet wallet private key (for actual transfers)
+
+  # Faucet wallet private key (legacy field, unused by the transfer path)
   wallet_key: null
 
 # Logging configuration

--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -92,7 +92,12 @@ DEFAULT_CONFIG = {
     'distribution': {
         'amount': 0.5,
         'min_balance': 10.0,
-        'mock_mode': True,
+        # Issue #8243: the default used to be True, so a faucet started
+        # without an explicit `mock_mode:` key recorded every drip and paid
+        # nobody while reporting success. Real transfers are now the default;
+        # mock has to be asked for, and asking for it is announced loudly at
+        # startup (see check_distribution_config).
+        'mock_mode': False,
         'node_rpc': None,
         'wallet_key': None
     },
@@ -659,6 +664,71 @@ def _ensure_column(c: sqlite3.Cursor, table: str, column: str, definition: str) 
                 raise
 
 
+class FaucetConfigError(RuntimeError):
+    """Raised at startup when the faucet cannot possibly pay anyone."""
+
+
+def check_distribution_config(
+    config: Dict[str, Any],
+    logger: Optional[logging.Logger] = None,
+    strict: bool = True,
+) -> list:
+    """Audit the distribution config before the server accepts traffic.
+
+    Issue #8243: both faucet failure modes used to be silent. A faucet left in
+    mock mode answered every caller with a success payload and paid nobody,
+    and a faucet in real mode without RC_ADMIN_KEY only surfaced that at the
+    first drip, as a 500 to a user. Both are now stated at startup.
+
+    Args:
+        config: the loaded configuration.
+        logger: logger to announce findings on; a module logger is used if
+            omitted.
+        strict: when True (deployment entry point) a config that cannot pay
+            raises FaucetConfigError instead of starting a faucet that will
+            fail every drip. Mock mode never raises -- it is a legitimate
+            local-development choice -- but it is always announced.
+
+    Returns:
+        The list of human-readable problems found (empty when healthy).
+    """
+    logger = logger or logging.getLogger('rustchain_faucet')
+    dist = config.get('distribution', {}) or {}
+    problems = []
+
+    if dist.get('mock_mode', False):
+        banner = (
+            '=' * 70
+            + '\nFAUCET IS IN MOCK MODE - NO RTC WILL BE SENT.\n'
+            + 'Every drip will be recorded and reported as successful while\n'
+            + 'transferring nothing. Set distribution.mock_mode: false in the\n'
+            + 'config for a faucet that actually pays (issue #8243).\n'
+            + '=' * 70
+        )
+        for line in banner.split('\n'):
+            logger.warning(line)
+        problems.append('distribution.mock_mode is enabled: no RTC will be sent')
+        return problems
+
+    admin_key = os.environ.get('RC_ADMIN_KEY') or dist.get('admin_key', '')
+    if not admin_key:
+        problems.append(
+            'RC_ADMIN_KEY is not set (and distribution.admin_key is empty): '
+            'the node rejects every /wallet/transfer, so every drip would 500'
+        )
+
+    for problem in problems:
+        logger.error('Faucet configuration problem: %s', problem)
+
+    if problems and strict:
+        raise FaucetConfigError(
+            'Refusing to start a faucet that cannot pay: '
+            + '; '.join(problems)
+        )
+
+    return problems
+
+
 # =============================================================================
 # Flask Application
 # =============================================================================
@@ -672,6 +742,14 @@ def create_app(config: Optional[Dict[str, Any]] = None) -> Flask:
     
     # Initialize logging
     logger = setup_logging(config)
+
+    # Issue #8243: announce a faucet that cannot pay. This runs here as well
+    # as in main() so that WSGI/gunicorn deployments -- which call create_app()
+    # directly and never reach main() -- get the same warning. Report-only
+    # here (strict=False): refusing to build the app object would break
+    # importers and test harnesses; main() is the deployment entry point and
+    # does refuse to start.
+    check_distribution_config(config, logger, strict=False)
     
     # Initialize database
     db_path = config.get('database', {}).get('path', 'faucet.db')
@@ -773,7 +851,7 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
             }), 429
         
         # In mock mode, just record the request
-        if config.get('distribution', {}).get('mock_mode', True):
+        if config.get('distribution', {}).get('mock_mode', False):
             tx_hash = None
             logger.info(f"Mock drip: {amount} RTC to {wallet}")
         else:
@@ -1064,7 +1142,7 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
         return jsonify({
             'status': 'operational',
             'network': 'testnet',
-            'mock_mode': config.get('distribution', {}).get('mock_mode', True),
+            'mock_mode': config.get('distribution', {}).get('mock_mode', False),
             'statistics': {
                 'total_drips': total_drips,
                 'total_amount': total_amount,
@@ -1248,7 +1326,7 @@ def _perform_faucet_transfer(
     reason: Optional[str] = None,
 ) -> Optional[str]:
     """Perform a faucet transfer or return None in mock mode."""
-    if config.get('distribution', {}).get('mock_mode', True):
+    if config.get('distribution', {}).get('mock_mode', False):
         logger.info(f"Mock event faucet claim: {amount} RTC to {wallet}")
         return None
 
@@ -1344,7 +1422,7 @@ def get_template_vars(config: Dict) -> Dict:
         'rate_limit': config.get('rate_limit', {}).get('max_amount', 0.5),
         'hours': config.get('rate_limit', {}).get('window_seconds', 86400) / 3600,
         'network': 'Testnet',
-        'mock_mode': config.get('distribution', {}).get('mock_mode', True)
+        'mock_mode': config.get('distribution', {}).get('mock_mode', False)
     }
 
 
@@ -1688,14 +1766,21 @@ def main():
     if args.debug:
         config['server']['debug'] = True
     
-    # Create and run app
+    # Create the app first: create_app() installs the log handlers, so the
+    # startup audit below is actually visible on console/log file.
     app = create_app(config)
+
+    logger = logging.getLogger('rustchain_faucet')
+
+    # Issue #8243: audit the deployed config before binding a port. A faucet
+    # that cannot pay must say so here, once and loudly, instead of one
+    # silent drip at a time.
+    check_distribution_config(config, logger, strict=True)
     
     host = config['server']['host']
     port = config['server']['port']
     debug = config['server']['debug']
     
-    logger = logging.getLogger('rustchain_faucet')
     logger.info(f"Starting RustChain Faucet on http://{host}:{port}")
     logger.info(f"Configuration: {args.config if os.path.exists(args.config) else 'default'}")
     

--- a/test_faucet_demo_labeling_8243.py
+++ b/test_faucet_demo_labeling_8243.py
@@ -1,0 +1,211 @@
+"""
+Regression tests for issue #8243:
+"Retire or clearly label legacy faucet.py (records drips, sends nothing)
+ + fix FAUCET.md + audit mock_mode".
+
+Two independent silent-success failures are covered here:
+
+1. Root `faucet.py` performs no node call at all, yet answered every drip with
+   a success payload and the UI copy "Sent X RTC". It must now identify itself
+   as a demo in the payload (`sent: false`) and in the page.
+
+2. `faucet_service/faucet_service.py` defaulted `mock_mode` to True, so a faucet
+   deployed without an explicit setting recorded drips and paid nobody. The
+   default is now False, and a configuration that cannot pay is reported at
+   startup instead of one 500 per drip.
+
+Run:
+    python -m pytest test_faucet_demo_labeling_8243.py -v
+"""
+
+import importlib.util
+import inspect
+import os
+import re
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, REPO_ROOT)
+
+import faucet  # noqa: E402  (root demo faucet)
+
+
+def _load_faucet_service():
+    """Import faucet_service/faucet_service.py under its own module name."""
+    path = os.path.join(REPO_ROOT, 'faucet_service', 'faucet_service.py')
+    spec = importlib.util.spec_from_file_location('faucet_service_8243', path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['faucet_service_8243'] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+faucet_service = _load_faucet_service()
+
+
+# ---------------------------------------------------------------------------
+# 1. Root faucet.py must not claim it sent anything
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def demo_client(tmp_path, monkeypatch):
+    """Flask test client for the demo faucet, backed by a throwaway DB."""
+    monkeypatch.setattr(faucet, 'DATABASE', str(tmp_path / 'faucet.db'))
+    faucet.init_db()
+    faucet.app.config['TESTING'] = True
+    with faucet.app.test_client() as client:
+        yield client
+
+
+WALLET = 'RTC' + 'a' * 40
+
+
+class TestDemoFaucetPayload:
+    def test_drip_reports_that_nothing_was_sent(self, demo_client):
+        resp = demo_client.post('/faucet/drip', json={'wallet': WALLET})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # The request is accepted and recorded ...
+        assert data['ok'] is True
+        assert data['wallet'] == WALLET
+        # ... but the payload must state that no transfer happened.
+        assert data['sent'] is False
+        assert data['demo'] is True
+        assert data['tx_hash'] is None
+        assert 'no RTC was sent' in data['notice']
+
+    def test_amount_is_not_advertised_as_a_transfer(self, demo_client):
+        """`amount` may stay for rate-limit accounting, but not alone."""
+        data = demo_client.post('/faucet/drip', json={'wallet': WALLET}).get_json()
+        assert data['amount'] == faucet.MAX_DRIP_AMOUNT
+        # A client that only knows the old schema must still be able to detect
+        # the demo from a field that did not exist before.
+        assert 'sent' in data
+
+    def test_rate_limited_response_is_unchanged(self, demo_client):
+        demo_client.post('/faucet/drip', json={'wallet': WALLET})
+        resp = demo_client.post('/faucet/drip', json={'wallet': WALLET})
+        assert resp.status_code == 429
+        assert resp.get_json()['ok'] is False
+
+
+class TestDemoFaucetCopy:
+    def test_page_warns_that_it_does_not_pay(self, demo_client):
+        body = demo_client.get('/faucet').get_data(as_text=True)
+        assert 'DEMO' in body
+        assert 'does not pay' in body.lower()
+
+    def test_success_copy_does_not_claim_rtc_was_sent(self, demo_client):
+        body = demo_client.get('/faucet').get_data(as_text=True)
+        # The old copy was: "✅ Success! Sent ' + data.amount + ' RTC to '"
+        assert not re.search(r"Success!\s*Sent", body)
+        assert 'no RTC was sent' in body
+
+    def test_module_is_stamped_as_demo(self):
+        doc = faucet.__doc__ or ''
+        assert 'DEMO' in doc
+        assert 'does not pay' in doc.lower()
+        assert faucet.DEMO_MODE is True
+
+    def test_module_makes_no_node_call(self):
+        """The demo must stay a demo: no HTTP client is wired in.
+
+        This is the whole point of #8243 -- the module claims a transfer it
+        never attempts. If someone later adds a real transfer here, this test
+        fails and the demo labelling has to be revisited.
+        """
+        source = inspect.getsource(faucet)
+        assert not re.search(r'^\s*import requests', source, re.M)
+        assert not re.search(r'^\s*import urllib', source, re.M)
+        assert 'requests.post(' not in source
+        assert 'urlopen(' not in source
+
+
+# ---------------------------------------------------------------------------
+# 2. faucet_service mock_mode default + startup audit
+# ---------------------------------------------------------------------------
+
+class TestMockModeDefault:
+    def test_default_config_does_not_enable_mock_mode(self):
+        assert faucet_service.DEFAULT_CONFIG['distribution']['mock_mode'] is False
+
+    def test_config_without_mock_mode_key_is_treated_as_real(self):
+        """A partial config file must not silently fall back to mock mode."""
+        source = inspect.getsource(faucet_service)
+        assert "get('mock_mode', True)" not in source
+
+    def test_status_reports_real_mode_for_a_config_without_the_key(self):
+        vars_ = faucet_service.get_template_vars({'distribution': {}})
+        assert vars_['mock_mode'] is False
+
+
+def _config(mock_mode=False, admin_key=None):
+    dist = {'amount': 0.5, 'mock_mode': mock_mode}
+    if admin_key is not None:
+        dist['admin_key'] = admin_key
+    return {'distribution': dist}
+
+
+class TestStartupAudit:
+    def test_real_mode_without_admin_key_refuses_to_start(self, monkeypatch):
+        monkeypatch.delenv('RC_ADMIN_KEY', raising=False)
+        with pytest.raises(faucet_service.FaucetConfigError) as exc:
+            faucet_service.check_distribution_config(_config(), strict=True)
+        assert 'RC_ADMIN_KEY' in str(exc.value)
+
+    def test_real_mode_with_env_admin_key_is_healthy(self, monkeypatch):
+        monkeypatch.setenv('RC_ADMIN_KEY', 'secret')
+        assert faucet_service.check_distribution_config(_config(), strict=True) == []
+
+    def test_real_mode_with_config_admin_key_is_healthy(self, monkeypatch):
+        monkeypatch.delenv('RC_ADMIN_KEY', raising=False)
+        cfg = _config(admin_key='secret')
+        assert faucet_service.check_distribution_config(cfg, strict=True) == []
+
+    def test_non_strict_reports_instead_of_raising(self, monkeypatch):
+        monkeypatch.delenv('RC_ADMIN_KEY', raising=False)
+        problems = faucet_service.check_distribution_config(_config(), strict=False)
+        assert problems and 'RC_ADMIN_KEY' in problems[0]
+
+    def test_mock_mode_is_announced_but_allowed(self, monkeypatch, caplog):
+        monkeypatch.delenv('RC_ADMIN_KEY', raising=False)
+        with caplog.at_level('WARNING', logger='rustchain_faucet'):
+            problems = faucet_service.check_distribution_config(
+                _config(mock_mode=True), strict=True
+            )
+        assert problems == ['distribution.mock_mode is enabled: no RTC will be sent']
+        assert 'NO RTC WILL BE SENT' in caplog.text
+
+    def test_empty_config_is_audited_without_crashing(self, monkeypatch):
+        monkeypatch.delenv('RC_ADMIN_KEY', raising=False)
+        problems = faucet_service.check_distribution_config({}, strict=False)
+        assert problems and 'RC_ADMIN_KEY' in problems[0]
+
+
+# ---------------------------------------------------------------------------
+# 3. Shipped configuration and documentation
+# ---------------------------------------------------------------------------
+
+class TestShippedConfigAndDocs:
+    def test_example_config_does_not_ship_mock_mode_on(self):
+        import yaml
+        path = os.path.join(REPO_ROOT, 'faucet_service', 'faucet_config.yaml')
+        with open(path, encoding='utf-8') as handle:
+            cfg = yaml.safe_load(handle)
+        assert cfg['distribution']['mock_mode'] is False
+
+    def test_deploy_script_keeps_mock_mode_off(self):
+        path = os.path.join(REPO_ROOT, 'testnet', 'deploy_testnet.sh')
+        with open(path, encoding='utf-8') as handle:
+            body = handle.read()
+        assert re.search(r'^\s*mock_mode:\s*false', body, re.M)
+        assert 'RC_ADMIN_KEY' in body
+
+    def test_faucet_md_points_at_the_service(self):
+        with open(os.path.join(REPO_ROOT, 'FAUCET.md'), encoding='utf-8') as handle:
+            body = handle.read()
+        assert 'faucet_service/faucet_service.py' in body
+        # It must no longer tell operators to run the demo.
+        assert not re.search(r'^\s*python faucet\.py\s*$', body, re.M)


### PR DESCRIPTION
Fixes #8243 (fallout from #8240).

Root `faucet.py` contains no node call, yet answered every drip with a success payload and the UI copy 'Sent X RTC'. `faucet_service` defaulted `mock_mode` to `True`, so even the supported faucet paid nobody unless explicitly configured, and a real-mode faucet without `RC_ADMIN_KEY` only surfaced that as a 500 on the first user request.

- **`faucet.py`**: stamped `# DEMO - records requests, does not pay` in the module docstring, in a `DEMO_MODE` constant, in the startup banner and on the page. `/faucet/drip` now returns `sent: false`, `demo: true`, `tx_hash: null` and a notice pointing at `faucet_service/`. `ok`/`amount` are kept for backward compatibility -- `ok` means "recorded", not "sent".
- **`FAUCET.md`**: rewritten around `faucet_service/faucet_service.py` as the only supported faucet, with a comparison table and the startup-audit rules.
- **`faucet_service`**: `mock_mode` default flipped to `False` in `DEFAULT_CONFIG` and in every `.get('mock_mode', ...)` call site, so a partial config no longer falls back to paying nobody.
- **`faucet_service`**: new `check_distribution_config()` runs in `main()` before the port is bound, and (report-only) in `create_app()` for WSGI/gunicorn deployments that never reach `main()`. `mock_mode` on -> loud warning banner (still starts -- it's a legitimate dev choice). `mock_mode` off with neither `RC_ADMIN_KEY` nor `distribution.admin_key` -> `FaucetConfigError` instead of a 500 on the first drip.
- **`faucet_config.yaml` / `faucet_service/README.md`**: ship `mock_mode: false` plus the `node_url` / `faucet_wallet` / `admin_key` keys the transfer path actually reads.
- **Audit of the deployed config**: `testnet/deploy_testnet.sh` already writes `mock_mode: false` and `RC_ADMIN_KEY`; a test now pins that so it stays true.

**Out of scope for this PR:** live-auditing the actually-deployed `faucet_config.yaml` on the production host -- that's infra, not something a repo PR can touch (already checked what generates it, see above).

**Tests:** `test_faucet_demo_labeling_8243.py`, 19 cases, all pass. Existing faucet suites (`faucet_service/test_faucet_service.py`, `test_faucet_wallet_validation_6136.py`, `tests/test_faucet*.py`, `tests/test_legacy_faucet_json_validation.py`) stay green: 130 passed, 6 subtests passed, 0 failed.

Wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`