### PR TITLE
Fix direct bounty verifier CLI invocation

### DIFF
--- a/tools/bounty_verifier/cli.py
+++ b/tools/bounty_verifier/cli.py
@@ -10,10 +10,21 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
-from .config import Config, load_config
-from .github_client import RateLimitExceeded
-from .models import VerificationStatus
-from .verifier import BountyVerifier
+if __package__:
+    from .config import Config, load_config
+    from .github_client import RateLimitExceeded
+    from .models import ClaimComment, VerificationStatus
+    from .verifier import BountyVerifier
+else:
+    # Preserve the executable-script contract implied by this file's shebang.
+    # Direct invocation puts ``tools/bounty_verifier`` on sys.path, while the
+    # imports below need its parent directory so ``bounty_verifier`` resolves
+    # as a package.
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from bounty_verifier.config import Config, load_config
+    from bounty_verifier.github_client import RateLimitExceeded
+    from bounty_verifier.models import ClaimComment, VerificationStatus
+    from bounty_verifier.verifier import BountyVerifier
 
 
 def setup_logging(level: str) -> None:
@@ -147,7 +158,6 @@ def cmd_check_rate_limit(verifier: BountyVerifier) -> int:
 
 def cmd_parse_comment(verifier: BountyVerifier, text: str) -> int:
     """Parse a claim comment and extract data."""
-    from .models import ClaimComment
     from datetime import datetime
     
     # Create a mock comment

--- a/tools/bounty_verifier/test_cli_entrypoint.py
+++ b/tools/bounty_verifier/test_cli_entrypoint.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for the bounty verifier CLI entry paths."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI = REPO_ROOT / "tools" / "bounty_verifier" / "cli.py"
+
+
+def _help(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args, "--help"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=15,
+    )
+
+
+def test_direct_script_help_is_executable() -> None:
+    result = _help(str(CLI))
+
+    assert result.returncode == 0, result.stderr
+    assert "RustChain Bounty Claim Verification Bot" in result.stdout
+
+
+def test_module_help_remains_supported() -> None:
+    result = _help("-m", "tools.bounty_verifier.cli")
+
+    assert result.returncode == 0, result.stderr
+    assert "RustChain Bounty Claim Verification Bot" in result.stdout


### PR DESCRIPTION
## Summary
- preserve `tools/bounty_verifier/cli.py` as a directly executable CLI by bootstrapping its package import path only when Python supplies no package context
- import `ClaimComment` through the same normalized entry path so the `parse` subcommand also works after direct startup
- add subprocess regression coverage for both direct-script and module invocation

Closes #8314.

## Reproduction before

```console
python tools/bounty_verifier/cli.py --help
ImportError: attempted relative import with no known parent package
```

The module form worked in the same environment, isolating the failure to entry-path handling rather than dependencies.

## Validation

```console
python tools/bounty_verifier/cli.py --help
# exit 0; usage displayed

python -m tools.bounty_verifier.cli --help
# exit 0; usage displayed

python -m pytest tools/bounty_verifier/test_cli_entrypoint.py -q
# 2 passed

python tools/bcos_spdx_check.py --base-ref origin/main
# BCOS SPDX check: OK

git diff --check
# clean
```

This is an ordinary CLI usability fix. No production probing, credentials, wallet operations, or security testing were involved.