### PR TITLE
fix(tools): fail node sync validator on attention

### DIFF
--- a/tests/test_node_sync_validator.py
+++ b/tests/test_node_sync_validator.py
@@ -330,3 +330,54 @@ def test_build_summary_marks_clean_and_attention_reports():
     assert "Status: OK (no discrepancies detected)" in module.build_summary(clean)
     assert "Down/unreachable nodes:" in module.build_summary(dirty)
     assert "Status: ATTENTION (review discrepancy details in JSON)" in module.build_summary(dirty)
+    assert module.report_needs_attention(clean) is False
+    assert module.report_needs_attention(dirty) is True
+
+
+def test_main_exits_zero_for_clean_report(monkeypatch, capsys):
+    module = load_module()
+
+    def fake_snapshot_node(node, timeout, verify_ssl, sample_balances):
+        return snapshot(module, node, miners=["alice"], balances={"alice": 3.0})
+
+    monkeypatch.setattr(module, "snapshot_node", fake_snapshot_node)
+    monkeypatch.setattr(sys, "argv", ["node_sync_validator.py", "--nodes", "n1", "n2"])
+
+    assert module.main() == 0
+    assert "Status: OK" in capsys.readouterr().out
+
+
+def test_main_exits_nonzero_for_attention_report_by_default(monkeypatch, capsys):
+    module = load_module()
+
+    def fake_snapshot_node(node, timeout, verify_ssl, sample_balances):
+        if node == "n2":
+            return snapshot(module, node, ok=False, error="refused")
+        return snapshot(module, node, miners=["alice"])
+
+    monkeypatch.setattr(module, "snapshot_node", fake_snapshot_node)
+    monkeypatch.setattr(sys, "argv", ["node_sync_validator.py", "--nodes", "n1", "n2"])
+
+    assert module.main() == 1
+    out = capsys.readouterr().out
+    assert "Down/unreachable nodes:" in out
+    assert "Status: ATTENTION" in out
+
+
+def test_main_allows_attention_exit_zero_for_manual_runs(monkeypatch, capsys):
+    module = load_module()
+
+    def fake_snapshot_node(node, timeout, verify_ssl, sample_balances):
+        if node == "n2":
+            return snapshot(module, node, ok=False, error="refused")
+        return snapshot(module, node, miners=["alice"])
+
+    monkeypatch.setattr(module, "snapshot_node", fake_snapshot_node)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["node_sync_validator.py", "--nodes", "n1", "n2", "--allow-attention-exit-zero"],
+    )
+
+    assert module.main() == 0
+    assert "Status: ATTENTION" in capsys.readouterr().out

--- a/tools/node_sync_validator.py
+++ b/tools/node_sync_validator.py
@@ -364,6 +364,16 @@ def compare_snapshots(snaps: List[NodeSnapshot], tip_drift_threshold: int) -> Di
     return out
 
 
+def report_needs_attention(report: Dict[str, Any]) -> bool:
+    """Return True when a validator report found C6-relevant failures."""
+    if report.get("down_nodes"):
+        return True
+    discrepancies = report.get("discrepancies", {})
+    if not isinstance(discrepancies, dict):
+        return False
+    return any(bool(items) for items in discrepancies.values())
+
+
 def build_summary(report: Dict[str, Any]) -> str:
     d = report.get("discrepancies", {})
     lines = []
@@ -391,7 +401,7 @@ def build_summary(report: Dict[str, Any]) -> str:
     for k, v in counts.items():
         lines.append(f"- {k}: {v}")
 
-    if sum(counts.values()) == 0 and not report.get("down_nodes"):
+    if not report_needs_attention(report):
         lines.append("Status: OK (no discrepancies detected)")
     else:
         lines.append("Status: ATTENTION (review discrepancy details in JSON)")
@@ -408,6 +418,11 @@ def main() -> int:
     parser.add_argument("--sample-balances", type=int, default=5)
     parser.add_argument("--output-json", default="")
     parser.add_argument("--output-text", default="")
+    parser.add_argument(
+        "--allow-attention-exit-zero",
+        action="store_true",
+        help="print ATTENTION reports but still exit 0 for exploratory/manual runs",
+    )
     args = parser.parse_args()
 
     verify_ssl = bool(args.verify_ssl)
@@ -428,6 +443,8 @@ def main() -> int:
         with open(args.output_text, "w", encoding="utf-8") as f:
             f.write(summary + "\n")
 
+    if report_needs_attention(report) and not args.allow_attention_exit_zero:
+        return 1
     return 0
 
 


### PR DESCRIPTION
## Summary
- make `tools/node_sync_validator.py` return a non-zero exit code when the C6 report contains down nodes or discrepancies
- add `--allow-attention-exit-zero` for exploratory/manual runs that still want the old exit-0 behavior
- add regression tests for clean, attention, and opt-out CLI behavior

## Why
The C6 validator currently prints `Status: ATTENTION` for real cross-node failures but still exits 0, so a CI/smoke gate can silently pass while C6 is violated. This patch makes the command-line contract match the matrix: OK reports exit 0, ATTENTION reports exit 1 by default.

Live read-only check on 2026-08-28 UTC after this patch produced exit 1 with current C6 failures:
- `http://76.8.228.245:8099` timed out on `/health`
- same epoch/slot `268/38630` on `50.28.86.131` and `50.28.86.153`, but miner state diverged
- `50.28.86.131`: 15 miners, enrolled_miners 16, stats_total_miners 1624, stats_total_balance 410411.185688
- `50.28.86.153`: 0 miners, enrolled_miners 0, stats_total_miners 390, stats_total_balance 527869.793772

This PR is a tooling fix for the #356 falsification matrix path; it does not send mutating traffic.

## Validation
- `uv run --no-project --with pytest --with requests --with flask --with flask-cors python -m pytest tests\test_node_sync_validator.py -q` → 15 passed
- `python -m py_compile tools\node_sync_validator.py tests\test_node_sync_validator.py`
- `git diff --check`
- live: `uv run --no-project --with requests python tools\node_sync_validator.py --timeout 8 --sample-balances 1` → exits 1 with `Status: ATTENTION`

## Payout metadata

Wallet/miner id / payout alias: `L1nkinPark`
Native RTC payout address: `RTC973498f72747cd1637e395521319c0ad61c0f68c`
Native RTC public key: `ee2b512bf5a18951c328282c07848e76aa9945c35cd56b229e90793dfe069e4c`
Wallet registration/update: https://github.com/Scottcjn/rustchain-bounties/issues/16647#issuecomment-5446887073