### PR TITLE
docs: fix miner Quick Start script paths

### DIFF
--- a/miners/README.md
+++ b/miners/README.md
@@ -36,19 +36,19 @@ The Linux miner auto-detects your hardware via `platform.machine()` and reports 
 ```bash
 # Linux
 python3 -m pip install -r linux/requirements-miner.txt
-python3 rustchain_linux_miner.py
+python3 linux/rustchain_linux_miner.py
 
 # Linux dry run: print hardware fingerprint/preflight details without mining
-python3 rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+python3 linux/rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
 
 # macOS
-python3 rustchain_mac_miner_v2.4.py
+python3 macos/rustchain_mac_miner_v2.4.py
 
 # Windows
-python rustchain_windows_miner.py
+python windows/rustchain_windows_miner.py
 
 # If your Python does not include Tcl/Tk (common on minimal/embeddable installs):
-python rustchain_windows_miner.py --headless --wallet YOUR_WALLET_ID --node https://rustchain.org
+python windows/rustchain_windows_miner.py --headless --wallet YOUR_WALLET_ID --node https://rustchain.org
 ```
 
 ## Windows installer & build helpers


### PR DESCRIPTION
## Summary

- qualify the Linux, macOS, and Windows miner script paths with their platform subdirectories
- fix the Linux dry-run and Windows headless examples for the same working directory used by the requirements command
- keep the Quick Start commands copy-pasteable from `Rustchain/miners`

Closes #8265

## Verification

Run from `miners/`:

- `git diff --check`
- `python linux/rustchain_linux_miner.py --help`
- `python macos/rustchain_mac_miner_v2.4.py --help`
- `python windows/rustchain_windows_miner.py --help`
- `python linux/rustchain_linux_miner.py --dry-run --wallet L1nkinPark` — completed without mining; node health returned HTTP 200

## Bounty payout

- RTC wallet / miner_id / payout alias: `L1nkinPark`
- Native RTC payout address: `RTC973498f72747cd1637e395521319c0ad61c0f68c`
- Registration: https://github.com/Scottcjn/rustchain-bounties/issues/16647

AI assistance: Yes (Codex). The path reproduction, duplicate search, documentation edit, and command verification were performed against current `main`.