### PR TITLE
[UTXO-BUG] Skip mempool-claimed inputs in transfer coin selection

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -7,6 +7,7 @@ Run: python3 -m pytest test_utxo_endpoints.py -v
 
 import json
 import os
+import sqlite3
 import tempfile
 import time
 import unittest
@@ -288,6 +289,52 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertEqual(self.utxo_db.get_balance('bob'), 60 * UNIT)
         sender_bal = self.utxo_db.get_balance('RTC_test_aabbccdd')
         self.assertEqual(sender_bal, 40 * UNIT)
+
+    def test_transfer_skips_mempool_claimed_inputs_when_clean_box_can_fund(self):
+        """A pending mempool spend must not poison /utxo/transfer coin selection."""
+        sender = 'RTC_test_aabbccdd'
+        self._seed_coinbase(sender, 1 * UNIT, height=1)
+        self._seed_coinbase(sender, 50 * UNIT, height=2)
+        boxes = sorted(
+            self.utxo_db.get_unspent_for_address(sender),
+            key=lambda box: box['value_nrtc'],
+        )
+        claimed_box = boxes[0]
+
+        self.assertTrue(self.utxo_db.mempool_add({
+            'tx_id': 'pending-small-input',
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': claimed_box['box_id'], 'spending_proof': 'sig'}],
+            'outputs': [{'address': 'carol', 'value_nrtc': 1 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+        }))
+        self.assertTrue(self.utxo_db.mempool_check_double_spend(claimed_box['box_id']))
+
+        r = self.client.post('/utxo/transfer', json={
+            'from_address': sender,
+            'to_address': 'bob',
+            'amount_rtc': 10.0,
+            'public_key': 'aabbccdd' * 8,
+            'signature': 'sig' * 22,
+            'nonce': int(time.time() * 1000),
+        })
+
+        self.assertEqual(r.status_code, 200, r.get_json())
+        self.assertEqual(r.get_json()['inputs_consumed'], 1)
+        self.assertEqual(self.utxo_db.get_balance('bob'), 10 * UNIT)
+        self.assertEqual(self.utxo_db.get_balance(sender), 41 * UNIT)
+        self.assertTrue(self.utxo_db.mempool_check_double_spend(claimed_box['box_id']))
+
+        conn = sqlite3.connect(self.db_path)
+        try:
+            spent = conn.execute(
+                'SELECT spent_at FROM utxo_boxes WHERE box_id = ?',
+                (claimed_box['box_id'],),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        self.assertIsNone(spent)
 
     def test_transfer_insufficient(self):
         self._seed_coinbase('RTC_test_aabbccdd', 50 * UNIT)

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -470,15 +470,27 @@ class UtxoDB:
         whole thing. Fetching a bounded slice keeps the cost of a transfer
         independent of how fragmented the wallet is.
 
-        Returns the union of both slices, deduplicated by box_id. Feeding this
-        to coin_select() yields the same selection as feeding it every unspent
-        box, because both of its passes see an identical prefix.
+        Returns the union of both immediately-spendable slices, deduplicated by
+        box_id. Feeding this to coin_select() yields the same selection as
+        feeding it every unspent, unclaimed box, because both of its passes see
+        an identical prefix.
+
+        Pending mempool spend-claims are intentionally excluded. /utxo/transfer
+        creates an immediate settlement transaction, not a block-candidate
+        confirmation of the stored mempool tx_id, so selecting a claimed box
+        only makes apply_transaction() fail after coin selection even when an
+        unclaimed box can fund the payment.
         """
         if not isinstance(max_inputs, int) or isinstance(max_inputs, bool) or max_inputs < 1:
             raise ValueError("max_inputs must be a positive integer")
 
         base = """SELECT * FROM utxo_boxes
-                  WHERE owner_address = ? AND spent_at IS NULL"""
+                  WHERE owner_address = ? AND spent_at IS NULL
+                    AND NOT EXISTS (
+                        SELECT 1 FROM utxo_mempool_inputs mi
+                        WHERE mi.box_id = utxo_boxes.box_id
+                    )"""
+        self.mempool_clear_expired()
         conn = self._conn()
         try:
             # Smallest-first needs one extra row: it is the row that proves the


### PR DESCRIPTION
## Summary
- Excludes currently mempool-claimed boxes from the bounded coin-selection candidate set used by `/utxo/transfer`.
- Clears expired mempool entries before selecting, so expired claims do not hide spendable funds.
- Adds a regression where the sender has 1 RTC reserved by a pending mempool tx and 50 RTC unclaimed; a 10 RTC `/utxo/transfer` succeeds using the clean box and leaves the pending box unspent/reserved.

## Finding / impact
`/utxo/transfer` creates an immediate-settlement transaction; it is not confirming the stored mempool transaction id. Before this patch, `UtxoDB.get_coin_select_candidates()` returned all unspent boxes for the address, including boxes already claimed in `utxo_mempool_inputs` by a pending transaction.

That lets a pending claim poison endpoint coin selection. Repro on current `origin/main`:

1. Sender owns a 1 RTC UTXO and a 50 RTC UTXO.
2. A valid mempool transaction claims the 1 RTC UTXO.
3. Sender posts `/utxo/transfer` for 10 RTC.
4. `coin_select()` selects the small claimed box first, then the large clean box.
5. `apply_transaction()` correctly rejects the endpoint tx because the selected box belongs to a different mempool `tx_id`.
6. Endpoint returns 500 `UTXO transaction failed (race condition or validation)` even though the 50 RTC box alone can fund the payment.

This is distinct from the earlier mempool claim hardening that rejects competing application of claimed boxes. That guard is still correct and remains in place. This patch prevents the endpoint from choosing a known-ineligible input in the first place, while preserving block-candidate confirmation through `mempool_get_block_candidates()`.

## Validation
- Red repro before patch: local Flask/SQLite repro returned HTTP 500 with 1 RTC claimed + 50 RTC clean + 10 RTC transfer.
- `python -m pytest test_utxo_endpoints.py::TestUtxoEndpoints::test_transfer_skips_mempool_claimed_inputs_when_clean_box_can_fund -q` -> 1 passed
- `python -m pytest test_utxo_endpoints.py test_utxo_db.py -q` -> 142 passed, 39 subtests passed
- `python -m pytest tests\test_utxo_transfer_spends_account_mirror.py tests\test_utxo_transfer_replay.py tests\test_utxo_transfer_nonce_required.py tests\test_utxo_transfer_json_validation.py tests\test_utxo_legacy_signature_deadline.py tests\test_utxo_malformed_pubkey_6114.py -q` -> 20 passed, 1 unrelated requests dependency warning
- `python -m py_compile node\utxo_db.py node\test_utxo_endpoints.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

Bounty reference: Scottcjn/rustchain-bounties#2819



## Bounty payout

- Native RTC payout address: $wallet
- Public key: $pubkey
- Wallet registration/update: https://github.com/Scottcjn/rustchain-bounties/issues/16647#issuecomment-5446887073

## Payout metadata

Wallet/miner id / payout alias: `L1nkinPark`
Native RTC payout address: `RTC973498f72747cd1637e395521319c0ad61c0f68c`
Native RTC public key: `ee2b512bf5a18951c328282c07848e76aa9945c35cd56b229e90793dfe069e4c`
Wallet registration/update: https://github.com/Scottcjn/rustchain-bounties/issues/16647#issuecomment-5446887073