### PR TITLE
fix(node/airdrop_v2): close #8245 airdrop claim-insert race (double allocation)

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -927,11 +927,35 @@ class AirdropV2:
             status="pending",
         )
 
-        # Store claim
+        # Store claim atomically.
+        # Serialize on the DB write lock (BEGIN IMMEDIATE) and re-check the
+        # dedup rule INSIDE the transaction. Closes #8245: the _has_claimed()
+        # SELECT at the top of this method and the INSERT below were not
+        # atomic, so two concurrent claims for the SAME github_username with
+        # DIFFERENT wallets could both pass the check and both INSERT (the
+        # UNIQUE constraint only covers the composite
+        # (github_username, wallet_address, chain)), double-allocating.
         conn = self._get_conn()
         cursor = conn.cursor()
 
         try:
+            # Acquire the write lock immediately so concurrent claims serialize
+            # on this (github_username, chain) instead of racing SELECT+INSERT.
+            cursor.execute("BEGIN IMMEDIATE")
+
+            # Re-check dedup inside the locked transaction.
+            cursor.execute(
+                """
+                SELECT 1 FROM airdrop_claims
+                WHERE chain = ? AND (github_username = ? OR wallet_address = ?)
+                AND status IN ('pending', 'completed')
+                """,
+                (chain_lower, github_username, wallet_address),
+            )
+            if cursor.fetchone() is not None:
+                conn.rollback()
+                return False, "Claim already exists for this GitHub account or wallet", None
+
             cursor.execute(
                 """
                 INSERT INTO airdrop_claims
@@ -977,6 +1001,10 @@ class AirdropV2:
         except sqlite3.IntegrityError as e:
             conn.rollback()
             return False, "Claim already exists for this wallet/github pair", None
+        except sqlite3.OperationalError as e:
+            # BEGIN IMMEDIATE / write lock contention under concurrency.
+            conn.rollback()
+            return False, "Concurrent claim conflict (database busy), please retry", None
         except Exception as e:
             conn.rollback()
             logger.error(f"Claim processing error: {e}")

--- a/node/test_airdrop_v2.py
+++ b/node/test_airdrop_v2.py
@@ -251,6 +251,67 @@ class TestEligibilityChecks(unittest.TestCase):
         self.assertIn("ownership verification required", message)
         self.assertIsNone(claim)
 
+    def test_concurrent_claim_same_username_no_double_allocate(self):
+        """Regression #8245: concurrent claims for the SAME github_username
+        with DIFFERENT wallets must not both insert (double-allocate).
+
+        The dedup rule is `github_username OR wallet_address`, but the schema's
+        UNIQUE constraint only covers the composite (github_username,
+        wallet_address, chain). So two racing claims with the same username and
+        different wallets could both pass the early SELECT and both INSERT.
+        The fix serializes the insert via BEGIN IMMEDIATE plus an in-transaction
+        re-check. We exercise the race with real threads against a file-backed
+        DB (the :memory: path shares a single connection and cannot race).
+        """
+        import tempfile
+        import threading
+
+        wallet_a = "RTC1234567890123456789012345678901234567890"
+        wallet_b = "RTC2234567890123456789012345678901234567890"
+
+        for _ in range(10):
+            tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+            tmp.close()
+            db_path = tmp.name
+            try:
+                airdrop = AirdropV2(db_path=db_path)
+                username = "raceuser"
+                results = []
+                barrier = threading.Barrier(2)
+
+                def worker(wallet):
+                    try:
+                        barrier.wait()
+                        ok, _, _ = airdrop.claim_airdrop(
+                            github_username=username,
+                            wallet_address=wallet,
+                            chain="base",
+                            tier="contributor",
+                            skip_antisybil=True,
+                        )
+                        results.append(ok)
+                    except Exception as e:  # pragma: no cover
+                        results.append(f"exc:{e}")
+
+                t1 = threading.Thread(target=worker, args=(wallet_a,))
+                t2 = threading.Thread(target=worker, args=(wallet_b,))
+                t1.start()
+                t2.start()
+                t1.join(timeout=10)
+                t2.join(timeout=10)
+
+                # Exactly one of the two concurrent claims may succeed; never both.
+                self.assertEqual(
+                    sum(1 for r in results if r is True),
+                    1,
+                    f"expected exactly 1 successful claim, got {results}",
+                )
+            finally:
+                try:
+                    os.remove(db_path)
+                except OSError:
+                    pass
+
     def test_duplicate_github_with_different_wallet_rejected(self):
         """A GitHub account cannot claim again with a different wallet."""
         success, _, _ = self.airdrop.claim_airdrop(


### PR DESCRIPTION
## Summary
Closes #8245 — a check-then-insert race in `AirdropV2.claim_airdrop` that allowed
**double airdrop allocation**.

### Root cause
The eligibility/dedup `SELECT` (`_has_claimed`) at the top of `claim_airdrop` and the
`INSERT INTO airdrop_claims` below were **not atomic**. The `UNIQUE` constraint only
covers the composite `(github_username, wallet_address, chain)`, so two concurrent
claims for the **same GitHub username with different wallets** could both pass the
early check and both `INSERT` (no constraint violation) → both get tokens.

### Fix (`node/airdrop_v2.py`)
- Open the write section with `BEGIN IMMEDIATE` to take the DB write lock.
- Re-check the dedup rule (`github_username OR wallet_address`, `pending`/`completed`)
  **inside** the locked transaction and roll back if a claim already exists.
- Serialize the `airdrop_allocation` `UPDATE` so concurrent claims cannot both pass
  the TOCTOU window; handle `sqlite3.OperationalError` (busy lock) gracefully.

### Test (`node/test_airdrop_v2.py`)
- `test_concurrent_claim_same_username_no_double_allocate`: two threads (Barrier(2))
  claim for the same username with different wallets against a real file-backed DB,
  looped 10x, asserting exactly **one** claim succeeds every time.

All 36 tests in `test_airdrop_v2` pass locally (incl. the new regression test and the
#8175 cross-user theft tests).

### Note on delivery
Branch pushed via API objects (git pack transport was being reset by the network
egress proxy); the resulting tree is identical to the local commit `9c607a65`.