### PR TITLE
docs(QUICKSTART): add copy-paste Windows bootstrap command (Closes #8311)

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -57,6 +57,16 @@ On Windows, choose one of these installer paths instead of the Bash one-liner:
 - **Build a custom installer (for developers):** follow
   `miners/windows/installer/README.md` to build a `.exe` installer with Inno Setup 6.
 
+To copy-paste the quick bootstrap on Windows, open PowerShell and run:
+
+```powershell
+curl.exe -sSL -o rustchain_miner_setup.bat https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/rustchain_miner_setup.bat
+.\rustchain_miner_setup.bat
+```
+
+This downloads the self-bootstrapping setup script and runs it (it installs Python if
+needed), giving Windows users a copy-paste-ready entry point like the Linux/macOS one-liner.
+
 **What this does:**
 
 1. Detects your operating system and CPU architecture


### PR DESCRIPTION
## Summary
Closes #8311.

The QUICKSTART guide states every command is copy-paste ready, but the Windows installer path was described only in prose (no command). This adds a copy-paste-ready PowerShell one-liner that downloads and runs the self-bootstrapping `miners/windows/rustchain_miner_setup.bat`.

### Why `curl.exe`
On Windows PowerShell, `curl` is an alias for `Invoke-WebRequest`, which does **not** accept `-sSL` -- so a bare `curl -o ...` fails. Using `curl.exe` bypasses the alias and the command actually works when pasted, making it genuinely copy-paste-ready (an improvement over the command suggested in the issue).

### Verification
- `miners/windows/rustchain_miner_setup.bat` exists at `main` (verified via contents API).
- Edit is a single-file, +9/-0 line addition; no other docs or code touched.
