### PR TITLE
fix(node): keep pinned signing keys, gate welcome bonus on fingerprint, file-backed airdrop DB, drop dead peers

### DIFF
--- a/node/rustchain_p2p_init.py
+++ b/node/rustchain_p2p_init.py
@@ -10,15 +10,17 @@ import ipaddress
 import os
 from urllib.parse import urlparse
 
-# All RustChain nodes - includes both Tailscale and public URLs
+# Live RustChain attestation nodes - includes both Tailscale and public URLs.
+# 2026-09-03: node3 (Ryan's Proxmox, 76.8.228.245 / 100.88.109.32) has been
+# offline for ~3 months and node4 (POWER8 Funnel / 100.94.28.32) is down; both
+# were removed so the sync loop stops posting the P2P secret to dead hosts.
+# node2 now uses https:// - 50.28.86.153 serves /health over TLS (verified
+# 2026-09-03) and plain http://...:8099 is not reachable from outside.
+# Extra peers belong in RC_P2P_PEERS, not in this list.
 PEER_NODES = {
     "node1": "https://rustchain.org",           # VPS Primary (public)
     "node1_ts": "http://100.125.31.50:8099",       # VPS via Tailscale
-    "node2": "http://50.28.86.153:8099",           # VPS Secondary / Ergo Anchor
-    "node3": "http://100.88.109.32:8099",          # Ryan's (Tailscale)
-    "node3_public": "http://76.8.228.245:8099",    # Ryan's (public)
-    "node4": "http://100.94.28.32:8099",           # POWER8 S824 (Tailscale)
-    "node4_public": "https://sophiapower8.tailbac22e.ts.net"  # POWER8 (Funnel - public!)
+    "node2": "https://50.28.86.153",               # VPS Secondary / Ergo Anchor
 }
 
 

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1540,7 +1540,10 @@ if HAVE_REWARDS:
 # RIP-305: Airdrop V2 endpoints
 if HAVE_AIRDROP:
     try:
-        airdrop_instance = AirdropV2()
+        # A5: without db_path AirdropV2 falls back to a per-process :memory:
+        # SQLite DB (one per gunicorn worker, wiped on every restart), so the
+        # one-claim-per-user rule never persisted. Share the node's DB file.
+        airdrop_instance = AirdropV2(db_path=DB_PATH)
         init_airdrop_routes(app, airdrop_instance, DB_PATH)
         print("[RIP-305] Airdrop V2 endpoints registered")
     except Exception as e:
@@ -3876,26 +3879,51 @@ def _ledger_reward_row(c, ledger_cols, epoch, miner_id, amount_i64, reason):
     return True
 
 
+def _welcome_bonus_source_balance_i64(conn: sqlite3.Connection) -> Optional[int]:
+    """Current balance of the fund that pays welcome bonuses, or None if absent."""
+    row = conn.execute(
+        "SELECT amount_i64 FROM balances WHERE miner_id = ?", (WELCOME_BONUS_SOURCE,)
+    ).fetchone()
+    if row is None or row[0] is None:
+        return None
+    return int(row[0])
+
+
 def _check_welcome_bonus(miner: str):
-    """Award welcome bonus on first-ever attestation. Funded from founder_community."""
+    """Award welcome bonus on first-ever attestation. Funded from founder_community.
+
+    Callers must only invoke this for attestations that PASSED the hardware
+    fingerprint (see the /attest/submit call site). The payer itself refuses to
+    drive WELCOME_BONUS_SOURCE negative and takes the write lock up front so two
+    concurrent first attests cannot both pass the already-paid check.
+    """
     try:
         with closing(sqlite3.connect(DB_PATH)) as conn:
+            conn.execute("BEGIN IMMEDIATE")
             # Check if this miner has ever attested before
             history_count = conn.execute(
                 "SELECT COUNT(*) FROM miner_attest_history WHERE miner = ?", (miner,)
             ).fetchone()[0]
-            
+
             if history_count <= 1:  # First attestation (just recorded)
                 ledger_cols = _table_columns(conn, "ledger")
                 balance_cols = _table_columns(conn, "balances")
                 # Check if welcome bonus already paid
                 already_paid = _welcome_bonus_already_paid(conn, miner, ledger_cols)
-                
+
                 if not already_paid:
                     bonus_i64 = int(WELCOME_BONUS_RTC * 1_000_000)
