### PR TITLE
[UTXO-BUG] Keep mirror boxes from poisoning standalone coin selection

### DIFF
--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -209,6 +209,23 @@ def _selected_account_mirror_boxes(conn: sqlite3.Connection, selected: list) -> 
     return [r[0] for r in rows]
 
 
+def _spendable_utxo_candidates(conn: sqlite3.Connection, candidates: list) -> tuple:
+    """Remove account-mirror boxes from UTXO selection while dual-write is off."""
+    mirrored = set(_selected_account_mirror_boxes(conn, candidates))
+    if not mirrored:
+        return candidates, []
+    return [box for box in candidates if box.get('box_id') not in mirrored], sorted(mirrored)
+
+
+def _account_mirror_blocked_response(box_ids: list):
+    return jsonify({
+        'error': 'Box mirrors an account balance; move it via the account '
+                 'transfer path while dual-write is off',
+        'code': 'ACCOUNT_MIRROR_BOX_NOT_SPENDABLE',
+        'box_ids': box_ids,
+    }), 409
+
+
 def _ensure_transfer_nonce_table(conn: sqlite3.Connection) -> None:
     conn.execute(
         """
@@ -692,9 +709,19 @@ def utxo_transfer():
     # slice of a wallet, so loading every unspent box let a third party inflate
     # the cost of this call by sending dust to the sender's address.
     utxos = _utxo_db.get_coin_select_candidates(from_address)
+    all_candidate_total_nrtc = sum(u['value_nrtc'] for u in utxos)
+    mirror_candidate_ids = []
+    if not _dual_write:
+        conn = sqlite3.connect(_db_path)
+        try:
+            utxos, mirror_candidate_ids = _spendable_utxo_candidates(conn, utxos)
+        finally:
+            conn.close()
     selected, change_nrtc = coin_select(utxos, target_nrtc)
 
     if not selected:
+        if mirror_candidate_ids and all_candidate_total_nrtc >= target_nrtc:
+            return _account_mirror_blocked_response(mirror_candidate_ids)
         utxo_balance = _utxo_db.get_balance(from_address)
         return jsonify({
             'error': 'Insufficient UTXO balance',
@@ -773,12 +800,7 @@ def utxo_transfer():
             mirrored = _selected_account_mirror_boxes(conn, selected)
             if mirrored:
                 conn.rollback()
-                return jsonify({
-                    'error': 'Box mirrors an account balance; move it via the account '
-                             'transfer path while dual-write is off',
-                    'code': 'ACCOUNT_MIRROR_BOX_NOT_SPENDABLE',
-                    'box_ids': mirrored,
-                }), 409
+                return _account_mirror_blocked_response(mirrored)
 
         ok = _utxo_db.apply_transaction(tx, block_height, conn=conn)
         if not ok:

--- a/tests/test_utxo_transfer_spends_account_mirror.py
+++ b/tests/test_utxo_transfer_spends_account_mirror.py
@@ -188,3 +188,53 @@ def test_independently_earned_boxes_are_unaffected(rig):
     })
 
     assert resp.status_code == 200, resp.get_json()
+
+
+def test_non_mirror_box_spends_when_same_wallet_also_has_small_mirror(rig):
+    """A small mirror box must not poison selection of spendable UTXOs.
+
+    With dual-write off, account-mirror boxes are correctly blocked because
+    the account balance behind them would not be debited. But a wallet may also
+    hold independently earned UTXOs. If a small mirror box sorts ahead of a
+    larger non-mirror box, smallest-first coin selection currently includes the
+    mirror in the selected set and the endpoint rejects the whole transfer even
+    though the non-mirror box alone can fund it.
+    """
+    client, utxo_db, db_path = rig
+
+    # Make the existing mirror small enough that smallest-first selection
+    # includes it before the independently earned box below.
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE balances SET amount_i64 = ? WHERE miner_id = ?",
+            (1_000_000, ALICE),
+        )
+        conn.execute(
+            "UPDATE utxo_boxes SET value_nrtc = ? WHERE box_id = ?",
+            (1 * UNIT, "mirror_box_alice"),
+        )
+        conn.execute(
+            "UPDATE account_mirror_boxes SET value_nrtc = ? WHERE box_id = ?",
+            (1 * UNIT, "mirror_box_alice"),
+        )
+
+    assert utxo_db.apply_transaction(
+        {"tx_type": "mining_reward", "inputs": [],
+         "outputs": [{"address": ALICE, "value_nrtc": 50 * UNIT}],
+         "timestamp": int(time.time()), "_allow_minting": True},
+        block_height=5,
+    ) is True
+
+    resp = _transfer(
+        client,
+        to_address="RTC_test_receiver",
+        amount_rtc=10.0,
+        nonce=1733420000002,
+    )
+
+    assert resp.status_code == 200, resp.get_json()
+    data = resp.get_json()
+    assert data["inputs_consumed"] == 1
+    assert data["to_address"] == "RTC_test_receiver"
+    assert utxo_db.get_balance("RTC_test_receiver") == 10 * UNIT
+    assert _unspent_mirror_value(db_path, ALICE) == 1 * UNIT


### PR DESCRIPTION
## Summary

Bounty context: rustchain-bounties#2819 (UTXO red-team / non-exploitable PR route).

With `UTXO_DUAL_WRITE=0`, `/utxo/transfer` correctly refuses to spend `account_mirror_boxes`, because those boxes mirror account-model balances and the account side would not be debited. The current guard runs after `coin_select()`, though, so a small mirror box can poison selection for the same wallet and block an otherwise valid spend from independently earned UTXOs.

## Repro / actual behavior before fix

Seed one wallet with:

- a small account-mirror box, e.g. 1 RTC;
- an independently earned non-mirror UTXO, e.g. 50 RTC;
- `dual_write=False`.

Then request a 10 RTC `/utxo/transfer`. The non-mirror 50 RTC box can fund the transfer by itself, but smallest-first selection picks `[mirror 1 RTC, non-mirror 50 RTC]`; the later mirror guard sees the mirror in `selected` and returns:

```json
{
  "code": "ACCOUNT_MIRROR_BOX_NOT_SPENDABLE"
}
```

That preserves safety, but it incorrectly blocks spendable non-mirror funds for the same wallet.

## Fix

- When dual-write is off, filter account-mirror boxes out of the UTXO candidate list before `coin_select()`.
- Preserve the existing 409 guard when a transfer would require mirror funds.
- Keep the in-transaction mirror check as a race-safety boundary in case provenance changes after preselection.
- Add a regression test where the same wallet has a small mirror box plus a larger non-mirror box; the transfer now consumes only the non-mirror box and leaves the mirror backing intact.

## Validation

- Red test before source fix: `tests/test_utxo_transfer_spends_account_mirror.py::test_non_mirror_box_spends_when_same_wallet_also_has_small_mirror` failed with `409 ACCOUNT_MIRROR_BOX_NOT_SPENDABLE`.
- `$env:PYTHONPATH='node'; uv run --no-project --with pytest --with flask python -m pytest -q tests\\test_utxo_transfer_spends_account_mirror.py` -> 4 passed
- `$env:PYTHONPATH='node'; uv run --no-project --with pytest --with flask python -m pytest -q tests\\test_utxo_transfer_replay.py` -> 2 passed
- `$env:PYTHONPATH='node'; uv run --no-project --with pytest --with flask python -m pytest -q tests\\test_utxo_transfer_nonce_required.py tests\\test_utxo_transfer_json_validation.py tests\\test_utxo_malformed_pubkey_6114.py` -> 12 passed
- `$env:PYTHONPATH='node'; uv run --no-project --with pytest --with flask python -m pytest -q node\\test_utxo_endpoints.py` -> 38 passed, 8 subtests passed
- `cd node; uv run --no-project --with pytest python -m pytest -q test_utxo_db.py` -> 103 passed, 31 subtests passed
- `python -m py_compile node\\utxo_endpoints.py tests\\test_utxo_transfer_spends_account_mirror.py`
- `git diff --check`


## Bounty payout

- Native RTC payout address: $wallet
- Public key: $pubkey
- Wallet registration/update: https://github.com/Scottcjn/rustchain-bounties/issues/16647#issuecomment-5446887073

## Payout metadata

Wallet/miner id / payout alias: `L1nkinPark`
Native RTC payout address: `RTC973498f72747cd1637e395521319c0ad61c0f68c`
Native RTC public key: `ee2b512bf5a18951c328282c07848e76aa9945c35cd56b229e90793dfe069e4c`
Wallet registration/update: https://github.com/Scottcjn/rustchain-bounties/issues/16647#issuecomment-5446887073