### PR TITLE
ci: add automated markdown link checker (closes rustchain-bounties#16248)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,40 @@
+name: Link Checker
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  schedule:
+    - cron: "0 6 * * 1" # weekly Monday 06:00 UTC
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --exclude-mail
+            --exclude "http://127.0.0.1.*"
+            --exclude "https://127.0.0.1.*"
+            --exclude "http://localhost.*"
+            --exclude "https://localhost.*"
+            --exclude "https://50.28.86.131*"
+            --exclude "https://rustchain.org/faq"
+            --accept 200,206,301,302,304,403,405,429
+            --max-concurrency 4
+            --timeout 20
+            --retry-wait-time 2
+            --max-retries 2
+            "**/*.md"
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/check_links.py
+++ b/check_links.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Quick markdown external link checker (requests-based). Excludes localhost/IPs."""
+import os, re, sys, requests
+from urllib.parse import urlparse
+
+EXCLUDE = re.compile(r"127\.0\.0\.1|localhost|50\.28\.86\.131|rustchain\.org/faq")
+URL_RE = re.compile(r"https?://[^\s)\]>'\"`]+")
+SKIP_EXT = (".png", ".jpg", ".svg", ".ico", ".woff", ".ttf")
+
+def md_files(root):
+    for dp, _, fns in os.walk(root):
+        if "node_modules" in dp or ".git" in dp:
+            continue
+        for f in fns:
+            if f.endswith(".md"):
+                yield os.path.join(dp, f)
+
+def main(root="."):
+    urls = {}
+    for fp in md_files(root):
+        try:
+            txt = open(fp, encoding="utf-8", errors="ignore").read()
+        except Exception:
+            continue
+        for m in URL_RE.findall(txt):
+            u = m.rstrip(".,)")
+            if EXCLUDE.search(u): continue
+            if u.lower().endswith(SKIP_EXT): continue
+            urls.setdefault(u, []).append(fp)
+    print(f"Checking {len(urls)} unique URLs...")
+    broken = {}
+    s = requests.Session(); s.headers["User-Agent"] = "Mozilla/5.0 linkcheck"
+    for u in urls:
+        try:
+            r = s.get(u, timeout=15, allow_redirects=True)
+            if r.status_code >= 400:
+                broken[u] = (r.status_code, urls[u][:2])
+        except Exception as e:
+            broken[u] = (f"ERR:{type(e).__name__}", urls[u][:2])
+    print(f"\nBROKEN ({len(broken)}):")
+    for u, (st, fns) in sorted(broken.items()):
+        print(f"  {st}  {u}")
+        print(f"        in: {fns}")
+    return 0 if not broken else 1
+
+sys.exit(main())


### PR DESCRIPTION
## Summary
Closes rustchain-bounties#16248 (5 RTC bounty).

Adds automated broken-link detection for the documentation so broken URLs across the 400+ external links in `docs/` and READMEs are caught automatically instead of by hand.

## Changes
- `.github/workflows/link-check.yml` — lychee-action based checker running on PRs + a weekly Monday cron. Excludes localhost, `127.0.0.1`, the node IP `50.28.86.131`, and known 301s (`rustchain.org/faq`). Accepts 200/206/301/302/304/403/405/429 to avoid false positives from bot-protected hosts.
- `check_links.py` — offline fallback checker (requests-based) for local verification, same exclusion rules.

## Verification
- `python3 check_links.py` runs locally and reports broken links.
- CI will fail on any genuinely broken external link, giving maintainers a clear signal.

## Notes
This pairs with the fresh-eyes finding in Scottcjn/Rustchain#8262 (no automated link checking existed). A follow-up PR can fix any specific broken URLs the checker surfaces.

## Test plan
- [x] Workflow YAML valid
- [x] check_links.py executes