### PR TITLE
chore(node): annotate two PRAGMA fetchall() sites for the guard

### DIFF
--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -125,7 +125,7 @@ def _balances_columns(cursor: sqlite3.Cursor) -> Tuple[str, str]:
     Falls back to the schema this module has always assumed if the table
     does not exist yet (a fresh DB gets it via init_db() before this runs).
     """
-    cols = {row[1] for row in cursor.execute("PRAGMA table_info(balances)").fetchall()}
+    cols = {row[1] for row in cursor.execute("PRAGMA table_info(balances)").fetchall()}  # fetchall-ok: pragma-result
     if "balance_rtc" in cols and "miner_pk" in cols and "amount_i64" not in cols:
         return "miner_pk", "balance_rtc"
     return "miner_id", "amount_i64"

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -7306,7 +7306,7 @@ def ingest_signed_header():
     # probe live columns rather than hardcoding either shape — same
     # dual-schema-tolerant pattern as lock_ledger.py / governance.py.
     with sqlite3.connect(DB_PATH) as db:
-        _hdr_live_cols = {r[1] for r in db.execute("PRAGMA table_info(headers)").fetchall()}
+        _hdr_live_cols = {r[1] for r in db.execute("PRAGMA table_info(headers)").fetchall()}  # fetchall-ok: pragma-result
         _hdr_fields = ["slot", "miner_id", "message_hex", "signature_hex", "pubkey_hex", "ts"]
         _hdr_vals = [slot, miner_id, msg_hex, sig_hex, verified_pubkey_hex]
         _hdr_placeholders = ["?", "?", "?", "?", "?", "strftime('%s','now')"]


### PR DESCRIPTION
Two `PRAGMA table_info(...)` reads merged today (#8251 lock_ledger, #8254 headers) are unannotated, so every open PR's merge-ref now fails `tests/test_fetchall_guard.py` with *2 new unannotated .fetchall() call(s)*. PRAGMA results are bounded by schema size — annotated `# fetchall-ok: pragma-result`. Guard passes locally on this branch.