### PR TITLE
docs: add payout notice audit tutorial

### DIFF
--- a/content-round-16497-payout-notice-audit/RUN_OUTPUT.txt
+++ b/content-round-16497-payout-notice-audit/RUN_OUTPUT.txt
@@ -1,0 +1,42 @@
+[
+  {
+    "author": "Scottcjn",
+    "fields": {
+      "amount": "33_RTC",
+      "confirms_at": "2026-09-02T12:00:00Z",
+      "pending_id": "pending-42",
+      "tx_hash": "tx-demo-abc",
+      "wallet": "demo-wallet"
+    },
+    "missing": [],
+    "settled": false,
+    "status": "ready_for_project_record_verification"
+  },
+  {
+    "author": "helpful-stranger",
+    "fields": {
+      "amount": "33_RTC",
+      "confirms_at": "tomorrow",
+      "pending_id": "pending-99",
+      "tx_hash": "tx-untrusted",
+      "wallet": "demo-wallet"
+    },
+    "missing": [],
+    "settled": false,
+    "status": "reject_unauthorized_author"
+  },
+  {
+    "author": "AutoJanitor",
+    "fields": {
+      "amount": "10_RTC",
+      "pending_id": "pending-77"
+    },
+    "missing": [
+      "wallet",
+      "tx_hash",
+      "confirms_at"
+    ],
+    "settled": false,
+    "status": "hold_missing_fields"
+  }
+]

