### PR TITLE
fix(node): let external sync nodes start without the fleet P2P secret (RC_NODE_ROLE)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,11 @@ services:
       - RUSTCHAIN_DB=/rustchain/data/rustchain_v2.db
       - DOWNLOAD_DIR=/rustchain/downloads
       - PYTHONUNBUFFERED=1
-      # P2P HMAC secret — MUST be set in .env or docker-compose.override.yml
-      - RC_P2P_SECRET=${RC_P2P_SECRET:?RC_P2P_SECRET is required — generate with: openssl rand -hex 32}
+      # Node role: 'sync' (external operator, default here) needs no fleet secret;
+      # 'settlement' (fleet nodes) requires the privately issued RC_P2P_SECRET.
+      - RC_NODE_ROLE=${RC_NODE_ROLE:-sync}
+      # Fleet P2P HMAC secret — only for RC_NODE_ROLE=settlement; leave unset otherwise.
+      - RC_P2P_SECRET=${RC_P2P_SECRET:-}
     volumes:
       # Persistent storage for SQLite database
       - rustchain-data:/rustchain/data

--- a/node/README.md
+++ b/node/README.md
@@ -10,6 +10,21 @@
 - `rip_200_round_robin_1cpu1vote.py` - 1 CPU = 1 Vote consensus
 - `state_pruning.py` - Opt-in SQLite pruning for spent UTXO history and expired mempool rows
 
+## Running a node: roles and the P2P secret
+
+- **Sync node** (external operators): set `RC_NODE_ROLE=sync`. No fleet secrets.
+  Serves the public read API, accepts attestations, does not settle epochs,
+  does not join the authenticated P2P mesh. Leave `RC_P2P_SECRET` unset; the node logs
+  `[P2P] RC_P2P_SECRET is not set: running as a SYNC node ...` and starts.
+- **Settlement node** (the default if `RC_NODE_ROLE` is unset; verified operators,
+  credentials issued privately): requires the issued `RC_P2P_SECRET` and fleet
+  `RC_ADMIN_KEY`, and refuses to start without them (fail closed).
+- `/p2p/state`, `/p2p/attestation_state`, `/p2p/peers` (and `/p2p/gossip`) on
+  fleet nodes answer `401 {"error":"unauthorized","message":"valid X-P2P-Key required"}`
+  to anyone without the fleet secret. That is expected for a sync node -- it is
+  not a misconfiguration on your side and there is no key to request for it.
+- DB path env var is `RUSTCHAIN_DB_PATH` (fallback `DB_PATH`), default `./rustchain_v2.db`.
+
 ## RIP-200 Features
 - Round-robin block production
 - Antiquity multipliers (G4: 2.5x, G5: 2.0x, etc.)

--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -1819,7 +1819,17 @@ def register_p2p_endpoints(app, p2p_node: RustChainP2PNode):
         """Require the shared P2P secret for sensitive read-only sync endpoints."""
         provided = request.headers.get("X-P2P-Key", "")
         if not provided or not hmac.compare_digest(provided, P2P_SECRET):
-            return jsonify({"error": "unauthorized", "message": "valid X-P2P-Key required"}), 401
+            return jsonify({
+                "error": "unauthorized",
+                "message": "valid X-P2P-Key required",
+                # Onboarding: external operators kept hitting this with a
+                # self-generated secret. The header must carry the SAME
+                # RC_P2P_SECRET as this node, which is fleet-only.
+                "hint": ("/p2p/* is the authenticated fleet mesh: X-P2P-Key must equal "
+                         "this node's RC_P2P_SECRET, which is issued privately to "
+                         "settlement-node operators. Sync nodes do not need it; use the "
+                         "public endpoints (/health, /epoch, /api/miners, /wallet/balance)."),
+            }), 401
         return None
 
     @app.route('/p2p/gossip', methods=['POST'])

--- a/node/rustchain_p2p_init.py
+++ b/node/rustchain_p2p_init.py
@@ -102,7 +102,46 @@ def resolve_advertised_url(local_ip, local_port=8099):
     return None
 
 
+def _p2p_secret_configured():
+    """True when the operator supplied a (non-empty) fleet P2P secret."""
+    return bool(os.environ.get("RC_P2P_SECRET", "").strip())
+
+
+def _node_role():
+    """RC_NODE_ROLE: 'settlement' (default, fail-closed: requires RC_P2P_SECRET)
+    or 'sync' (external operator, no fleet secrets, no P2P mesh).
+
+    Settlement is the default on purpose: a fleet node that loses its secret
+    must die loudly, not silently degrade into a public-API-only node
+    (Grok once-over 2026-09-02)."""
+    return os.environ.get("RC_NODE_ROLE", "settlement").strip().lower() or "settlement"
+
+
 def init_p2p(app, db_path, node_id=None):
