### PR TITLE
fix(beacon): route Atlas registration through rustchain.org

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -500,6 +500,7 @@ def get_public_beacon_agent(agent_id):
 # BEACON JOIN ROUTING ENDPOINTS (Issue #2127)
 # ============================================================
 
+@beacon_api.route('/api/join', methods=['POST', 'OPTIONS'])
 @beacon_api.route('/beacon/join', methods=['POST', 'OPTIONS'])
 def beacon_join():
     """

--- a/site/nginx-rustchain-org.conf
+++ b/site/nginx-rustchain-org.conf
@@ -83,6 +83,33 @@ server {
         }
     }
 
+    # Beacon Atlas registration and directory endpoints
+    location = /beacon/join {
+        proxy_pass http://127.0.0.1:8071/beacon/join;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Methods "POST, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Content-Type" always;
+        if ($request_method = OPTIONS) {
+            return 204;
+        }
+    }
+
+    location = /beacon/atlas {
+        proxy_pass http://127.0.0.1:8071/beacon/atlas;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Methods "GET, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Content-Type" always;
+        if ($request_method = OPTIONS) {
+            return 204;
+        }
+    }
+
     # BEP-2: External Agent Relay endpoints
     # Beacon SEO: Agent profiles, directory, sitemap, llms.txt
     location /beacon/agent/ {
@@ -407,6 +434,33 @@ server {
         add_header Access-Control-Allow-Origin "*" always;
         add_header Access-Control-Allow-Methods "POST, GET, PATCH, OPTIONS" always;
         add_header Access-Control-Allow-Headers "Content-Type, Authorization" always;
+        if ($request_method = OPTIONS) {
+            return 204;
+        }
+    }
+
+    # Beacon Atlas registration and directory endpoints
+    location = /beacon/join {
+        proxy_pass http://127.0.0.1:8071/beacon/join;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Methods "POST, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Content-Type" always;
+        if ($request_method = OPTIONS) {
+            return 204;
+        }
+    }
+
+    location = /beacon/atlas {
+        proxy_pass http://127.0.0.1:8071/beacon/atlas;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Methods "GET, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Content-Type" always;
         if ($request_method = OPTIONS) {
             return 204;
         }

--- a/tests/test_beacon_join_routing.py
+++ b/tests/test_beacon_join_routing.py
@@ -107,6 +107,29 @@ class TestBeaconJoinRouting(unittest.TestCase):
         self.assertEqual(data['status'], 'active')
         self.assertIn('timestamp', data)
 
+    def test_api_join_alias_registers_and_upserts_agent(self):
+        """POST /api/join supports the Atlas service's legacy route."""
+        payload = {
+            'agent_id': 'bcn_api_join_alias',
+            'pubkey_hex': '0x' + '12' * 32,
+            'name': 'Original Name',
+        }
+
+        response = self.client.post('/api/join', json=payload)
+        self.assertEqual(response.status_code, 200)
+
+        payload['name'] = 'Updated Name'
+        response = self.client.post('/api/join', json=payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['name'], 'Updated Name')
+
+        with sqlite3.connect(self.test_db_path) as conn:
+            rows = conn.execute(
+                "SELECT name FROM relay_agents WHERE agent_id = ?",
+                (payload['agent_id'],),
+            ).fetchall()
+        self.assertEqual(rows, [('Updated Name',)])
+
     def test_join_upsert_duplicate_agent(self):
         """POST /beacon/join upserts mutable fields for duplicate agent_id.
 

--- a/tests/test_rustchain_org_nginx_config.py
+++ b/tests/test_rustchain_org_nginx_config.py
@@ -14,3 +14,18 @@ def test_rustchain_org_nginx_proxies_api_stats_in_all_server_blocks():
     assert stats_locations == miners_locations
     assert config.count("proxy_pass http://127.0.0.1:8099/api/stats;") == stats_locations
     assert config.count('add_header Access-Control-Allow-Origin "*" always;') >= stats_locations
+
+
+def test_rustchain_org_nginx_proxies_beacon_join_and_atlas_in_all_server_blocks():
+    config = (ROOT / "site" / "nginx-rustchain-org.conf").read_text(encoding="utf-8")
+
+    serving_blocks = config.count("location /api/stats {")
+    assert serving_blocks == 2
+    assert config.count("location = /beacon/join {") == serving_blocks
+    assert config.count("location = /beacon/atlas {") == serving_blocks
+    assert config.count(
+        "proxy_pass http://127.0.0.1:8071/beacon/join;"
+    ) == serving_blocks
+    assert config.count(
+        "proxy_pass http://127.0.0.1:8071/beacon/atlas;"
+    ) == serving_blocks


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

BCOS tier: L1

- [x] BCOS-L1 selected; the publisher can apply the corresponding tier label.
- [x] No new code files were added, so the new-file SPDX requirement is not applicable.
- [x] Test evidence is provided below.

## What Changed

- Added the Atlas API's `POST /api/join` compatibility route to the existing validated registration/upsert handler.
- Added exact `/beacon/join` and `/beacon/atlas` proxies to both serving blocks in the rustchain.org nginx configuration, targeting the Atlas service on port 8071.
- Added regressions for alias registration/upsert behavior and complete nginx coverage.

Bounty: https://github.com/Scottcjn/rustchain-bounties/issues/2127

## Testing / Evidence

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -p no:cacheprovider -q tests/test_beacon_join_routing.py node/tests/test_beacon_api_join.py tests/test_rustchain_org_nginx_config.py` — 40 passed.
- `RUFF_CACHE_DIR=/tmp/rustchain-ruff-cache ruff check tests --select E9,F63,F7,F82` — passed.
- `PYTHONPYCACHEPREFIX=/tmp/rustchain-pycache python3 -m py_compile node/beacon_api.py tests/test_beacon_join_routing.py tests/test_rustchain_org_nginx_config.py` — passed.

