### PR TITLE
docs: kill remaining Rust-binary/cargo/config.yaml fiction (dev tutorial, nl-NL, upgrade guide)

### DIFF
--- a/docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md
+++ b/docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md
@@ -242,16 +242,13 @@ pip install requests
 
 #### Step 4: Download Miner
 
+The miner is a **Python script** — there is no compiled binary to download,
+and it is the same file for every OS/architecture.
+
 ```bash
-# Detect your architecture
-ARCH=$(uname -m)
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-
-# Download appropriate binary
-curl -sSL "https://github.com/Scottcjn/Rustchain/releases/latest/download/rustchain_miner_${OS}_${ARCH}" \
+# Download the miner script (pure Python — works on any architecture)
+curl -sSL "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/rustchain_linux_miner.py" \
   -o rustchain_miner.py
-
-chmod +x rustchain_miner.py
 ```
 
 #### Step 5: Configure Wallet
@@ -905,7 +902,9 @@ tail -f ~/.rustchain/miner.log
 
 ### Running a Full Node
 
-For developers who want to run a full RustChain node:
+For developers who want to run a full RustChain node. The node is a
+Python/Flask app served with `gunicorn` (see the
+[Node Operator Guide](NODE_OPERATOR_GUIDE.md) for the complete walkthrough):
 
 ```bash
 # Clone the repository
@@ -913,14 +912,17 @@ git clone https://github.com/Scottcjn/Rustchain.git
 cd Rustchain
 
 # Install node dependencies
-pip install -r requirements.txt
+pip install -r requirements-node.txt
 
-# Initialize node data directory
-mkdir -p ~/.rustchain-node/data
-cp config/node.example.json ~/.rustchain-node/config.json
+# Configure via environment variables (a sync node needs no fleet secrets)
+cd node
+export RC_NODE_ROLE=sync
+export RC_NODE_ID=sync-1
+export RC_ADMIN_KEY=$(openssl rand -hex 32)
+export RUSTCHAIN_DB_PATH=$PWD/rustchain_v2.db
 
 # Start the node
-python node/integrated_node.py --config ~/.rustchain-node/config.json
+gunicorn -w 4 -b 0.0.0.0:8099 wsgi:app --timeout 120
 ```
 
 See [`DOCKER_DEPLOYMENT.md`](../DOCKER_DEPLOYMENT.md) for containerized deployment.

--- a/docs/UPGRADE_MIGRATION_GUIDE.md
+++ b/docs/UPGRADE_MIGRATION_GUIDE.md
@@ -65,7 +65,7 @@ clawrtc --version
 clawrtc wallet show > wallet_info.txt
 
 # 记录矿工配置
-cat ~/.rustchain/config.yaml > config.backup
+cat ~/.rustchain/config.json > config.backup
 ```
 
 ### 3. 检查系统要求
@@ -124,7 +124,7 @@ python3 -m venv venv
 source venv/bin/activate
 
 # 3. 安装依赖
-pip install -r requirements.txt
+pip install -r requirements-node.txt
 
 # 4. 运行安装脚本
 bash install-miner.sh --wallet YOUR_WALLET
@@ -321,7 +321,7 @@ pip uninstall clawrtc
 python3 -m pip install clawrtc==1.0.0
 
 # 5. 恢复配置
-cp config.backup ~/.rustchain/config.yaml
+cp config.backup ~/.rustchain/config.json
 
 # 6. 重启矿工
 systemctl --user start rustchain-miner  # Linux

--- a/docs/nl-NL/README.md
+++ b/docs/nl-NL/README.md
@@ -50,24 +50,27 @@ Wanneer een nieuw knooppunt zich bij het netwerk aansluit, genereert het:
 ## Installatie
 
 ### Linux-miner
+
+> **Let op:** RustChain draait op **Python**, niet op Rust — er is geen
+> `cargo build` en geen gecompileerde binary. (De naam verwijst naar de
+> Rust-programmeertaal, maar de node en miner zijn in Python geschreven.)
+
 ```bash
-# Kloon de repository
+# Officieel installatiescript: maakt een Python-venv aan en start de miner
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --wallet jesusmp
+```
+
+Handmatig (Python):
+```bash
 git clone https://github.com/Scottcjn/Rustchain.git
 cd Rustchain
-
-# Bouw de miner
-cargo build --release
-
-# Start de miner
-./target/release/rustchain-miner --wallet jesusmp
+python3 -m venv venv && source venv/bin/activate
+pip install -r requirements-node.txt
+python3 miners/linux/rustchain_linux_miner.py
 ```
 
-### Docker
-```bash
-docker run -d --name rustchain-miner \
-  -e WALLET=jesusmp \
-  rustchain/miner:latest
-```
+Voor het draaien van een volledige node, zie de
+[Node Operator Guide](../NODE_OPERATOR_GUIDE.md).
 
 ## Mining
 


### PR DESCRIPTION
Follow-up to #8341. Three more docs still told operators/devs to `cargo build`, download a per-arch release binary, or use a `config.yaml` — none of which exist (RustChain's node + miner are Python). This is the same class of error that blocked a new contractor.

**Fixes (verified against the repo's real paths):**
- `docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md` — nonexistent `releases/latest/download/rustchain_miner_*` → real `miners/linux/rustchain_linux_miner.py`; full-node appendix → real `gunicorn wsgi:app` on 8099 (was `integrated_node.py`/`config.json`, `requirements.txt`)
- `docs/nl-NL/README.md` — `cargo build`/`target/release`/unverified docker image → `install-miner.sh` + venv/`requirements-node.txt`
- `docs/UPGRADE_MIGRATION_GUIDE.md` — `config.yaml` → `config.json`; `requirements.txt` → `requirements-node.txt`

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)