### PR TITLE
docs(api): document paginated envelope shape for /api/miners (#8272)

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -211,37 +211,48 @@ curl -fsS https://rustchain.org/api/miners | jq .
 
 **Response (200 OK):**
 ```json
-[
-  {
-    "miner": "eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC",
-    "device_arch": "G4",
-    "device_family": "PowerPC",
-    "hardware_type": "PowerPC G4 (Vintage)",
-    "antiquity_multiplier": 2.5,
-    "entropy_score": 0.0,
-    "last_attest": 1770112912
-  },
-  {
-    "miner": "g5-selena-179",
-    "device_arch": "G5",
-    "device_family": "PowerPC",
-    "hardware_type": "PowerPC G5 (Vintage)",
-    "antiquity_multiplier": 2.0,
-    "entropy_score": 0.0,
-    "last_attest": 1770112865
+{
+  "miners": [
+    {
+      "miner": "eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC",
+      "device_arch": "G4",
+      "device_family": "PowerPC",
+      "hardware_type": "PowerPC G4 (Vintage)",
+      "antiquity_multiplier": 2.5,
+      "entropy_score": 0.0,
+      "last_attest": 1770112912
+    },
+    {
+      "miner": "g5-selena-179",
+      "device_arch": "G5",
+      "device_family": "PowerPC",
+      "hardware_type": "PowerPC G5 (Vintage)",
+      "antiquity_multiplier": 2.0,
+      "entropy_score": 0.0,
+      "last_attest": 1770112865
+    }
+  ],
+  "pagination": {
+    "count": 2,
+    "limit": 50,
+    "offset": 0,
+    "total": 2,
+    "total_enrolled": 2
   }
-]
+}
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `miner` | string | Miner wallet ID |
-| `device_arch` | string | CPU architecture (G4, G5, x86_64, M2, etc.) |
-| `device_family` | string | CPU family (PowerPC, Intel, etc.) |
-| `hardware_type` | string | Human-readable hardware description |
-| `antiquity_multiplier` | float | Reward multiplier (1.0–2.5x) |
-| `entropy_score` | float | Hardware entropy quality |
-| `last_attest` | integer | Unix timestamp of last attestation |
+| `miners` | array | List of active/enrolled miner objects |
+| `miners[].miner` | string | Miner wallet ID |
+| `miners[].device_arch` | string | CPU architecture (G4, G5, x86_64, M2, etc.) |
+| `miners[].device_family` | string | CPU family (PowerPC, Intel, etc.) |
+| `miners[].hardware_type` | string | Human-readable hardware description |
+| `miners[].antiquity_multiplier` | float | Reward multiplier (1.0–2.5x) |
+| `miners[].entropy_score` | float | Hardware entropy quality |
+| `miners[].last_attest` | integer | Unix timestamp of last attestation |
+| `pagination` | object | Pagination metadata object (`count`, `limit`, `offset`, `total`, `total_enrolled`) |
 
 **Error Codes:** `500 INTERNAL_ERROR`
 
@@ -1293,7 +1304,7 @@ print(f"Balance: {data['amount_rtc']} RTC ({data['amount_i64']} micro-RTC)")
 
 # List miners
 resp = requests.get(f"{BASE_URL}/api/miners")
-for m in resp.json():
+for m in resp.json().get("miners", []):
     print(f"{m['miner'][:20]}... | {m['device_arch']} | mult={m['antiquity_multiplier']}x")
 ```
 

--- a/docs/zh-CN/API_REFERENCE.md
+++ b/docs/zh-CN/API_REFERENCE.md
@@ -211,37 +211,48 @@ curl -fsS https://rustchain.org/api/miners | jq .
 
 **响应 (200 OK):**
 ```json
-[
-  {
-    "miner": "eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC",
-    "device_arch": "G4",
-    "device_family": "PowerPC",
-    "hardware_type": "PowerPC G4 (古董)",
-    "antiquity_multiplier": 2.5,
-    "entropy_score": 0.0,
-    "last_attest": 1770112912
-  },
-  {
-    "miner": "g5-selena-179",
-    "device_arch": "G5",
-    "device_family": "PowerPC",
-    "hardware_type": "PowerPC G5 (古董)",
-    "antiquity_multiplier": 2.0,
-    "entropy_score": 0.0,
-    "last_attest": 1770112865
+{
+  "miners": [
+    {
+      "miner": "eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC",
+      "device_arch": "G4",
+      "device_family": "PowerPC",
+      "hardware_type": "PowerPC G4 (古董)",
+      "antiquity_multiplier": 2.5,
+      "entropy_score": 0.0,
+      "last_attest": 1770112912
+    },
+    {
+      "miner": "g5-selena-179",
+      "device_arch": "G5",
+      "device_family": "PowerPC",
+      "hardware_type": "PowerPC G5 (古董)",
+      "antiquity_multiplier": 2.0,
+      "entropy_score": 0.0,
+      "last_attest": 1770112865
+    }
+  ],
+  "pagination": {
+    "count": 2,
+    "limit": 50,
+    "offset": 0,
+    "total": 2,
+    "total_enrolled": 2
   }
-]
+}
 ```
 
 | 字段 | 类型 | 描述 |
 |-------|------|-------------|
-| `miner` | string | 矿工钱包 ID |
-| `device_arch` | string | CPU 架构 (G4, G5, x86_64, M2 等) |
-| `device_family` | string | CPU 系列 (PowerPC, Intel 等) |
-| `hardware_type` | string | 人类可读的硬件描述 |
-| `antiquity_multiplier` | float | 奖励乘数 (1.0–2.5x) |
-| `entropy_score` | float | 硬件熵质量 |
-| `last_attest` | integer | 上次认证的 Unix 时间戳 |
+| `miners` | array | 活跃/已注册矿工对象列表 |
+| `miners[].miner` | string | 矿工钱包 ID |
+| `miners[].device_arch` | string | CPU 架构 (G4, G5, x86_64, M2 等) |
+| `miners[].device_family` | string | CPU 系列 (PowerPC, Intel 等) |
+| `miners[].hardware_type` | string | 人类可读的硬件描述 |
+| `miners[].antiquity_multiplier` | float | 奖励乘数 (1.0–2.5x) |
+| `miners[].entropy_score` | float | 硬件熵质量 |
+| `miners[].last_attest` | integer | 上次认证的 Unix 时间戳 |
+| `pagination` | object | 分页元数据对象 (`count`, `limit`, `offset`, `total`, `total_enrolled`) |
 
 **错误代码:** `500 INTERNAL_ERROR`
 
@@ -1275,8 +1286,8 @@ print(f"余额: {data['amount_rtc']} RTC ({data['amount_i64']} 微 RTC)")
 
 # 列出矿工
 resp = requests.get(f"{BASE_URL}/api/miners")
-for m in resp.json():
-    print(f"{m['miner'][:20]}... | {m['device_arch']} | 乘数={m['antiquity_multiplier']}x")
+for m in resp.json().get("miners", []):
+    print(f"{m['miner'][:20]}... | {m['device_arch']} | mult={m['antiquity_multiplier']}x")
 ```
 
 ### Python — 签名转账


### PR DESCRIPTION
### Description
Updates the `/api/miners` documentation and code snippets in `docs/API_REFERENCE.md` (and `docs/zh-CN/API_REFERENCE.md`) to reflect the actual paginated envelope response structure (`{"miners": [...], "pagination": {...}}`) returned by live nodes.

Fixes #8272

### Changes:
1. Updated `/api/miners` 200 OK JSON response example to show the `miners` list and `pagination` envelope metadata.
2. Updated field reference table with descriptions for `miners` and `pagination` properties.
3. Updated Python sample snippet to unwrap `resp.json().get("miners", [])` when iterating active miners.
4. Synchronized English and Simplified Chinese documentation references.