### PR TITLE
docs(rip-0001): update stale consensus/poa.rs path to active implementations (#8276)

### DIFF
--- a/rips/docs/RIP-0001-proof-of-antiquity.md
+++ b/rips/docs/RIP-0001-proof-of-antiquity.md
@@ -86,7 +86,7 @@ Not compatible with PoW or PoS. Requires full node support of PoA consensus modu
 
 # Implementation Notes
 
-Implemented as part of the `rustchain-core` runtime (see: `consensus/poa.rs`).
+Implemented as part of the `rustchain-core` runtime (see: `rips/src/proof_of_antiquity.rs` and `rips/rustchain-core/consensus/poa.py`).
 APIs:
 - `GET /api/node/antiquity` — return AS and validation eligibility
 - `POST /api/node/claim` — submit block claim with PoA metadata


### PR DESCRIPTION
### Description
Updates the implementation note in `rips/docs/RIP-0001-proof-of-antiquity.md` from the nonexistent `consensus/poa.rs` pointer to the active implementation paths (`rips/src/proof_of_antiquity.rs` and `rips/rustchain-core/consensus/poa.py`).

Fixes #8276

### Changes:
- **`rips/docs/RIP-0001-proof-of-antiquity.md`**: Pointed implementation notes to existing PoA modules (`rips/src/proof_of_antiquity.rs` and `rips/rustchain-core/consensus/poa.py`).