--- a/content-round-16497-payout-notice-audit/article.md
+++ b/content-round-16497-payout-notice-audit/article.md
@@ -1,0 +1,54 @@
+# Auditing RustChain Payout Notices Without Mistaking a Promise for Payment
+
+RustChain contributors often encounter several different kinds of evidence during a bounty payout: an issue comment that mentions an amount, a project-issued pending transfer identifier, a transaction hash, a confirmation time, and eventually a confirmed transfer. Those are not interchangeable. A message that says “payment is on the way” is weaker than a project-authorized payout record, and a pending record is still not the same thing as settled funds.
+
+This tutorial builds a small, dependency-free Python tool that performs a conservative first-pass audit of payout notices. It is designed to answer one narrow question: **does this message contain the minimum identity and field signals needed for a human to verify it against project records?** It deliberately does not claim to prove that a transaction exists, that a hash is valid, or that RTC has settled.
+
+The canonical RustChain repository is [Scottcjn/Rustchain](https://github.com/Scottcjn/Rustchain). Its [payment-authority policy](https://github.com/Scottcjn/Rustchain/blob/main/SECURITY.md#payment-authority-impersonation) says that payout authority belongs to `@Scottcjn` or clearly labeled project automation accounts acting on his behalf. A legitimate notice also includes details such as the amount, recipient wallet, `pending_id`, `tx_hash`, and confirmation timing. The policy warns contributors not to treat similar language from an unrelated account as authorization.
+
+## What the checker does
+
+The runnable file is [`payout_notice_audit.py`](https://github.com/Aming9303/Rustchain/blob/bounty-16497-payout-verifier/content-round-16497-payout-notice-audit/payout_notice_audit.py). It accepts a JSON array in which each object has an `author` and a `body`. For every notice it:
+
+1. checks the author against the project accounts documented in `SECURITY.md`;
+2. extracts the documented payout fields without trying to interpret or validate their values;
+3. reports any missing fields; and
+4. assigns one of three preflight statuses.
+
+The statuses are intentionally cautious:
+
+- `reject_unauthorized_author` means the author is not in the documented authority list, even when the message contains convincing-looking identifiers;
+- `hold_missing_fields` means the author is recognized but the notice is incomplete; and
+- `ready_for_project_record_verification` means the message has enough structure for the next verification step.
+
+Every result also contains `"settled": false`. That invariant is important. Offline text parsing cannot establish that a project database contains the pending record or that a transfer has reached its confirmation state.
+
+## Run the reproducible sample
+
+The directory includes [`sample_notices.json`](https://github.com/Aming9303/Rustchain/blob/bounty-16497-payout-verifier/content-round-16497-payout-notice-audit/sample_notices.json) with three synthetic examples. No real wallet, transfer identifier, or transaction hash is used. From the repository root, run:
+
+```bash
+python content-round-16497-payout-notice-audit/payout_notice_audit.py \
+  content-round-16497-payout-notice-audit/sample_notices.json
+```
+
+The first example has a documented authority and all five fields, so it is ready for record verification. The second contains every field but comes from an unrelated account, so it is rejected. The third comes from an authorized automation account but lacks the wallet, transaction hash, and confirmation time, so it is held.
+
+Run the focused tests with:
+
+```bash
+python -m unittest discover -s content-round-16497-payout-notice-audit \
+  -p "test_payout_notice_audit.py" -v
+```
+
+The tests cover all three classifications and reject a malformed top-level JSON object. They also assert that even a complete authorized notice remains unsettled at this stage.
+
+## Where real verification begins
+
+After the preflight passes, a contributor should compare the `pending_id` and `tx_hash` with the project-issued record or documented public API response. The wallet and amount must match the intended recipient and bounty. Confirmation timing should be preserved rather than rounded into an immediate “paid” status. Only the final confirmed project or chain evidence should update an accounting ledger as settled.
+
+This separation prevents two common errors. The first is social engineering: a stranger can copy the vocabulary of a legitimate payout notice. The second is premature accounting: even a genuine project account may announce a pending transfer before its confirmation window closes. Identity checks address the first problem; lifecycle-aware verification addresses the second.
+
+The example is small enough to audit and adapt. A production version could load the authority list from a signed project policy, fetch the corresponding pending record, validate field formats, and store a checkpoint so the same transfer is not counted twice. Those additions should preserve the same conservative rule: text is a lead, a project record is evidence, and confirmation is settlement.
+
+Assistance disclosure: this tutorial and code were prepared with AI assistance, then checked against RustChain's public `SECURITY.md` payment-authority policy. The examples are synthetic, and the tests were run locally before submission.

--- a/content-round-16497-payout-notice-audit/article.md
+++ b/content-round-16497-payout-notice-audit/article.md
@@ -41,7 +41,7 @@ python -m unittest discover -s content-round-16497-payout-notice-audit \
   -p "test_payout_notice_audit.py" -v
 ```
 
-The tests cover all three classifications and reject a malformed top-level JSON object. They also assert that even a complete authorized notice remains unsettled at this stage.
+The tests cover all three classifications, case-insensitive GitHub login matching, and malformed JSON structures. They also assert that even a complete authorized notice remains unsettled at this stage.
 
 ## Where real verification begins
 

--- a/content-round-16497-payout-notice-audit/payout_notice_audit.py
+++ b/content-round-16497-payout-notice-audit/payout_notice_audit.py
@@ -11,6 +11,7 @@ from typing import Any
 
 
 AUTHORIZED_AUTHORS = {"Scottcjn", "sophiaeagent-beep", "AutoJanitor"}
+AUTHORIZED_AUTHOR_KEYS = {author.casefold() for author in AUTHORIZED_AUTHORS}
 FIELD_PATTERNS = {
     "amount": re.compile(r"(?i)\b(?:amount|payout)\s*[:=]\s*([^\s,;]+)"),
     "wallet": re.compile(r"(?i)\b(?:recipient|wallet)\s*[:=]\s*([^\s,;]+)"),
@@ -32,12 +33,14 @@ def extract_fields(body: str) -> dict[str, str]:
 
 def audit_notice(notice: dict[str, Any]) -> dict[str, Any]:
     """Classify one notice for manual follow-up, never as settled payment."""
+    if not isinstance(notice, dict):
+        raise ValueError("each notice must be a JSON object")
     author = str(notice.get("author", ""))
     body = str(notice.get("body", ""))
     fields = extract_fields(body)
     missing = [name for name in FIELD_PATTERNS if name not in fields]
 
-    if author not in AUTHORIZED_AUTHORS:
+    if author.casefold() not in AUTHORIZED_AUTHOR_KEYS:
         status = "reject_unauthorized_author"
     elif missing:
         status = "hold_missing_fields"

--- a/content-round-16497-payout-notice-audit/payout_notice_audit.py
+++ b/content-round-16497-payout-notice-audit/payout_notice_audit.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: MIT
+"""Conservative offline preflight checks for RustChain payout notices."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+AUTHORIZED_AUTHORS = {"Scottcjn", "sophiaeagent-beep", "AutoJanitor"}
+FIELD_PATTERNS = {
+    "amount": re.compile(r"(?i)\b(?:amount|payout)\s*[:=]\s*([^\s,;]+)"),
+    "wallet": re.compile(r"(?i)\b(?:recipient|wallet)\s*[:=]\s*([^\s,;]+)"),
+    "pending_id": re.compile(r"(?i)\bpending_id\s*[:=]\s*([^\s,;]+)"),
+    "tx_hash": re.compile(r"(?i)\btx_hash\s*[:=]\s*([^\s,;]+)"),
+    "confirms_at": re.compile(r"(?i)\bconfirms_at\s*[:=]\s*([^\s,;]+)"),
+}
+
+
+def extract_fields(body: str) -> dict[str, str]:
+    """Extract documented payout fields without interpreting their values."""
+    fields: dict[str, str] = {}
+    for name, pattern in FIELD_PATTERNS.items():
+        match = pattern.search(body)
+        if match:
+            fields[name] = match.group(1)
+    return fields
+
+
+def audit_notice(notice: dict[str, Any]) -> dict[str, Any]:
+    """Classify one notice for manual follow-up, never as settled payment."""
+    author = str(notice.get("author", ""))
+    body = str(notice.get("body", ""))
+    fields = extract_fields(body)
+    missing = [name for name in FIELD_PATTERNS if name not in fields]
+
+    if author not in AUTHORIZED_AUTHORS:
+        status = "reject_unauthorized_author"
+    elif missing:
+        status = "hold_missing_fields"
+    else:
+        status = "ready_for_project_record_verification"
+
+    return {
+        "author": author,
+        "status": status,
+        "fields": fields,
+        "missing": missing,
+        "settled": False,
+    }
+
+
+def audit_file(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError("input must be a JSON array of notice objects")
+    return [audit_notice(item) for item in payload]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="JSON array containing author/body notices")
+    args = parser.parse_args()
+    print(json.dumps(audit_file(args.input), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/content-round-16497-payout-notice-audit/sample_notices.json
+++ b/content-round-16497-payout-notice-audit/sample_notices.json
@@ -1,0 +1,14 @@
+[
+  {
+    "author": "Scottcjn",
+    "body": "amount: 33_RTC wallet: demo-wallet pending_id: pending-42 tx_hash: tx-demo-abc confirms_at: 2026-09-02T12:00:00Z"
+  },
+  {
+    "author": "helpful-stranger",
+    "body": "amount: 33_RTC wallet: demo-wallet pending_id: pending-99 tx_hash: tx-untrusted confirms_at: tomorrow"
+  },
+  {
+    "author": "AutoJanitor",
+    "body": "amount: 10_RTC pending_id: pending-77"
+  }
+]

--- a/content-round-16497-payout-notice-audit/test_payout_notice_audit.py
+++ b/content-round-16497-payout-notice-audit/test_payout_notice_audit.py
@@ -35,6 +35,19 @@ class PayoutNoticeAuditTests(unittest.TestCase):
         self.assertEqual(result["status"], "reject_unauthorized_author")
         self.assertIs(result["settled"], False)
 
+    def test_authorized_login_match_is_case_insensitive(self):
+        result = audit_notice(
+            {
+                "author": "SCOTTCJN",
+                "body": (
+                    "amount: 33_RTC wallet: demo-wallet pending_id: pending-42 "
+                    "tx_hash: tx-demo-abc confirms_at: 2026-09-02T12:00:00Z"
+                ),
+            }
+        )
+
+        self.assertEqual(result["status"], "ready_for_project_record_verification")
+
     def test_authorized_notice_with_missing_fields_is_held(self):
         result = audit_notice({"author": "AutoJanitor", "body": "amount: 33_RTC"})
 
@@ -51,6 +64,16 @@ class PayoutNoticeAuditTests(unittest.TestCase):
             path = Path(directory) / "notice.json"
             path.write_text(json.dumps({"author": "Scottcjn"}), encoding="utf-8")
             with self.assertRaisesRegex(ValueError, "JSON array"):
+                audit_file(path)
+
+    def test_each_file_item_must_be_an_object(self):
+        from tempfile import TemporaryDirectory
+        from pathlib import Path
+
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "notice.json"
+            path.write_text(json.dumps(["not-an-object"]), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "each notice"):
                 audit_file(path)
 
 

--- a/content-round-16497-payout-notice-audit/test_payout_notice_audit.py
+++ b/content-round-16497-payout-notice-audit/test_payout_notice_audit.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+import json
+import unittest
+
+from payout_notice_audit import audit_file, audit_notice
+
+
+class PayoutNoticeAuditTests(unittest.TestCase):
+    def test_authorized_complete_notice_requires_record_verification(self):
+        result = audit_notice(
+            {
+                "author": "Scottcjn",
+                "body": (
+                    "amount: 33_RTC wallet: demo-wallet pending_id: pending-42 "
+                    "tx_hash: tx-demo-abc confirms_at: 2026-09-02T12:00:00Z"
+                ),
+            }
+        )
+
+        self.assertEqual(result["status"], "ready_for_project_record_verification")
+        self.assertIs(result["settled"], False)
+        self.assertEqual(result["missing"], [])
+
+    def test_unauthorized_notice_is_rejected_even_with_all_fields(self):
+        result = audit_notice(
+            {
+                "author": "helpful-stranger",
+                "body": (
+                    "amount: 33_RTC wallet: demo-wallet pending_id: pending-42 "
+                    "tx_hash: tx-demo-abc confirms_at: tomorrow"
+                ),
+            }
+        )
+
+        self.assertEqual(result["status"], "reject_unauthorized_author")
+        self.assertIs(result["settled"], False)
+
+    def test_authorized_notice_with_missing_fields_is_held(self):
+        result = audit_notice({"author": "AutoJanitor", "body": "amount: 33_RTC"})
+
+        self.assertEqual(result["status"], "hold_missing_fields")
+        self.assertEqual(
+            result["missing"], ["wallet", "pending_id", "tx_hash", "confirms_at"]
+        )
+
+    def test_file_input_must_be_an_array(self):
+        from tempfile import TemporaryDirectory
+        from pathlib import Path
+
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "notice.json"
+            path.write_text(json.dumps({"author": "Scottcjn"}), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "JSON array"):
+                audit_file(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a runnable tutorial for conservatively auditing RustChain payout notices before treating them as payment evidence.

The example checks the documented payout-authority accounts, extracts the amount, wallet, pending ID, transaction hash, and confirmation time, and keeps every result explicitly unsettled until project-record verification. It includes synthetic sample data and captured output; no real wallet or transaction identifiers are used.

Related bounty round: Scottcjn/rustchain-bounties#16497

## Validation

- Standard-library unit tests: 6 passed
- Sample CLI output matches RUN_OUTPUT.txt
- Article length: 698 words
- git diff --check passed

## Disclosure

The tutorial and code were prepared with AI assistance and checked against the repository's payment-authority policy. The runnable examples and tests were executed locally.