### PR TITLE
fix(rust-tools): make the rustchain-sdk example crate a valid Cargo package

### DIFF
--- a/rust-tools/examples/rustchain-sdk/Cargo.toml
+++ b/rust-tools/examples/rustchain-sdk/Cargo.toml
@@ -24,6 +24,9 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 base64 = "0.21"
 hex = "0.4"
+# Optional wallet dependencies (enabled by the `wallet` feature)
+bip39 = { version = "2.0", optional = true }
+ed25519-dalek = { version = "2.0", optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4"
@@ -31,6 +34,4 @@ wiremock = "0.5"
 
 [features]
 default = []
-wallet = ["bip39", "ed25519-dalek"]
-bip39 = { version = "2.0", optional = true }
-ed25519-dalek = { version = "2.0", optional = true }
+wallet = ["dep:bip39", "dep:ed25519-dalek"]

--- a/rust-tools/examples/rustchain-sdk/src/lib.rs
+++ b/rust-tools/examples/rustchain-sdk/src/lib.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+//! Minimal RustChain SDK entry point.
+//!
+//! The example SDK crate is intentionally small until the full client API is
+//! implemented, but it must still expose a valid crate root for Cargo.
+//! (Approach from Scottcjn/Rustchain#8097 by @qiann0512-gif.)
+
+/// SDK crate version from Cargo metadata.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn version_is_set() {
+        assert!(!super::VERSION.is_empty());
+    }
+}


### PR DESCRIPTION
Closes the Cargo-config cluster (#8191, #8182, #8098, #8097, #8096). On current main only ONE manifest still fails: `rust-tools/examples/rustchain-sdk/Cargo.toml` (optional deps declared under `[features]`, and no `src/` at all). This PR fixes exactly that and nothing else.

Verified locally: `cargo metadata --no-deps` passes for all 9 manifests.

Approach credited to @qiann0512-gif (#8097), who had the correct `dep:` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RDgENXHE8sjiekfdvw3jn