+                    source_balance = _welcome_bonus_source_balance_i64(conn)
+                    if source_balance is None or source_balance < bonus_i64:
+                        print(f"[WELCOME] SKIPPED for {miner}: {WELCOME_BONUS_SOURCE} "
+                              f"balance {source_balance} < {bonus_i64} uRTC")
+                        conn.rollback()
+                        return
                     _write_welcome_bonus(conn, miner, bonus_i64, ledger_cols, balance_cols)
                     conn.commit()
                     print(f"[WELCOME] {miner} received {WELCOME_BONUS_RTC} RTC welcome bonus!")
+                    return
+            conn.rollback()
     except Exception as e:
         print(f"[WELCOME] Error for {miner}: {e}")
 
@@ -4019,7 +4047,7 @@ def record_attestation_success(miner: str, device: dict, fingerprint_passed: boo
                 device_arch = excluded.device_arch,
                 source_ip = excluded.source_ip,
                 fingerprint_passed = MAX(miner_attest_recent.fingerprint_passed, excluded.fingerprint_passed),
-                signing_pubkey = excluded.signing_pubkey,
+                signing_pubkey = COALESCE(excluded.signing_pubkey, miner_attest_recent.signing_pubkey),
                 fingerprint_checks_json = excluded.fingerprint_checks_json
         """, (miner, now, verified_device["device_family"], verified_device["device_arch"], entropy_score, new_fp, source_ip, signing_pubkey, fingerprint_checks_json))
         _ = append_fingerprint_snapshot(conn, miner, fingerprint if isinstance(fingerprint, dict) else {}, now)
@@ -6425,8 +6453,11 @@ def _submit_attestation_impl():
     if macs:
         record_macs(miner, macs)
 
-    # Check for welcome bonus (first attestation)
-    _check_welcome_bonus(miner)
+    # Check for welcome bonus (first attestation). Only a miner that PASSED the
+    # hardware fingerprint earns it: a VM/emulator/missing-fingerprint attest is
+    # still recorded (zero reward weight) but must not drain founder_community.
+    if fingerprint_passed:
+        _check_welcome_bonus(miner)
 
     # AUTO-ENROLL: Automatically enroll miner in current epoch on successful attestation
     # This eliminates the need for miners to make a separate POST /epoch/enroll call

--- a/node/tests/test_airdrop_db_is_file_backed.py
+++ b/node/tests/test_airdrop_db_is_file_backed.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression (audit A5): the node must construct AirdropV2 on its real DB file.
+
+AirdropV2(db_path=":memory:") is the constructor default. The node used to call
+AirdropV2() with no arguments, so every gunicorn worker held its own private
+in-memory claims table that vanished on restart - the one-claim-per-GitHub/
+wallet rule (RIP-305) was never actually persisted or shared.
+"""
+
+import importlib.util
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+NODE_DIR = PROJECT_ROOT / "node"
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+if str(NODE_DIR) not in sys.path:
+    sys.path.insert(0, str(NODE_DIR))
+
+from airdrop_v2 import AirdropV2  # noqa: E402
+
+
+def _load_node(db_path: Path):
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    from tests import mock_crypto
+
+    sys.modules["rustchain_crypto"] = mock_crypto
+    os.environ["DB_PATH"] = str(db_path)
+    os.environ["RUSTCHAIN_DB_PATH"] = str(db_path)
+    os.environ.setdefault("RC_ADMIN_KEY", "0" * 32)
+    spec = importlib.util.spec_from_file_location("integrated_node_airdrop_db_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_node_constructs_airdrop_on_its_db_file(tmp_path):
+    db_path = tmp_path / "node_airdrop.sqlite3"
+    node = _load_node(db_path)
+    if not getattr(node, "HAVE_AIRDROP", False):
+        pytest.skip("airdrop_v2 not importable in this environment")
+
+    airdrop = node.airdrop_instance
+    assert airdrop.db_path == node.DB_PATH == str(db_path)
+    assert airdrop.db_path != ":memory:"
+
+    # The schema landed in the shared file, not in a private in-memory DB.
+    with sqlite3.connect(db_path) as conn:
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert {"airdrop_claims", "airdrop_allocation"} <= tables
+
+
+def test_claims_persist_across_instances_on_same_path(tmp_path):
+    """Two workers (two AirdropV2 instances) on the same file see the same claim."""
+    db_path = str(tmp_path / "shared_airdrop.sqlite3")
+    worker_a = AirdropV2(db_path=db_path)
+    conn = worker_a._get_conn()
+    conn.execute(
+        "INSERT INTO airdrop_claims (claim_id, github_username, wallet_address, chain, tier, amount_uwrtc, timestamp, status)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, 'completed')",
+        ("claim-a", "octocat", "octocat-wallet", "solana", "bronze", 1_000_000, int(time.time())),
+    )
+    conn.commit()
+    worker_a._close_conn(conn)
+
+    worker_b = AirdropV2(db_path=db_path)  # simulates a second gunicorn worker / restart
+    assert worker_b._has_claimed("octocat", "octocat-wallet", "solana") is True
+    assert worker_b._has_claimed("someone-else", "other-wallet", "solana") is False
+
+    # Control: the in-memory default really is per-instance (what the node used to get).
+    mem_a = AirdropV2()
+    assert mem_a.db_path == ":memory:"
+    assert mem_a._has_claimed("octocat", "octocat-wallet", "solana") is False

--- a/node/tests/test_attest_pin_survives_unsigned_attest.py
+++ b/node/tests/test_attest_pin_survives_unsigned_attest.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression (audit A1): an unsigned / legacy re-attest must NOT erase a pinned
+signing key.
+
+record_attestation_success() upserts miner_attest_recent with
+`signing_pubkey = excluded.signing_pubkey`. The /attest/submit handler passes
+pin_pubkey=None whenever it decides not to ADD a key (already pinned, frozen,
+grandfathered, or the submission was unsigned) and its comment says COALESCE
+keeps the existing pin - but the SQL did not COALESCE, so every unsigned
+attest for a miner NULLed the #8016 pin ledger. In the default log_only
+enforce mode unsigned submissions are accepted, so anyone could wipe a
+victim's pin and then sign as that miner to get pinned themselves.
+
+Fix: signing_pubkey = COALESCE(excluded.signing_pubkey, miner_attest_recent.signing_pubkey)
+"""
+
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import nacl.signing
+    HAVE_NACL = True
+except Exception:  # pragma: no cover - environment dependent
+    HAVE_NACL = False
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+EXTRA_SCHEMA = [
+    "CREATE TABLE IF NOT EXISTS blocked_wallets (wallet TEXT PRIMARY KEY, reason TEXT)",
+    "CREATE TABLE IF NOT EXISTS ip_rate_limit (client_ip TEXT NOT NULL, miner_id TEXT NOT NULL, ts INTEGER NOT NULL, PRIMARY KEY (client_ip, miner_id))",
+    "CREATE TABLE IF NOT EXISTS miner_attest_recent (miner TEXT PRIMARY KEY, ts_ok INTEGER NOT NULL, device_family TEXT, device_arch TEXT, entropy_score REAL DEFAULT 0, fingerprint_passed INTEGER DEFAULT 0, source_ip TEXT, warthog_bonus REAL DEFAULT 1.0)",
+    "CREATE TABLE IF NOT EXISTS hardware_bindings (hardware_id TEXT PRIMARY KEY, bound_miner TEXT NOT NULL, device_arch TEXT, device_model TEXT, bound_at INTEGER NOT NULL, attestation_count INTEGER DEFAULT 0)",
+    "CREATE TABLE IF NOT EXISTS miner_header_keys (miner_id TEXT PRIMARY KEY, pubkey_hex TEXT NOT NULL)",
+    "CREATE TABLE IF NOT EXISTS miner_macs (miner TEXT NOT NULL, mac_hash TEXT NOT NULL, first_ts INTEGER NOT NULL, last_ts INTEGER NOT NULL, count INTEGER NOT NULL DEFAULT 1, PRIMARY KEY (miner, mac_hash))",
+]
+
+
+def _sign_message(miner_id, wallet, nonce, commitment):
+    signing_key = nacl.signing.SigningKey.generate()
+    pubkey_hex = signing_key.verify_key.encode().hex()
+    message = "{}|{}|{}|{}".format(miner_id, wallet, nonce, commitment)
+    return signing_key.sign(message.encode("utf-8")).signature.hex(), pubkey_hex
+
+
+class TestPinSurvivesUnsignedAttest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_env = {k: os.environ.get(k) for k in ("RC_ADMIN_KEY", "RUSTCHAIN_DB_PATH", "DB_PATH", "RTC_ATTEST_ENFORCE_MODE")}
+        os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
+        # The vulnerable path is the default rollout phase: unsigned attests accepted.
+        os.environ["RTC_ATTEST_ENFORCE_MODE"] = "log_only"
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+    @classmethod
+    def tearDownClass(cls):
+        for k, v in cls._prev_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        cls._tmp.cleanup()
+
+    def _load_module(self, module_name, db_name):
+        db_path = str(Path(self._tmp.name) / db_name)
+        os.environ["RUSTCHAIN_DB_PATH"] = db_path
+        os.environ["DB_PATH"] = db_path
+        spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        mod.DB_PATH = db_path
+        # Same identical-fingerprint replay heuristic every attest harness disables;
+        # it is orthogonal to the pin ledger under test.
+        mod.HAVE_REPLAY_DEFENSE = False
+        mod.init_db()
+        with sqlite3.connect(db_path) as conn:
+            for stmt in EXTRA_SCHEMA:
+                conn.execute(stmt)
+            conn.commit()
+        return mod, db_path
+
+    def _get_challenge(self, mod):
+        with mod.app.test_request_context("/attest/challenge", method="POST", json={}):
+            return mod.get_challenge().get_json()["nonce"]
+
+    def _submit(self, mod, payload):
+        with mod.app.test_request_context("/attest/submit", method="POST", json=payload):
+            resp = mod._submit_attestation_impl()
+        if isinstance(resp, tuple):
+            body, status = resp
+            return status, body.get_json()
+        return resp.status_code, resp.get_json()
+
+    @staticmethod
+    def _payload(miner, nonce, commitment="deadbeef", sig_hex=None, pubkey_hex=None, miner_id=None):
+        payload = {
+            "miner": miner,
+            "report": {"nonce": nonce, "commitment": commitment},
+            "device": {"family": "x86_64", "arch": "default", "model": "test-box", "cores": 4},
+            "signals": {"hostname": "test-host", "macs": []},
+            "fingerprint": {
+                "checks": {
+                    "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
+                    "clock_drift": {"passed": True, "data": {"cv": 0.05, "samples": 64}},
+                },
+                "all_passed": True,
+            },
+        }
+        if sig_hex is not None:
+            payload["signature"] = sig_hex
+        if pubkey_hex is not None:
+            payload["public_key"] = pubkey_hex
+        if miner_id is not None:
+            payload["miner_id"] = miner_id
+        return payload
+
+    @staticmethod
+    def _pinned_key(db_path, miner):
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT signing_pubkey FROM miner_attest_recent WHERE miner = ?", (miner,)
+            ).fetchone()
+        return row[0] if row else None
+
+    @unittest.skipUnless(HAVE_NACL, "pynacl not installed")
+    def test_unsigned_attest_keeps_pinned_key(self):
+        """Signed attest pins a key; a later unsigned attest must leave it intact."""
+        mod, db_path = self._load_module("rustchain_attest_pin_survives", "pin_survives.db")
+        miner = "pin-survivor-miner"  # brand-new symbolic identity -> TOFU pin allowed
+        miner_id = "pin-survivor-miner"
+
+        nonce = self._get_challenge(mod)
+        sig_hex, pubkey_hex = _sign_message(miner_id, miner, nonce, "deadbeef")
+        status, body = self._submit(mod, self._payload(miner, nonce, "deadbeef", sig_hex, pubkey_hex, miner_id))
+        self.assertEqual(status, 200, body)
+        self.assertEqual(self._pinned_key(db_path, miner), pubkey_hex)
+
+        # Attacker (or a legacy client) re-attests the same identity WITHOUT a signature.
+        nonce2 = self._get_challenge(mod)
+        status, body = self._submit(mod, self._payload(miner, nonce2, "cafebabe", miner_id=miner_id))
+        self.assertEqual(status, 200, body)
+
+        self.assertEqual(
+            self._pinned_key(db_path, miner), pubkey_hex,
+            "unsigned re-attest NULLed the pinned signing key (audit A1)",
+        )
+
+    def test_record_attestation_success_upsert_coalesces_pin(self):
+        """Direct UPSERT check: signing_pubkey=None on conflict keeps the stored pin."""
+        mod, db_path = self._load_module("rustchain_attest_pin_upsert", "pin_upsert.db")
+        miner = "upsert-miner"
+        device = {"family": "x86_64", "arch": "default", "model": "test-box", "cores": 4}
+        mod.record_attestation_success(miner, device, True, "127.0.0.1", fingerprint={}, signing_pubkey="ab" * 32)
+        self.assertEqual(self._pinned_key(db_path, miner), "ab" * 32)
+
+        mod.record_attestation_success(miner, device, True, "127.0.0.1", fingerprint={}, signing_pubkey=None)
+        self.assertEqual(self._pinned_key(db_path, miner), "ab" * 32)
+
+        # A first-time pin on a row that has no key still lands.
+        mod.record_attestation_success("fresh-miner", device, True, "127.0.0.1", fingerprint={}, signing_pubkey=None)
+        self.assertIsNone(self._pinned_key(db_path, "fresh-miner"))
+        mod.record_attestation_success("fresh-miner", device, True, "127.0.0.1", fingerprint={}, signing_pubkey="cd" * 32)
+        self.assertEqual(self._pinned_key(db_path, "fresh-miner"), "cd" * 32)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/node/tests/test_p2p_init_peer_list.py
+++ b/node/tests/test_p2p_init_peer_list.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MIT
+"""
+Peer-list hygiene for rustchain_p2p_init.PEER_NODES.
+
+The sync loop POSTs to every entry here every 30s with the fleet P2P key
+attached, so dead hosts are both wasted traffic and a secret-leak surface
+(audit A3). node3 (Ryan's Proxmox, offline ~3 months) and node4 (POWER8,
+down) were removed on 2026-09-03; node2 moved to https:// because
+50.28.86.153 answers /health over TLS and the plain :8099 port is not
+reachable from outside.
+"""
+
+import os
+import sys
+from urllib.parse import urlparse
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from rustchain_p2p_init import PEER_NODES  # noqa: E402
+
+DEAD_HOSTS = {
+    "76.8.228.245",      # node3 public (Ryan)
+    "100.88.109.32",     # node3 Tailscale (Ryan)
+    "38.76.217.189",     # old node4 (createkr, now an unrelated SPA)
+    "100.94.28.32",      # node4 POWER8 Tailscale
+    "sophiapower8.tailbac22e.ts.net",  # node4 POWER8 Funnel
+}
+
+
+def test_only_live_fleet_nodes_are_hardcoded():
+    assert set(PEER_NODES) == {"node1", "node1_ts", "node2"}
+    assert not any(k.startswith(("node3", "node4")) for k in PEER_NODES)
+
+
+def test_no_dead_hosts_in_peer_list():
+    hosts = {urlparse(url).hostname for url in PEER_NODES.values()}
+    assert not (hosts & DEAD_HOSTS), hosts & DEAD_HOSTS
+
+
+def test_node1_entries_unchanged_and_node2_uses_tls():
+    assert PEER_NODES["node1"] == "https://rustchain.org"
+    assert PEER_NODES["node1_ts"] == "http://100.125.31.50:8099"
+    node2 = urlparse(PEER_NODES["node2"])
+    assert node2.scheme == "https"
+    assert node2.hostname == "50.28.86.153"
+
+
+def test_every_peer_url_passes_gossip_scheme_validation():
+    for url in PEER_NODES.values():
+        parsed = urlparse(url)
+        assert parsed.scheme in {"http", "https"} and parsed.netloc, url

--- a/node/tests/test_welcome_bonus_gated_on_fingerprint.py
+++ b/node/tests/test_welcome_bonus_gated_on_fingerprint.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression (audit A2): the WELCOME_BONUS_RTC welcome bonus (paid out of
+founder_community) must only go to miners whose hardware fingerprint PASSED,
+and the payer must never drive founder_community negative.
+
+Before the fix /attest/submit called _check_welcome_bonus(miner) unconditionally
+after fingerprint_passed had already been set to False for VM / emulator /
+missing-evidence attests, so every fresh miner id (15 per IP per hour) drained
+0.5 RTC from the community fund with zero proof of hardware.
+"""
+
+import importlib.util
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+NODE_DIR = PROJECT_ROOT / "node"
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+EPOCH = 85
+SOURCE = "founder_community"
+
+
+def _load_integrated_node(db_path: Path, tag: str):
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    if str(NODE_DIR) not in sys.path:
+        sys.path.insert(0, str(NODE_DIR))
+
+    from tests import mock_crypto
+
+    sys.modules["rustchain_crypto"] = mock_crypto
+    os.environ["DB_PATH"] = str(db_path)
+    os.environ["RUSTCHAIN_DB_PATH"] = str(db_path)
+    os.environ.setdefault("RC_ADMIN_KEY", "0" * 32)
+
+    spec = importlib.util.spec_from_file_location(f"integrated_node_welcome_gate_{tag}", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    module.DB_PATH = str(db_path)
+    module.app.config["TESTING"] = True
+    module.UTXO_DUAL_WRITE = False
+    module.HW_BINDING_V2 = False
+    module.HW_PROOF_AVAILABLE = False
+    module.HAVE_REPLAY_DEFENSE = False
+    module.HAVE_FLEET_IMMUNE = False
+    module.HAVE_WARTHOG = False
+    module.check_ip_rate_limit = lambda client_ip, miner_id: (True, "ok")
+    module._check_hardware_binding = lambda *args, **kwargs: (True, "ok", "")
+    module._check_oui_gate = lambda macs: (True, {"ok": True})
+    module.wallet_review_gate_response = lambda miner: None
+    module.record_macs = lambda *args, **kwargs: None
+    module.current_slot = lambda: 12345
+    module.slot_to_epoch = lambda slot: EPOCH
+    # NOTE: _check_welcome_bonus is deliberately NOT stubbed - it is the code under test.
+    return module
+
+
+def _prepare_db(node, db_path: Path, nonces, source_balance_i64: int):
+    now = int(time.time())
+    with sqlite3.connect(db_path) as conn:
+        node.attest_ensure_tables(conn)
+        for nonce in nonces:
+            conn.execute("INSERT INTO nonces (nonce, expires_at) VALUES (?, ?)", (nonce, now + 3600))
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS tickets (ticket_id TEXT PRIMARY KEY, expires_at INTEGER, commitment TEXT);
+            CREATE TABLE IF NOT EXISTS epoch_state (epoch INTEGER PRIMARY KEY, settled INTEGER DEFAULT 0, settled_ts INTEGER);
+            CREATE TABLE IF NOT EXISTS epoch_enroll (
+                epoch INTEGER NOT NULL, miner_pk TEXT NOT NULL, weight INTEGER NOT NULL,
+                PRIMARY KEY(epoch, miner_pk)
+            );
+            CREATE TABLE IF NOT EXISTS balances (
+                miner_id TEXT PRIMARY KEY, miner_pk TEXT,
+                amount_i64 INTEGER DEFAULT 0, balance_rtc REAL DEFAULT 0
+            );
+            CREATE TABLE IF NOT EXISTS ledger (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts INTEGER NOT NULL, epoch INTEGER, miner_id TEXT NOT NULL,
+                delta_i64 INTEGER NOT NULL, reason TEXT
+            );
+            CREATE TABLE IF NOT EXISTS miner_attest_recent (
+                miner TEXT PRIMARY KEY, ts_ok INTEGER, device_family TEXT, device_arch TEXT,
+                entropy_score REAL DEFAULT 0.0, fingerprint_passed INTEGER DEFAULT 0,
+                source_ip TEXT, signing_pubkey TEXT, fingerprint_checks_json TEXT
+            );
+            CREATE TABLE IF NOT EXISTS miner_attest_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, miner TEXT NOT NULL, ts_ok INTEGER NOT NULL,
+                device_family TEXT, device_arch TEXT, entropy_score REAL DEFAULT 0.0,
+                fingerprint_passed INTEGER DEFAULT 0, fingerprint_checks_json TEXT
+            );
+            """
+        )
+        conn.execute("INSERT OR IGNORE INTO epoch_state(epoch, settled) VALUES (?, 0)", (EPOCH,))
+        conn.execute(
+            "INSERT INTO balances(miner_id, miner_pk, amount_i64, balance_rtc) VALUES (?, ?, ?, ?)",
+            (SOURCE, SOURCE, source_balance_i64, source_balance_i64 / 1_000_000),
+        )
+        conn.commit()
+
+
+def _payload(miner, nonce, fingerprint_ok: bool):
+    if fingerprint_ok:
+        checks = {
+            "clock_drift": {"passed": True, "data": {"cv": 0.05, "samples": 64}},
+            "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
+        }
+    else:
+        # Client honestly reports a hypervisor: server marks fingerprint_passed=False
+        # but still records the attestation (zero weight).
+        checks = {
+            "clock_drift": {"passed": True, "data": {"cv": 0.05, "samples": 64}},
+            "anti_emulation": {"passed": False, "data": {"vm_indicators": ["cpuinfo:hypervisor"]}},
+        }
+    return {
+        "miner": miner,
+        "miner_id": miner,
+        "nonce": nonce,
+        "device": {"model": "Generic CPU", "arch": "x86_64", "family": "x86_64", "cores": 4},
+        "signals": {"hostname": "baremetal-host"},
+        "report": {"nonce": nonce, "commitment": "commitment"},
+        "fingerprint": {"checks": checks},
+    }
+
+
+def _state(db_path, miner):
+    with sqlite3.connect(db_path) as conn:
+        source = conn.execute("SELECT amount_i64 FROM balances WHERE miner_id=?", (SOURCE,)).fetchone()[0]
+        row = conn.execute("SELECT amount_i64 FROM balances WHERE miner_id=?", (miner,)).fetchone()
+        miner_bal = row[0] if row else 0
+        bonus_rows = conn.execute(
+            "SELECT COUNT(*) FROM ledger WHERE miner_id=? AND delta_i64 > 0 AND reason LIKE 'welcome_bonus:%'",
+            (miner,),
+        ).fetchone()[0]
+        fp = conn.execute("SELECT fingerprint_passed FROM miner_attest_recent WHERE miner=?", (miner,)).fetchone()
+    return source, miner_bal, bonus_rows, (fp[0] if fp else None)
+
+
+def test_failed_fingerprint_miner_gets_no_welcome_bonus(tmp_path):
+    db_path = tmp_path / "welcome_gate_fail.sqlite3"
+    node = _load_integrated_node(db_path, "fail")
+    bonus_i64 = int(node.WELCOME_BONUS_RTC * 1_000_000)
+    start = 10 * bonus_i64
+    miner = "vm-farm-miner"
+    _prepare_db(node, db_path, ["nonce-vm-1"], start)
+
+    with node.app.test_client() as client:
+        resp = client.post("/attest/submit", json=_payload(miner, "nonce-vm-1", fingerprint_ok=False))
+    assert resp.status_code == 200, resp.get_json()
+
+    source, miner_bal, bonus_rows, fp = _state(db_path, miner)
+    assert fp == 0, "precondition: attestation recorded with fingerprint_passed=0"
+    assert bonus_rows == 0, "failed-fingerprint miner was paid a welcome bonus (audit A2)"
+    assert miner_bal == 0
+    assert source == start, "founder_community was debited for a failed-fingerprint miner"
+
+
+def test_passing_miner_gets_exactly_one_welcome_bonus(tmp_path):
+    db_path = tmp_path / "welcome_gate_pass.sqlite3"
+    node = _load_integrated_node(db_path, "pass")
+    bonus_i64 = int(node.WELCOME_BONUS_RTC * 1_000_000)
+    start = 10 * bonus_i64
+    miner = "honest-baremetal-miner"
+    _prepare_db(node, db_path, ["nonce-ok-1", "nonce-ok-2"], start)
+
+    with node.app.test_client() as client:
+        resp = client.post("/attest/submit", json=_payload(miner, "nonce-ok-1", fingerprint_ok=True))
+        assert resp.status_code == 200, resp.get_json()
+        source, miner_bal, bonus_rows, fp = _state(db_path, miner)
+        assert fp == 1
+        assert bonus_rows == 1
+        assert miner_bal == bonus_i64
+        assert source == start - bonus_i64
+
+        # Second attestation: no second bonus.
+        resp = client.post("/attest/submit", json=_payload(miner, "nonce-ok-2", fingerprint_ok=True))
+        assert resp.status_code == 200, resp.get_json()
+    source, miner_bal, bonus_rows, _ = _state(db_path, miner)
+    assert bonus_rows == 1
+    assert miner_bal == bonus_i64
+    assert source == start - bonus_i64
+
+
+def test_welcome_bonus_never_overdraws_source_fund(tmp_path):
+    db_path = tmp_path / "welcome_gate_broke.sqlite3"
+    node = _load_integrated_node(db_path, "broke")
+    bonus_i64 = int(node.WELCOME_BONUS_RTC * 1_000_000)
+    start = bonus_i64 // 2  # fund cannot cover one bonus
+    miner = "late-honest-miner"
+    _prepare_db(node, db_path, ["nonce-late-1"], start)
+
+    with node.app.test_client() as client:
+        resp = client.post("/attest/submit", json=_payload(miner, "nonce-late-1", fingerprint_ok=True))
+    assert resp.status_code == 200, resp.get_json()
+
+    source, miner_bal, bonus_rows, fp = _state(db_path, miner)
+    assert fp == 1
+    assert bonus_rows == 0
+    assert miner_bal == 0
+    assert source == start, "founder_community went below its balance (would have gone negative)"
+    assert source >= 0


### PR DESCRIPTION
Implements three HIGH findings from the 2026-09-02 node security review (A1, A2, A5) plus a peer-list cleanup. Each fix is minimal and carries a regression test under `node/tests/`.

### A1 - unsigned re-attest wiped the pinned signing key
`record_attestation_success()` upserted `miner_attest_recent` with `signing_pubkey = excluded.signing_pubkey`, while `/attest/submit` passes `pin_pubkey=None` whenever it decides not to *add* a key (already pinned, frozen, grandfathered, or the submission was unsigned) and its comment claimed COALESCE semantics. In the default `log_only` enforce mode unsigned attests are accepted, so an attacker could submit one unsigned attest for a victim id to NULL its pin, then sign as that id and get pinned themselves. Fix (`node/rustchain_v2_integrated_v2.2.1_rip200.py:4050`): `signing_pubkey = COALESCE(excluded.signing_pubkey, miner_attest_recent.signing_pubkey)`. Test `test_attest_pin_survives_unsigned_attest.py` pins a key via a real Ed25519-signed attest, submits an unsigned attest for the same miner, and asserts the pin survives (plus a direct UPSERT check).

### A2 - welcome bonus paid regardless of fingerprint, no floor
`_check_welcome_bonus(miner)` was called unconditionally after `fingerprint_passed` may already be False, so every fresh miner id (VM, emulator, empty evidence) drained `WELCOME_BONUS_RTC` (0.5 RTC) from `founder_community` - roughly 7.5 RTC/hour/IP with the 15-ids-per-IP limit - and the debit had no floor or write lock. Fix: the call site (`:6459`) only pays when `fingerprint_passed` is truthy; the payer (`:3882-3927`) takes `BEGIN IMMEDIATE` and skips (with a log line) if the source fund cannot cover the bonus, so `founder_community` can never go negative. Passing miners still get exactly one bonus. Test `test_welcome_bonus_gated_on_fingerprint.py` drives `/attest/submit` end to end: failed-fingerprint miner gets nothing, passing miner gets exactly one bonus across two attests, underfunded source is not overdrawn.

### A5 - airdrop claims lived in a per-worker in-memory DB
`AirdropV2()` was constructed with no `db_path`, so `airdrop_v2.py` fell back to `:memory:` - one private claims table per gunicorn worker, wiped on every restart, so the one-claim-per-GitHub/wallet rule never persisted. Fix (`:1546`): `AirdropV2(db_path=DB_PATH)`. Test `test_airdrop_db_is_file_backed.py` loads the node against a temp DB and asserts `airdrop_instance.db_path == DB_PATH` with the schema present in the file, and that a claim written by one instance is visible to a second instance on the same path (while the `:memory:` default is shown to be per-instance).

### Peer cleanup - stop posting the P2P secret to dead hosts
`node/rustchain_p2p_init.py` `PEER_NODES` hard-coded `node3`/`node3_public` (Ryan's Proxmox, `100.88.109.32` / `76.8.228.245`, offline ~3 months; Tailscale shows last seen 105d) and `node4`/`node4_public`. Note: on current main those `node4` entries point at the POWER8 (`100.94.28.32` / `sophiapower8...ts.net`), not the old `38.76.217.189` host the audit text mentions - both POWER8 URLs are unreachable, so all four entries are removed. `node1`/`node1_ts` are untouched. `node2` moves from `http://50.28.86.153:8099` to `https://50.28.86.153` - verified 2026-09-03: `curl -sk https://50.28.86.153/health` returns the node's health JSON, and plain `http://50.28.86.153:8099` does not answer from outside. `_valid_peer_url` accepts https and requests use `TLS_VERIFY`, so no code change was needed for the scheme. Test `test_p2p_init_peer_list.py` pins the live set and rejects the dead hosts.

### Verification
- `python3 -m py_compile` on both touched modules and all four test files: OK; `ruff check --select E9,F63,F7,F82` on the new tests: clean.
- New tests: **11 passed** (`pytest node/tests/test_attest_pin_survives_unsigned_attest.py node/tests/test_welcome_bonus_gated_on_fingerprint.py node/tests/test_airdrop_db_is_file_backed.py node/tests/test_p2p_init_peer_list.py`).
- CI suite as run by `.github/workflows/ci.yml` (`pytest tests/ --ignore=tests/test_epoch_settlement_formal.py --ignore=tests/test_rip201_bucket_spoof.py`, same env vars): **3903 passed, 46 skipped, 2 xfailed, 0 failed**.
- Full `pytest node/tests` on this branch: **1695 passed, 95 failed**. Same command on unpatched `main` (87e2b86f): **1682 passed, 97 failed**. The failure sets differ only by two tests that pass on this branch and fail on main (`test_attest_challenge_body_validation_v5::test_live_null_body_status`, a live-network probe, and `test_sophia_elya_service::test_finalize_epoch_excludes_poisoned_negative_weight_rows`) - i.e. no failure is introduced by this PR. That set includes the 3 `test_p2p_hardening_phase2.py` failures documented in the audit (A15) and 6 further P2P failures that only appear when `node/tests` runs as a batch (order-dependent; they pass file-by-file on main too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKwZZP79b6Acc44cwVZkj4
