### PR TITLE
fix(security #71): close alternate-serial migration-takeover of hardware bindings

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2062,9 +2062,24 @@ def init_db():
                 device_arch TEXT,
                 device_model TEXT,
                 bound_at INTEGER NOT NULL,
-                attestation_count INTEGER DEFAULT 0
+                attestation_count INTEGER DEFAULT 0,
+                stable_hw_id TEXT
             )
         """)
+        # stable_hw_id is the SERIAL-FREE machine identity (equal to the hardened
+        # hardware_id). It lets _check_hardware_binding resolve prior ownership of
+        # a machine WITHOUT trusting the client-supplied cpu_serial, which closes
+        # the alternate-serial migration-takeover (#71). DDL lives here in init,
+        # NEVER inside the BEGIN IMMEDIATE write lock in the attest path (running
+        # ALTER there would commit the transaction and reopen the first-bind race
+        # #8267 was written to close). Idempotent for already-deployed DBs.
+        _hwb_cols = [r[1] for r in c.execute("PRAGMA table_info(hardware_bindings)").fetchall()]
+        if "stable_hw_id" not in _hwb_cols:
+            try:
+                c.execute("ALTER TABLE hardware_bindings ADD COLUMN stable_hw_id TEXT")
+            except sqlite3.OperationalError:
+                pass  # concurrent worker already added it
+        c.execute("CREATE INDEX IF NOT EXISTS idx_hwb_stable ON hardware_bindings(stable_hw_id)")
         c.execute("""
             CREATE TABLE IF NOT EXISTS oui_deny(
                 oui TEXT PRIMARY KEY,
@@ -5667,14 +5682,49 @@ def _compute_legacy_hardware_id_with_client_serial(
     hw_fields = [ip_component, model, arch, family, cores, mac_str, cpu_serial]
     return hashlib.sha256('|'.join(str(f) for f in hw_fields).encode()).hexdigest()[:32]
 
+_HWB_STABLE_COL_READY_FOR = None
+
+
+def _ensure_stable_hw_id_column():
+    """Idempotently add hardware_bindings.stable_hw_id + its index, once per
+    DB_PATH, OUTSIDE any BEGIN IMMEDIATE write lock.
+
+    This must not depend on init_db(): init_db() only runs under
+    `if __name__ == "__main__"`, so under gunicorn/WSGI it never fires and the
+    column would be missing -> every bind would fail closed -> full attest
+    outage. Calling this from the attest path makes the schema self-heal on any
+    launcher. Readiness is keyed to DB_PATH (not a bare flag) so a runtime DB
+    switch re-ensures. Concurrent workers racing the ALTER are tolerated."""
+    global _HWB_STABLE_COL_READY_FOR
+    if _HWB_STABLE_COL_READY_FOR == DB_PATH:
+        return
+    try:
+        with closing(sqlite3.connect(DB_PATH, timeout=10)) as conn:
+            cols = [r[1] for r in conn.execute("PRAGMA table_info(hardware_bindings)").fetchall()]
+            if 'stable_hw_id' not in cols:
+                try:
+                    conn.execute("ALTER TABLE hardware_bindings ADD COLUMN stable_hw_id TEXT")
+                except sqlite3.OperationalError:
+                    pass  # another worker won the race; column now exists
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_hwb_stable ON hardware_bindings(stable_hw_id)")
+            conn.commit()
+        _HWB_STABLE_COL_READY_FOR = DB_PATH
+    except sqlite3.Error:
+        # Leave readiness unset so the next attest retries. Do NOT mark ready.
+        pass
+
+
 def _check_hardware_binding(miner_id: str, device: dict, signals: dict = None, source_ip: str = None):
     """Check if hardware is already bound to a different wallet. One machine = One wallet."""
+    _ensure_stable_hw_id_column()
     hardware_id = _compute_hardware_id(device, signals, source_ip=source_ip)
     legacy_hardware_id = _compute_legacy_hardware_id_with_client_serial(
         device, signals, source_ip=source_ip
     )
     now = int(time.time())
     
+    req_arch = device.get('device_arch')
+    req_model = device.get('device_model')
     try:
         with closing(sqlite3.connect(DB_PATH, timeout=10, isolation_level=None)) as conn:
             c = conn.cursor()
@@ -5682,68 +5732,79 @@ def _check_hardware_binding(miner_id: str, device: dict, signals: dict = None, s
 
             # Check and mutate under the same write lock so a losing concurrent
             # first bind cannot be treated as successful for a different wallet.
+            # (The stable_hw_id column/index are created in init_db, never here:
+            # DDL under BEGIN IMMEDIATE would commit and reopen the race.)
             c.execute('SELECT bound_miner, attestation_count FROM hardware_bindings WHERE hardware_id = ?',
                       (hardware_id,))
             row = c.fetchone()
 
-            if row is None:
-                # Migration bridge for rows written before client-controlled
-                # cpu_serial/hardware_id was removed from the binding key. If
-                # the same wallet already owns the old key, preserve continuity
-                # by rewriting that row to the hardened key instead of creating
-                # a second binding.
-                c.execute(
-                    'SELECT bound_miner, attestation_count FROM hardware_bindings WHERE hardware_id = ?',
-                    (legacy_hardware_id,),
-                )
-                legacy_row = c.fetchone()
-                if legacy_row is not None:
-                    legacy_bound_miner, _ = legacy_row
-                    if legacy_bound_miner != miner_id:
-                        conn.rollback()
-                        return (
-                            False,
-                            f'Hardware bound to {legacy_bound_miner[:16]}...',
-                            legacy_bound_miner,
-                        )
-
+            if row is not None:
+                bound_miner = row[0]
+                if bound_miner == miner_id:
+                    # Same wallet re-attesting. Backfill stable_hw_id on touch so
+                    # this machine's serial-free identity is recorded for (a) below.
                     c.execute(
-                        """UPDATE hardware_bindings
-                           SET hardware_id = ?,
-                               device_arch = ?,
-                               device_model = ?,
-                               attestation_count = attestation_count + 1
-                           WHERE hardware_id = ? AND bound_miner = ?""",
-                        (
-                            hardware_id,
-                            device.get('device_arch'),
-                            device.get('device_model'),
-                            legacy_hardware_id,
-                            miner_id,
-                        ),
+                        'UPDATE hardware_bindings '
+                        'SET attestation_count = attestation_count + 1, '
+                        '    stable_hw_id = COALESCE(stable_hw_id, ?) '
+                        'WHERE hardware_id = ?',
+                        (hardware_id, hardware_id),
                     )
                     conn.commit()
                     return True, 'Authorized', miner_id
+                # DIFFERENT wallet on the same hardened hardware id.
+                conn.rollback()
+                return False, f'Hardware bound to {bound_miner[:16]}...', bound_miner
 
-                c.execute("""INSERT INTO hardware_bindings 
-                    (hardware_id, bound_miner, device_arch, device_model, bound_at, attestation_count)
-                    VALUES (?, ?, ?, ?, ?, 1)""",
-                    (hardware_id, miner_id, device.get('device_arch'), device.get('device_model'), now))
-                conn.commit()
-                return True, 'Hardware bound', miner_id
+            # No hardened row yet. Resolve prior ownership of this machine
+            # INDEPENDENTLY of the client-supplied serial before minting the key.
 
-            bound_miner, _ = row
+            # (a) A migrated or freshly-bound row already claims this serial-free
+            #     machine identity. A different wallet must not take it over by
+            #     presenting a different serial (this is the #71 fix). stable_hw_id
+            #     equals the hardened id, so it is not forgeable from the serial.
+            c.execute('SELECT bound_miner FROM hardware_bindings WHERE stable_hw_id = ?',
+                      (hardware_id,))
+            stable_row = c.fetchone()
+            if stable_row is not None and stable_row[0] != miner_id:
+                conn.rollback()
+                return False, f'Hardware bound to {stable_row[0][:16]}...', stable_row[0]
 
-            if bound_miner == miner_id:
-                # Same wallet - allow
-                c.execute('UPDATE hardware_bindings SET attestation_count = attestation_count + 1 WHERE hardware_id = ?',
-                          (hardware_id,))
+            # (b) Same-wallet legacy continuity: a pre-hardening row keyed with
+            #     THIS wallet's own serial is rewritten once to the hardened key
+            #     and stamped with stable_hw_id so it is protected from then on.
+            c.execute(
+                'SELECT bound_miner FROM hardware_bindings WHERE hardware_id = ?',
+                (legacy_hardware_id,),
+            )
+            legacy_row = c.fetchone()
+            if legacy_row is not None:
+                legacy_bound_miner = legacy_row[0]
+                if legacy_bound_miner != miner_id:
+                    conn.rollback()
+                    return (False, f'Hardware bound to {legacy_bound_miner[:16]}...', legacy_bound_miner)
+                c.execute(
+                    """UPDATE hardware_bindings
+                       SET hardware_id = ?, stable_hw_id = ?,
+                           device_arch = ?, device_model = ?,
+                           attestation_count = attestation_count + 1
+                       WHERE hardware_id = ? AND bound_miner = ?""",
+                    (hardware_id, hardware_id, req_arch, req_model, legacy_hardware_id, miner_id),
+                )
                 conn.commit()
                 return True, 'Authorized', miner_id
 
-            # DIFFERENT wallet on same hardware!
-            conn.rollback()
-            return False, f'Hardware bound to {bound_miner[:16]}...', bound_miner
+            # (c) No prior owner resolvable without trusting the serial -> fresh
+            #     hardened binding, stable_hw_id set so it is takeover-proof.
+            #     NOTE: device_arch/device_model are NOT used as a machine
+            #     identity here on purpose -- they are shared across thousands of
+            #     unrelated miners and would reject honest first binds.
+            c.execute("""INSERT INTO hardware_bindings
+                (hardware_id, bound_miner, device_arch, device_model, bound_at, attestation_count, stable_hw_id)
+                VALUES (?, ?, ?, ?, ?, 1, ?)""",
+                (hardware_id, miner_id, req_arch, req_model, now, hardware_id))
+            conn.commit()
+            return True, 'Hardware bound', miner_id
     except sqlite3.Error as exc:
         app.logger.warning(
             "legacy hardware binding check failed closed for %s/%s: %s",

--- a/tests/test_legacy_hardware_binding_race.py
+++ b/tests/test_legacy_hardware_binding_race.py
@@ -62,7 +62,8 @@ def test_legacy_hardware_binding_rechecks_after_concurrent_insert(tmp_path, monk
                 device_arch TEXT,
                 device_model TEXT,
                 bound_at INTEGER NOT NULL,
-                attestation_count INTEGER DEFAULT 0
+                attestation_count INTEGER DEFAULT 0,
+                stable_hw_id TEXT
             )
             """
         )
@@ -112,7 +113,8 @@ def test_legacy_hardware_binding_ignores_spoofable_cpu_serial(tmp_path, monkeypa
                 device_arch TEXT,
                 device_model TEXT,
                 bound_at INTEGER NOT NULL,
-                attestation_count INTEGER DEFAULT 0
+                attestation_count INTEGER DEFAULT 0,
+                stable_hw_id TEXT
             )
             """
         )
@@ -153,7 +155,8 @@ def test_legacy_hardware_binding_migrates_same_wallet_old_hash(tmp_path, monkeyp
                 device_arch TEXT,
                 device_model TEXT,
                 bound_at INTEGER NOT NULL,
-                attestation_count INTEGER DEFAULT 0
+                attestation_count INTEGER DEFAULT 0,
+                stable_hw_id TEXT
             )
             """
         )
@@ -222,3 +225,143 @@ def test_legacy_hardware_binding_fails_closed_when_db_unavailable(monkeypatch):
     assert ok is False
     assert reason == "hardware_binding_unavailable"
     assert bound_miner == ""
+
+
+_SCHEMA = """
+    CREATE TABLE hardware_bindings (
+        hardware_id TEXT PRIMARY KEY,
+        bound_miner TEXT NOT NULL,
+        device_arch TEXT,
+        device_model TEXT,
+        bound_at INTEGER NOT NULL,
+        attestation_count INTEGER DEFAULT 0,
+        stable_hw_id TEXT
+    )
+"""
+
+
+def test_legacy_migration_cannot_be_stolen_with_alternate_client_serial(tmp_path, monkeypatch):
+    """#71: a different wallet must not seize the hardened key by changing the
+    client-controlled serial so its legacy lookup misses the victim's row."""
+    db_path = tmp_path / "hb-71-takeover.sqlite3"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(_SCHEMA)
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+
+    base = {"device_model": "shared-host", "device_arch": "x86_64",
+            "device_family": "modern", "cores": 8}
+    victim_device = {**base, "cpu_serial": "S_REAL"}
+    attacker_device = {**base, "cpu_serial": "S_FAKE"}
+    signals = {"macs": ["aa:bb:cc:dd:ee:ff"]}
+    source_ip = "203.0.113.50"
+
+    # Seed the victim's pre-#8267 binding keyed with THEIR real serial, and
+    # stamp its serial-free stable identity the way a migrated/backfilled row has.
+    victim_old = integrated_node._compute_legacy_hardware_id_with_client_serial(
+        victim_device, signals, source_ip=source_ip)
+    hardened = integrated_node._compute_hardware_id(
+        victim_device, signals, source_ip=source_ip)
+    assert victim_old != hardened
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO hardware_bindings (hardware_id, bound_miner, device_arch, "
+            "device_model, bound_at, attestation_count, stable_hw_id) VALUES (?,?,?,?,?,?,?)",
+            (victim_old, "victim-wallet", "x86_64", "shared-host", 1_700_000_000, 4, hardened),
+        )
+
+    # Attacker presents the same machine tuple but a DIFFERENT serial.
+    a_ok, _, a_bound = integrated_node._check_hardware_binding(
+        "attacker-wallet", attacker_device, signals, source_ip=source_ip)
+    assert a_ok is False
+    assert a_bound == "victim-wallet"
+
+    # Victim continuity still works.
+    v_ok, _, v_bound = integrated_node._check_hardware_binding(
+        "victim-wallet", victim_device, signals, source_ip=source_ip)
+    assert v_ok is True
+    assert v_bound == "victim-wallet"
+
+
+def test_arch_model_are_not_treated_as_machine_identity(tmp_path, monkeypatch):
+    """Regression: two UNRELATED miners sharing a common arch/model but on
+    different machines (IP/MACs) must both bind. arch/model is not an identity."""
+    db_path = tmp_path / "hb-arch-model.sqlite3"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(_SCHEMA)
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+
+    common = {"device_model": "Threadripper", "device_arch": "x86_64",
+              "device_family": "modern", "cores": 32, "cpu_serial": "X"}
+    # Miner A on one machine.
+    a_ok, _, _ = integrated_node._check_hardware_binding(
+        "miner-a", common, {"macs": ["11:11:11:11:11:11"]}, source_ip="198.51.100.1")
+    # Miner B: identical arch/model, DIFFERENT machine (different IP + MACs).
+    b_ok, b_reason, _ = integrated_node._check_hardware_binding(
+        "miner-b", common, {"macs": ["22:22:22:22:22:22"]}, source_ip="198.51.100.2")
+    assert a_ok is True
+    assert b_ok is True, f"honest second miner rejected: {b_reason}"
+
+
+def test_binding_self_heals_when_stable_column_missing(tmp_path, monkeypatch):
+    """gunicorn safety: init_db() runs only under __main__, so the attest path
+    must add stable_hw_id itself. A bare pre-existing table (no column) must not
+    cause a fail-closed attest outage."""
+    db_path = tmp_path / "hb-no-column.sqlite3"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE hardware_bindings (hardware_id TEXT PRIMARY KEY, "
+            "bound_miner TEXT NOT NULL, device_arch TEXT, device_model TEXT, "
+            "bound_at INTEGER NOT NULL, attestation_count INTEGER DEFAULT 0)"
+        )
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    monkeypatch.setattr(integrated_node, "_HWB_STABLE_COL_READY_FOR", None)
+    dev = {"device_model": "m", "device_arch": "x86_64", "device_family": "modern",
+           "cores": 4, "cpu_serial": "Z"}
+    ok, reason, _ = integrated_node._check_hardware_binding(
+        "miner-x", dev, {"macs": ["33:33:33:33:33:33"]}, source_ip="192.0.2.9")
+    assert ok is True, f"attest failed closed on missing column: {reason}"
+    with sqlite3.connect(db_path) as conn:
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(hardware_bindings)").fetchall()]
+    assert "stable_hw_id" in cols
+
+
+def test_legacy_null_row_self_heals_then_resists_takeover(tmp_path, monkeypatch):
+    """Honest deploy-state coverage for #71. A real pre-#8267 row arrives with
+    stable_hw_id IS NULL (no backfill is possible: the serial-free identity needs
+    IP/MACs/cores the old row never stored). Documented remediation: the moment
+    the legitimate owner re-attests once (same serial, <=10min attest interval),
+    its row is migrated + stamped, and an alternate-serial takeover then FAILS.
+    """
+    db_path = tmp_path / "hb-null-selfheal.sqlite3"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(_SCHEMA)
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    monkeypatch.setattr(integrated_node, "_HWB_STABLE_COL_READY_FOR", None)
+
+    base = {"device_model": "shared-host", "device_arch": "x86_64",
+            "device_family": "modern", "cores": 8}
+    victim = {**base, "cpu_serial": "S_REAL"}
+    attacker = {**base, "cpu_serial": "S_FAKE"}
+    signals = {"macs": ["aa:bb:cc:dd:ee:ff"]}
+    ip = "203.0.113.50"
+
+    victim_legacy = integrated_node._compute_legacy_hardware_id_with_client_serial(
+        victim, signals, source_ip=ip)
+    with sqlite3.connect(db_path) as conn:  # unmigrated row: stable_hw_id NULL
+        conn.execute(
+            "INSERT INTO hardware_bindings (hardware_id, bound_miner, device_arch, "
+            "device_model, bound_at, attestation_count) VALUES (?,?,?,?,?,?)",
+            (victim_legacy, "victim-wallet", "x86_64", "shared-host", 1_700_000_000, 4))
+
+    # Owner re-attests once with their own serial -> migrate + stamp stable_hw_id.
+    ok, _, bound = integrated_node._check_hardware_binding("victim-wallet", victim, signals, source_ip=ip)
+    assert ok is True and bound == "victim-wallet"
+    with sqlite3.connect(db_path) as conn:
+        stamped = conn.execute(
+            "SELECT stable_hw_id FROM hardware_bindings WHERE bound_miner='victim-wallet'").fetchone()[0]
+    assert stamped is not None, "self-heal must stamp stable_hw_id on owner re-attest"
+
+    # Now the alternate-serial takeover is blocked.
+    a_ok, _, a_bound = integrated_node._check_hardware_binding("attacker-wallet", attacker, signals, source_ip=ip)
+    assert a_ok is False
+    assert a_bound == "victim-wallet"


### PR DESCRIPTION
## What
Closes the alternate-serial migration-takeover reported by **@prins1bap-ui** (Blake Prins) against **#8267** (merged yesterday). Verified real: his pytest returns `attacker_ok=True` on current main.

## The flaw
On a hardened-key miss, `_check_hardware_binding` recomputed the legacy binding key from the **current request's client-controlled** `cpu_serial`. A second wallet supplying a different serial misses the victim's legacy row → no hardened row exists → it INSERTs the hardened key for itself and locks out the legitimate miner.

## The fix
Resolve prior ownership **independently of the client serial** via a serial-free `stable_hw_id` (== the hardened id). Stamped on every migrate/fresh-bind, backfilled on same-wallet re-attest. `device_arch`/`device_model` are **not** used as identity (shared across thousands of miners → would reject honest binds — an earlier draft did this and tribrain caught it).

## Deploy-safety (tribrain-hardened)
- Schema change runs in `init_db` **and** lazily from the attest path — `init_db` only runs under `__main__`, so under gunicorn it never fires → missing column → full attest outage. This self-heals on any launcher.
- DDL kept **outside** `BEGIN IMMEDIATE` (running it there commits and reopens the #8267 first-bind race).
- Concurrent-worker ALTER tolerated; readiness keyed to `DB_PATH`.

## ⚠️ Residual — read before deploying
The serial-free identity of ~7k pre-#8267 rows **cannot be backfilled** (old rows never stored IP/MACs/cores). They self-heal the instant their owner re-attests once (same serial, ≤10 min attest interval). Until then, an attacker who has cloned the full hardware identity could still win the race. **Deploy should be monitored and ideally paired with a forced re-attest sweep.** Also note: **prod is still pre-#8267** — this fix must land together with #8267, never after it.

## Tests
Blake's exact takeover case, arch/model-not-identity, gunicorn column-missing self-heal, honest NULL-row self-heal→resist. 326 hardware/attest tests pass; 3 tribrain loops (arch/model poison, DDL-in-txn race, gunicorn outage all found & fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)