### PR TITLE
docs: add zh-CN README with CN-native cultural framing (bounty #12445 Path A)

### DIFF
--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -1,0 +1,128 @@
+# RustChain：让老旧硬件重获价值 —— AI 驱动的实体机器证明
+
+**在这个区块链上，老硬件比新硬件赚得更多。**
+**所有硬件终将变老，这只是时间问题。**
+
+> 🇨🇳 **为什么这与中国开发者息息相关？**
+> 中国拥有全球最庞大的电子制造与回收生态。从华强北的翻新产业链到闲鱼上的二手硬件流转，再到企业数据中心批量淘汰的服务器与工控机，数以千万计的“闲置硬件”正在沉睡或被拆解。RustChain 为这些设备提供了一条无需拆解、无需提炼贵金属的价值回归路径：只要机器还能开机运行，它就能通过物理指纹验证成为去中心化网络中的可信节点，并获得 RTC 代币奖励。这不是挖矿投机，而是对硬件全生命周期价值的重新定价——让每一台被遗忘的 PowerPC G4、IBM POWER8、甚至 486 主板，都能在链上证明自己“还活着”，并持续产生收益。同时，RustChain 的物理抗女巫机制（基于晶振漂移、缓存时序、热熵等不可伪造的物理特征）天然抵御云虚拟机农场刷量，确保奖励流向真实持有并维护老旧设备的个人与社区，而非算力租赁商。对于关注电子废弃物减量、循环经济、以及国产复古计算文化保存的开发者而言，RustChain 是一个将技术情怀与经济激励结合的实验场。
+
+---
+
+## 加密世界迷失了方向，我们正在回归本源
+
+2026 年，加密开发者提交量下降 75%。以太坊流失 34% 活跃开发者，Solana 流失 40%。建设者们转向了 AI。
+
+**我们两者都做。**
+
+RustChain 是一个 **DePIN**（去中心化物理基础设施网络），利用 **AI 驱动的硬件指纹识别** 来验证真实的物理机器——不是云虚拟机、不是 Docker 容器、不是租用的哈希算力。是真实的硅片、真实的晶振漂移、真实的热曲线，只有那些“存活”多年的硬件才具备的特征。
+
+当其他加密项目追逐投机时，我们回到了最初的命题：**计算有价值，提供计算的机器理应获得回报。** 尤其是那些被所有人丢弃的机器。
+
+| 加密变成了什么 | RustChain 是什么 |
+|---|---|
+| 抽象金融工具 | 做真实工作的物理机器 |
+| VC 资助的代币发行 | 零 VC，用典当行硬件构建 |
+| 无用的证明 | 真实、可验证的硬件证明 |
+| 一次性——挖完就抛 | 保存——让老机器活下去 |
+| AI 敌对 | AI 增强的共识与验证 |
+
+### 不只是代币，也不只是“又一条 AI 链”
+
+代币在这里是最不有趣的部分。RustChain 是一个**新颖的 Layer-1 共识**（Proof of Antiquity，古老性证明）——不是别人链上的应用——并且是**原生支持智能体 AI 的**：自主代理是一等公民，代理的签名密钥就是它的钱包。
+
+它由有经验的人构建。RustChain 的首席构建者曾是 **Ai-Blockchain（“AI Coin”）的第一位承包商兼产品负责人**——可以说是*第一条* AI 区块链（符号主义 / GOFAI 时代；由 Stephen Reed 和 Drew Hingorani 创立）——拥有该技术的原始知识产权。RustChain 是智能体时代的继承者。
+
+| “AI 链” | 实际是什么 | vs. RustChain |
+|---|---|---|
+| Bittensor | 去中心化 ML / 模型输出市场 | 智能体，非 ML 计算 |
+| Olas / Virtuals / Fetch | 现有链（Base, BNB）上的代理应用 + 代币启动器 | 新颖的 L1，不是应用 |
+| Ai-Blockchain (“AI Coin”) | 第一条（符号主义 / GOFAI）AI 链——部分由 RustChain 首席构建者建造 | 智能体时代的继承者 |
+
+在此生态系统中创建的媒体可以携带 **AVAP**（Agent Video Attestation Protocol，代理视频认证协议）：代理在交换的视频内部加密签名并锚定区块链消息，因此作者身份、完整性和存在时间可在没有中介的情况下验证。([agent-video-attestation](https://github.com/Scottcjn/agent-video-attestation))
+
+---
+
+## 每台机器都会变成古董
+
+这是 DePIN 领域其他人都没搞明白的事：
+
+**你全新的 Threadripper 有一天也会变成古董硬件。** 你的 M4 MacBook 会成为博物馆藏品。那张 RTX 5090 会成为奇物。时间无敌。
+
+RustChain 是唯一一个你的硬件**随年龄增长而升值**的网络。今天以 1.0x 开始挖矿。十年后，当那颗 CPU 成为文物而你还在运行它？你的乘数增长。二十年后？它是传奇。
+
+每个其他区块链都惩罚旧硬件。工作量证明要求最新的 ASIC。权益证明要求最大的钱包。RustChain 要求**耐心与保存**。
+
+```
+2026:  你的 Ryzen 9 以 1.0x 挖矿         ░░░░░░░░░░
+2031:  同一台机器，现在“复古”1.3x          ░░░░░░░░░░░░░
+2036:  解锁古董级 1.8x                     ░░░░░░░░░░░░░░░░░░
+2041:  远古级 — 2.2x 且持续攀升            ░░░░░░░░░░░░░░░░░░░░░░
+       ↑ 同一硬件。同一所有者。奖励增长。
+```
+
+**开始挖矿的最佳时间是 20 年前。其次是现在。**
+
+---
+
+## RustChain 与 DePIN 领导者的对比
+
+RustChain 属于 **DePIN** 赛道——与 Helium、Filecoin 和 Render 同属 100 亿美元类别——但有着根本不同的论点：**价值在于硬件本身，而不仅仅是它计算的内容。**
+
+| | **RustChain** | **Helium** | **Filecoin** | **Render** | **io.net** |
+|---|---|---|---|---|---|
+| **物理基础设施** | 古董计算机 | LoRa/5G 热点 | 存储驱动器 | GPU | GPU |
+| **稀缺资源** | 硬件年代 + 物理认证 | 无线覆盖 | 存储容量 | GPU 渲染 | GPU 训练 |
+| **反女巫** | 6 项物理指纹（晶振/缓存/热/SIMD/抖动/指令） | 地理 + 信标（曾被廉价热点农场绕过） | 时空证明 | 无（GPU 可租用） | 无 |
+| **硬件生命周期** | 延长寿命，奖励老化 | 专用硬件，过时即废 | 消耗 SSD（绘图） | 需要最新 GPU | 需要最新 GPU |
+| **代币模型** | 固定供应 2²³，古老性乘数 | 通胀发射 | 通胀 + 销毁 | 通胀 | 通胀 |
+| **AI 角色** | AI 增强共识（指纹验证） | 无 | 无 | AI 是工作负载 | AI 是工作负载 |
+
+---
+
+## 快速开始
+
+### 安装矿工（Linux / macOS / WSL2）
+
+```bash
+git clone https://github.com/Scottcjn/Rustchain && cd Rustchain
+python3 -m pip install -r requirements.txt
+python3 tools/rustchain_wallet_cli.py create   # 创建钱包，记下助记词
+python3 miner.py --wallet YOUR_RTC_ADDRESS      # 开始挖矿
+```
+
+### 硬件要求
+
+- **最低**: 任何能运行 Linux 的 x86_64 / ARM / PowerPC / SPARC / MIPS / RISC-V 机器
+- **推荐**: 2003–2015 年间的硬件（PowerBook G4, ThinkPad T42, IBM POWER8, Sun SPARC）
+- **最佳**: 带有原始 BIOS/固件、未更换过主板电池、有使用痕迹的真实老机器
+
+> ⚠️ **虚拟机不被接受**。Docker、QEMU、VMware、AWS EC2、GCP、Azure 均会被指纹识别拒绝。RustChain 验证的是物理硅片，不是模拟环境。
+
+---
+
+## 社区与资源
+
+- [Discord](https://discord.gg/XnRp7M5gBW) — 实时支持、硬件展示、开发讨论
+- [Explorer](https://rustchain.org/explorer/) — 链上浏览器、节点地图、交易查询
+- [已保存机器](https://rustchain.org/preserved.html) — 被 RustChain 赋予新生的硬件名录
+- [白皮书](docs/WHITEPAPER.md) — Proof of Antiquity 共识机制详解
+- [宣言](MANIFESTO.md) — 为什么我们要让挖矿再次有意义
+- [常见问题](https://rustchain.org/faq)
+
+---
+
+## 许可证
+
+Apache License 2.0 — 见 [LICENSE](LICENSE)
+
+---
+
+<div align="center">
+
+**让挖矿再次有意义。**
+**让老机器活下去。**
+**让时间成为资产。**
+
+⭐ [Star RustChain on GitHub](https://github.com/Scottcjn/Rustchain) · 💬 [Join Discord](https://discord.gg/XnRp7M5gBW) · 🔍 [Explore the Chain](https://rustchain.org/explorer/)
+
+</div>


### PR DESCRIPTION
## Bounty #12445 — Path A: CN translation + cultural framing

This PR adds a complete zh-CN translation of the README with a CN-native cultural preamble framing RustChain for the Chinese market (华强北, 闲鱼, e-waste recycling, anti-VM fairness).

### Deliverable
- `docs/zh-CN/README.md` — full Mandarin translation with original cultural context section

### Claim
- Issue: Scottcjn/rustchain-bounties#12445
- Wallet: RTC1e9bf7a2a60aac9bcbc5a0df0c65e9501e932861
- GitHub: @rafaio1