### PR TITLE
fix(docs): repair broken rustchain.org links in README and blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Emission is a fixed 1.5 RTC per epoch and does not halve. It continues at that r
 
 ### Reference rate climbs as holder count grows
 
-The published USD-equivalent reference rate for RTC moves up as the network gains wallet holders. **Per-bounty RTC awards scale DOWN inversely**, so the *USD value paid per finding* stays stable as the token appreciates. The live rate is always at [`/api/tokenomics`](docs/WHITEPAPER.md).
+The published USD-equivalent reference rate for RTC moves up as the network gains wallet holders. **Per-bounty RTC awards scale DOWN inversely**, so the *USD value paid per finding* stays stable as the token appreciates. The live rate is always at [/api/tokenomics](https://rustchain.org/api/tokenomics).
 
 | Holder count | Reference rate | Bounty rate scale |
 |--------------|----------------|-------------------|

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Emission is a fixed 1.5 RTC per epoch and does not halve. It continues at that r
 
 ### Reference rate climbs as holder count grows
 
-The published USD-equivalent reference rate for RTC moves up as the network gains wallet holders. **Per-bounty RTC awards scale DOWN inversely**, so the *USD value paid per finding* stays stable as the token appreciates. The live rate is always at [`/api/tokenomics`](https://rustchain.org/api/tokenomics).
+The published USD-equivalent reference rate for RTC moves up as the network gains wallet holders. **Per-bounty RTC awards scale DOWN inversely**, so the *USD value paid per finding* stays stable as the token appreciates. The live rate is always at [`/api/tokenomics`](docs/WHITEPAPER.md).
 
 | Holder count | Reference rate | Bounty rate scale |
 |--------------|----------------|-------------------|

--- a/docs/blog/rustchain-utility-coin-not-security.md
+++ b/docs/blog/rustchain-utility-coin-not-security.md
@@ -171,7 +171,7 @@ RTC is earned through work, spent on services, and anchored to physical reality.
 
 *RustChain is MIT-licensed open source. Star the repo: github.com/Scottcjn/Rustchain*
 *Block Explorer: rustchain.org/explorer*
-*BCOS Certification: rustchain.org/bcos*
+*BCOS Certification: https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md*
 
 ---
 


### PR DESCRIPTION
## Summary

Repairs dead `rustchain.org` links reported in issues #7910, #7908, #7886, #7885, and #7792.

### Changes
- **README.md**: Replaced dead `/api/tokenomics` link with `docs/WHITEPAPER.md` (the canonical tokenomics reference).
- **docs/blog/rustchain-utility-coin-not-security.md**: Replaced dead `/bcos` link with the GitHub `BCOS.md` file.

### Verification
- All relative links in `README.md` verified locally via filesystem check.
- Existing `lychee.yml` CI workflow already enforces relative link integrity on PRs touching markdown files.
- External `rustchain.org/api/tokenomics` returns HTTP 200 but serves generic content; Whitepaper is the authoritative source per repo structure.
- External `rustchain.org/bcos/` returns HTTP 404; BCOS.md is the current certification reference.

Closes #7910, #7908, #7886, #7885, #7792.

---
Bounty claim for #16248. Wallet: RTC1e9bf7a2a60aac9bcbc5a0df0c65e9501e932861