### PR TITLE
ci(docs): add scheduled link checking and private node exclusions (#8262)

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - '**.md'
       - 'docs/**'
+  schedule:
+    - cron: '0 4 * * 1'
   workflow_dispatch:
 
 jobs:
@@ -23,6 +25,9 @@ jobs:
             --exclude "https?://(twitter|x)\.com"
             --exclude "https://github.com/Scottcjn/Rustchain/actions"
             --exclude "https?://(www\.)?(linkedin|facebook|instagram|tiktok)"
+            --exclude "https?://(127\.0\.0\.1|localhost)(:\d+)?"
+            --exclude "https?://50\.28\.86\.131(:\d+)?"
+            --exclude "https://rustchain.org/faq"
             -- './**/*.md' './**/*.html'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
Enhances `.github/workflows/lychee.yml` to run weekly scheduled link checking on documentation (`cron: '0 4 * * 1'`) and adds exclusion regex patterns for localhost, local node IP (`50.28.86.131`), and the known redirect route (`https://rustchain.org/faq`).

Fixes #8262

### Changes:
- **`.github/workflows/lychee.yml`**:
  - Added `schedule` trigger for weekly automated runs.
  - Added exclude regex patterns for localhost/127.0.0.1, node IP `50.28.86.131`, and `rustchain.org/faq`.