### PR TITLE
fix(attest): serialize legacy hardware binding under IMMEDIATE txn (Fixes Scottcjn/rustchain-bounties#16648)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5652,40 +5652,57 @@ def _compute_hardware_id(device: dict, signals: dict = None, source_ip: str = No
 def _check_hardware_binding(miner_id: str, device: dict, signals: dict = None, source_ip: str = None):
     """Check if hardware is already bound to a different wallet. One machine = One wallet."""
     hardware_id = _compute_hardware_id(device, signals, source_ip=source_ip)
-    
+
     with closing(sqlite3.connect(DB_PATH)) as conn:
         c = conn.cursor()
-        
-        # Check existing binding
-        c.execute('SELECT bound_miner, attestation_count FROM hardware_bindings WHERE hardware_id = ?',
-                  (hardware_id,))
-        row = c.fetchone()
-        
         now = int(time.time())
-        
-        if row is None:
-            # No binding - create one
-            try:
-                c.execute("""INSERT INTO hardware_bindings 
-                    (hardware_id, bound_miner, device_arch, device_model, bound_at, attestation_count)
-                    VALUES (?, ?, ?, ?, ?, 1)""",
-                    (hardware_id, miner_id, device.get('device_arch'), device.get('device_model'), now))
+
+        # Serialize read-check-insert under one write lock so two concurrent
+        # first-time submissions for the same hardware_id cannot both pass.
+        c.execute('BEGIN IMMEDIATE')
+        try:
+            c.execute(
+                'SELECT bound_miner, attestation_count FROM hardware_bindings WHERE hardware_id = ?',
+                (hardware_id,),
+            )
+            row = c.fetchone()
+
+            if row is None:
+                try:
+                    c.execute(
+                        """INSERT INTO hardware_bindings
+                        (hardware_id, bound_miner, device_arch, device_model, bound_at, attestation_count)
+                        VALUES (?, ?, ?, ?, ?, 1)""",
+                        (hardware_id, miner_id, device.get('device_arch'), device.get('device_model'), now),
+                    )
+                    conn.commit()
+                    return True, 'Hardware bound', miner_id
+                except sqlite3.IntegrityError:
+                    c.execute(
+                        'SELECT bound_miner FROM hardware_bindings WHERE hardware_id = ?',
+                        (hardware_id,),
+                    )
+                    row = c.fetchone()
+                    if row is None:
+                        conn.rollback()
+                        raise
+                    bound_miner = row[0]
+            else:
+                bound_miner, _ = row
+
+            if bound_miner == miner_id:
+                c.execute(
+                    'UPDATE hardware_bindings SET attestation_count = attestation_count + 1 WHERE hardware_id = ?',
+                    (hardware_id,),
+                )
                 conn.commit()
-            except:
-                pass  # Race condition - another thread created it
-            return True, 'Hardware bound', miner_id
-        
-        bound_miner, _ = row
-        
-        if bound_miner == miner_id:
-            # Same wallet - allow
-            c.execute('UPDATE hardware_bindings SET attestation_count = attestation_count + 1 WHERE hardware_id = ?',
-                      (hardware_id,))
-            conn.commit()
-            return True, 'Authorized', miner_id
-        else:
-            # DIFFERENT wallet on same hardware!
+                return True, 'Authorized', miner_id
+
+            conn.rollback()
             return False, f'Hardware bound to {bound_miner[:16]}...', bound_miner
+        except Exception:
+            conn.rollback()
+            raise
 
 
 @app.route('/attest/submit', methods=['POST'])
@@ -6088,7 +6105,18 @@ def _submit_attestation_impl():
         print(f"[HW_BIND_V2] OK: {miner} - {hw_msg}")
     else:
         # Legacy binding check (for miners not yet sending serial)
-        hw_ok, hw_msg, bound_wallet = _check_hardware_binding(miner, device, signals, source_ip=client_ip)
+        try:
+            hw_ok, hw_msg, bound_wallet = _check_hardware_binding(
+                miner, device, signals, source_ip=client_ip,
+            )
+        except Exception as exc:
+            app.logger.error(f"[HW_BINDING] unavailable for {miner}: {exc}")
+            return jsonify({
+                "ok": False,
+                "error": "hardware_binding_unavailable",
+                "message": "Could not verify hardware binding; retry later",
+                "code": "BINDING_UNAVAILABLE",
+            }), 503
         if not hw_ok:
             print(f"[HW_BINDING] REJECTED: {miner} trying to use hardware bound to {bound_wallet}")
             return jsonify({

--- a/node/tests/test_hardware_binding_race.py
+++ b/node/tests/test_hardware_binding_race.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: MIT
+"""Regression for rustchain-bounties#16648: legacy hardware-binding race.
+
+Two concurrent first-time submissions for the same hardware_id but different
+miner ids must not both be accepted. Unpatched code returned success for the
+loser after a broad `except: pass` on INSERT failure.
+"""
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+DEVICE = {
+    "device_model": "test-rig",
+    "device_arch": "modern",
+    "device_family": "x86",
+    "cores": 4,
+}
+SIGNALS = {"macs": ["aa:bb:cc:dd:ee:ff"]}
+SOURCE_IP = "203.0.113.50"
+
+
+class HardwareBindingRaceTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._db = os.path.join(cls._tmp.name, "hw-binding-race.db")
+        os.environ["RUSTCHAIN_DB_PATH"] = cls._db
+        os.environ.setdefault("RC_ADMIN_KEY", "0123456789abcdef0123456789abcdef")
+        os.environ.setdefault("RUSTCHAIN_DISABLE_P2P_AUTO_START", "1")
+
+        if str(NODE_DIR) not in sys.path:
+            sys.path.insert(0, str(NODE_DIR))
+
+        with sqlite3.connect(cls._db) as conn:
+            conn.execute(
+                """CREATE TABLE hardware_bindings (
+                    hardware_id TEXT PRIMARY KEY,
+                    bound_miner TEXT NOT NULL,
+                    device_arch TEXT,
+                    device_model TEXT,
+                    bound_at INTEGER NOT NULL,
+                    attestation_count INTEGER DEFAULT 0
+                )"""
+            )
+
+        spec = importlib.util.spec_from_file_location("rcnode_hw_binding_race", MODULE_PATH)
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._tmp.cleanup()
+
+    def _run_race(self):
+        results = []
+        lock = threading.Lock()
+        start = threading.Barrier(2)
+
+        def _check(miner_id):
+            start.wait()
+            res = self.mod._check_hardware_binding(
+                miner_id, DEVICE, SIGNALS, source_ip=SOURCE_IP,
+            )
+            with lock:
+                results.append(res)
+
+        threads = [
+            threading.Thread(target=_check, args=("miner-a",)),
+            threading.Thread(target=_check, args=("miner-b",)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+        return results
+
+    def test_concurrent_first_bind_admits_only_one_miner(self):
+        for _ in range(20):
+            with sqlite3.connect(self._db) as conn:
+                conn.execute("DELETE FROM hardware_bindings")
+            results = self._run_race()
+            self.assertEqual(len(results), 2, results)
+            accepted = [r for r in results if r[0] is True]
+            rejected = [r for r in results if r[0] is False]
+            self.assertEqual(len(accepted), 1, results)
+            self.assertEqual(len(rejected), 1, results)
+            with sqlite3.connect(self._db) as conn:
+                rows = conn.execute(
+                    "SELECT bound_miner FROM hardware_bindings",
+                ).fetchall()
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0][0], accepted[0][2])
+            self.assertEqual(rejected[0][2], accepted[0][2])
+
+    def test_binding_check_propagates_sqlite_errors(self):
+        def boom(_path, *args, **kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+        orig_connect = self.mod.sqlite3.connect
+        self.mod.sqlite3.connect = boom
+        try:
+            with self.assertRaises(sqlite3.OperationalError):
+                self.mod._check_hardware_binding(
+                    "miner-a", DEVICE, SIGNALS, source_ip=SOURCE_IP,
+                )
+        finally:
+            self.mod.sqlite3.connect = orig_connect
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes Scottcjn/rustchain-bounties#16648

### Changes Implemented:
- Serialize legacy `_check_hardware_binding()` read-check-insert under `BEGIN IMMEDIATE` so concurrent first-time submissions for the same `hardware_id` cannot both pass.
- Handle `IntegrityError` on concurrent INSERT by re-reading the winner binding instead of returning success via `except: pass`.
- Return HTTP 503 from `/attest/submit` when hardware binding lookup is unavailable (fail closed).
- Regression tests for concurrent first-bind race and SQLite error propagation.

### Verification:
- `pytest tests/test_hardware_binding_race.py tests/test_attest_submit_challenge_binding.py tests/test_attest_signature_verification.py tests/test_attest_nonce_replay.py` — 25 passed

### Payout Settlement:
- **Wallet**: `RTCe3eac583f4bc8dcb44b045fee3a65464d5df45b6`