+    # Onboarding gate: the authenticated gossip mesh (rustchain_p2p_gossip) needs
+    # the fleet-wide RC_P2P_SECRET and hard-exits at import when it is missing.
+    # A new operator running a SYNC node (the documented default) does not hold
+    # that secret and cannot obtain it from the docs -- it is issued privately to
+    # settlement-node operators. Without this gate the whole node process dies
+    # at startup with "[P2P] FATAL: RC_P2P_SECRET ...", or, if the operator
+    # invents a secret, every /p2p/* call to the fleet answers 401
+    # "valid X-P2P-Key required". So: no secret + sync role -> run the public
+    # API without the mesh. Settlement nodes keep the fail-closed behaviour.
+    if not _p2p_secret_configured():
+        role = _node_role()
+        if role == "sync":
+            print("[P2P] RC_P2P_SECRET is not set: running as a SYNC node without "
+                  "the authenticated P2P mesh (no authenticated /p2p mesh endpoints, no gossip). "
+                  "The mesh is fleet-only; sync nodes serve the public read API "
+                  "(/health, /epoch, /api/miners, /wallet/balance) and accept "
+                  "attestations.")
+            return None
+        raise SystemExit(
+            f"[P2P] FATAL: RC_NODE_ROLE={role!r} requires RC_P2P_SECRET (the fleet "
+            "P2P secret issued to verified settlement-node operators). Unset "
+            "RC_NODE_ROLE=sync to run an external sync node without the P2P mesh."
+        )
+
     try:
         from rustchain_p2p_gossip import RustChainP2PNode, register_p2p_endpoints
     except ImportError:

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -12608,8 +12608,15 @@ try:
             print(f"[ERROR] p2p request failed: {e!r}")
             return jsonify({"ok": False, "error": "internal_error"}), 400
 
-    # Start background sync unless an integration test explicitly disables it.
-    if os.environ.get("RUSTCHAIN_DISABLE_P2P_AUTO_START") != "1":
+    # Start background sync unless an integration test explicitly disables it,
+    # or no shared RC_P2P_KEY is configured. Sync/external nodes have no fleet
+    # key: without it every gunicorn worker mints its own random HMAC key and
+    # each outbound sync request 401s every 30s (security audit 2026-09-02, A14).
+    if os.environ.get("RUSTCHAIN_DISABLE_P2P_AUTO_START") == "1":
+        pass
+    elif not os.environ.get("RC_P2P_KEY"):
+        print("[P2P] RC_P2P_KEY not set: legacy block sync not started (fleet-only); public API unaffected")
+    else:
         block_sync.start()
 
     print("[P2P] [OK] Endpoints registered successfully")


### PR DESCRIPTION
## Why
An external operator (Hardik) set up a node per the docs and got stuck on
`{"error":"unauthorized","message":"valid X-P2P-Key required"}`. Root cause: `RC_P2P_SECRET` is a single symmetric fleet key with no exchange path. Without it the node dies at import; with an invented one, every `/p2p/*` call to the fleet 401s forever. Nothing in the tree actually implemented the "sync node" role that PR #8304 documents.

## What
- `RC_NODE_ROLE=settlement` (default when unset): unchanged, fail-closed -- no secret, no start.
- `RC_NODE_ROLE=sync`: external operators. No secret needed; gossip mesh is skipped with one clear log line; public read API + attestation intake run. The role is local-only and grants no remote trust.
- 401 body gains a `hint`.
- Legacy `block_sync.start()` gated on `RC_P2P_KEY` (without it each gunicorn worker minted a random HMAC key and outbound sync 401'd every 30s).
- `docker-compose.yml` no longer forces `openssl rand` on operators; `node/README.md` documents the roles.
- `docs/NODE_OPERATOR_GUIDE.md` wording should land on top of #8304, not here.

## Verified
- `py_compile` clean; behavioural check: unset role/no secret -> SystemExit, `sync`/no secret -> starts without importing gossip, `settlement`/no secret -> SystemExit.
- Real secret -> `/p2p/state` 401+hint without header, 200 with it. Existing P2P suites: 26 pass / 3 fail, same 3 fail on unpatched main.
- Reviewed adversarially by Codex (gpt-5.6-sol) and Grok 4.6; the settlement-by-default and `block_sync` gating are their findings.

Relates to #8304, #8322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKwZZP79b6Acc44cwVZkj4