### PR TITLE
feat(beacon): add heartbeat and contract agent leaderboard (rebase of #8221 by @SageHaven)

### DIFF
--- a/site/beacon/index.html
+++ b/site/beacon/index.html
@@ -93,6 +93,11 @@ function escapeHtml(value) {
     </div>
   </div>
 
+  <!-- Live agent rankings (Track C: agent leaderboard) -->
+  <aside class="agent-leaderboard" aria-label="Top Beacon agents" aria-live="polite">
+    <div class="leaderboard-empty">Loading agent activity...</div>
+  </aside>
+
   <!-- Controls hint (bottom-left) -->
   <div class="controls-hint">
     DRAG rotate | SCROLL zoom | RIGHT-DRAG pan<br>

--- a/site/beacon/leaderboard.mjs
+++ b/site/beacon/leaderboard.mjs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+
+const MAX_METRIC = 1_000_000_000;
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+
+function safeCount(value) {
+  const count = Number(value);
+  if (!Number.isFinite(count) || count <= 0) return 0;
+  return Math.min(MAX_METRIC, Math.floor(count));
+}
+
+function safeLimit(value) {
+  const limit = Number(value);
+  if (!Number.isFinite(limit) || limit <= 0) return DEFAULT_LIMIT;
+  return Math.min(MAX_LIMIT, Math.floor(limit));
+}
+
+function reputationFor(reputation, agentId) {
+  if (reputation instanceof Map) return reputation.get(agentId) || {};
+  if (!reputation || typeof reputation !== 'object') return {};
+  return reputation[agentId] || {};
+}
+
+function visibleContractCounts(contracts) {
+  const counts = new Map();
+  const seenByAgent = new Map();
+
+  for (const [index, contract] of (Array.isArray(contracts) ? contracts : []).entries()) {
+    if (!contract || typeof contract !== 'object') continue;
+    const contractKey = String(contract.id ?? `row-${index}`);
+    const participants = new Set([contract.from, contract.to].filter(value => (
+      typeof value === 'string' && value.length > 0
+    )));
+
+    for (const agentId of participants) {
+      if (!seenByAgent.has(agentId)) seenByAgent.set(agentId, new Set());
+      const seen = seenByAgent.get(agentId);
+      if (seen.has(contractKey)) continue;
+      seen.add(contractKey);
+      counts.set(agentId, (counts.get(agentId) || 0) + 1);
+    }
+  }
+
+  return counts;
+}
+
+function compareText(left, right) {
+  const a = String(left ?? '').toLowerCase();
+  const b = String(right ?? '').toLowerCase();
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+/**
+ * Build a deterministic leaderboard without mutating live Atlas data.
+ *
+ * Contract totals use the larger of currently-visible relationships and the
+ * backend's completed-contract counter so historical work remains represented.
+ */
+export function buildAgentLeaderboard(
+  agents,
+  contracts,
+  reputation = {},
+  sortBy = 'beats',
+  limit = DEFAULT_LIMIT,
+) {
+  const contractCounts = visibleContractCounts(contracts);
+  const entries = [];
+  const seenAgentIds = new Set();
+
+  for (const agent of (Array.isArray(agents) ? agents : [])) {
+    if (!agent || typeof agent !== 'object') continue;
+    const id = typeof agent.id === 'string' ? agent.id : '';
+    if (!id || seenAgentIds.has(id)) continue;
+    seenAgentIds.add(id);
+
+    const rep = reputationFor(reputation, id);
+    const beats = safeCount(agent.beat_count);
+    const contractCount = Math.max(
+      safeCount(contractCounts.get(id)),
+      safeCount(rep.contracts_completed),
+    );
+
+    if (beats === 0 && contractCount === 0) continue;
+    entries.push({
+      id,
+      name: typeof agent.name === 'string' && agent.name.trim() ? agent.name.trim() : id,
+      beats,
+      contracts: contractCount,
+    });
+  }
+
+  const mode = sortBy === 'contracts' ? 'contracts' : 'beats';
+  const secondary = mode === 'beats' ? 'contracts' : 'beats';
+  entries.sort((a, b) => (
+    b[mode] - a[mode]
+    || b[secondary] - a[secondary]
+    || compareText(a.name, b.name)
+    || compareText(a.id, b.id)
+  ));
+
+  return entries.slice(0, safeLimit(limit));
+}

--- a/site/beacon/styles.css
+++ b/site/beacon/styles.css
@@ -233,6 +233,123 @@ html, body {
 .city-teleport-select option {
   background: var(--bg-terminal);
   color: var(--green);
+/* --- Agent Leaderboard (left sidebar) --- */
+.agent-leaderboard {
+  position: fixed;
+  top: 150px;
+  left: 16px;
+  z-index: 50;
+  width: min(340px, calc(100vw - 32px));
+  max-height: calc(100vh - 220px);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  box-shadow: 0 0 20px rgba(0, 255, 0, 0.05);
+  color: var(--text-body);
+  font-family: var(--font-mono);
+  pointer-events: auto;
+  overflow: hidden;
+}
+
+.leaderboard-header {
+  padding: 8px 10px;
+  background: rgba(0, 20, 0, 0.65);
+  border-bottom: 1px solid var(--border);
+}
+
+.leaderboard-title {
+  color: var(--amber);
+  font-family: var(--font-display);
+  font-size: 20px;
+  font-weight: 400;
+  letter-spacing: 1px;
+}
+
+.leaderboard-controls {
+  display: flex;
+  gap: 6px;
+  margin-top: 5px;
+}
+
+.leaderboard-mode {
+  padding: 2px 7px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.leaderboard-mode[aria-pressed="true"] {
+  border-color: var(--amber-dim);
+  color: var(--amber);
+  background: rgba(255, 176, 0, 0.08);
+}
+
+.leaderboard-list {
+  min-height: 34px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--green-dim) transparent;
+}
+
+.leaderboard-item {
+  margin: 0;
+  padding: 0;
+}
+
+.leaderboard-row {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 26px minmax(0, 1fr) 54px 54px;
+  gap: 5px;
+  align-items: center;
+  padding: 6px 9px;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid rgba(26, 51, 26, 0.65);
+  color: var(--text-body);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.leaderboard-row:hover,
+.leaderboard-row:focus-visible {
+  background: rgba(51, 255, 51, 0.08);
+  color: var(--green);
+  outline: 1px solid var(--green-dim);
+  outline-offset: -1px;
+}
+
+.leaderboard-rank {
+  color: var(--amber);
+}
+
+.leaderboard-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.leaderboard-metric {
+  color: var(--text-dim);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.leaderboard-empty {
+  padding: 10px;
+  color: var(--text-dim);
+  font-size: 11px;
 }
 
 /* --- Controls hint (bottom-left) --- */
@@ -984,6 +1101,17 @@ button.hud-action {
 
   .agent-search {
     width: min(300px, calc(100vw - 16px));
+  }
+
+  .agent-leaderboard {
+    top: 132px;
+    left: 8px;
+    width: min(330px, calc(100vw - 16px));
+    max-height: 36vh;
+  }
+
+  .leaderboard-row {
+    padding: 5px 7px;
   }
 
   .controls-hint { display: none; }

--- a/site/beacon/ui.js
+++ b/site/beacon/ui.js
@@ -14,6 +14,7 @@ import { highlightAgentConnections, addContractLine } from './connections.js';
 import { initChat, setCurrentAgent, getChatHTML, bindChatEvents } from './chat.js';
 import { buildContractHistory, formatContractTimestamp } from './contract-history.mjs';
 import { playClickTone, playHoverTone } from './sound.js';
+import { buildAgentLeaderboard } from './leaderboard.mjs';
 
 const BEACON_API = (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')
   ? 'http://localhost:8071'
@@ -37,6 +38,8 @@ function escapeHtml(value) {
     .replaceAll("'", '&#39;');
 }
 let hoveredObjectKey = null;
+let leaderboardRoot = null;
+let leaderboardMode = 'beats';
 
 function safeNumber(value, fallback = 0, min = 0, max = Number.MAX_SAFE_INTEGER) {
   const number = Number(value);
@@ -97,6 +100,7 @@ async function loadReputation() {
         });
       }
       reputationTs = Date.now();
+      renderAgentLeaderboard();
     }
   } catch (e) {
     console.warn('[rep] Failed to load reputation:', e.message);
@@ -124,6 +128,7 @@ export function initUI() {
   updateHUD();
   initAgentSearch();
   initCityTeleport();
+  initAgentLeaderboard();
 
   // Click handlers
   setClickHandler(onObjectClick);
@@ -333,6 +338,94 @@ function updateHUD() {
     if (parts.length) agentStr += ` (${parts.join('+')})`;
     el.innerHTML = `AGENTS: <span>${escapeHtml(agentStr)}</span> | CITIES: <span>${escapeHtml(CITIES.length)}</span> | CONTRACTS: <span>${escapeHtml(CONTRACTS.length)}</span>`;
   }
+}
+
+function initAgentLeaderboard() {
+  leaderboardRoot = document.querySelector('.agent-leaderboard');
+  renderAgentLeaderboard();
+}
+
+function renderAgentLeaderboard() {
+  if (!leaderboardRoot) return;
+
+  const header = document.createElement('div');
+  header.className = 'leaderboard-header';
+
+  const title = document.createElement('h2');
+  title.className = 'leaderboard-title';
+  title.textContent = '[TOP AGENTS]';
+  header.appendChild(title);
+
+  const controls = document.createElement('div');
+  controls.className = 'leaderboard-controls';
+  for (const mode of ['beats', 'contracts']) {
+    const modeButton = document.createElement('button');
+    modeButton.type = 'button';
+    modeButton.className = 'leaderboard-mode';
+    modeButton.textContent = mode === 'beats' ? 'BEATS' : 'CONTRACTS';
+    modeButton.setAttribute('aria-pressed', String(leaderboardMode === mode));
+    modeButton.addEventListener('click', () => {
+      leaderboardMode = mode;
+      renderAgentLeaderboard();
+    });
+    controls.appendChild(modeButton);
+  }
+  header.appendChild(controls);
+
+  const entries = buildAgentLeaderboard(
+    AGENTS,
+    CONTRACTS,
+    reputationCache,
+    leaderboardMode,
+    10,
+  );
+  const list = document.createElement('ol');
+  list.className = 'leaderboard-list';
+
+  if (entries.length === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'leaderboard-empty';
+    empty.textContent = 'No heartbeat or contract activity yet.';
+    list.appendChild(empty);
+  }
+
+  entries.forEach((entry, index) => {
+    const item = document.createElement('li');
+    item.className = 'leaderboard-item';
+
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = 'leaderboard-row';
+    row.setAttribute(
+      'aria-label',
+      `${index + 1}. ${entry.name}; ${entry.beats} heartbeats; ${entry.contracts} contracts`,
+    );
+    row.addEventListener('click', () => selectAgent(entry.id));
+
+    const rank = document.createElement('span');
+    rank.className = 'leaderboard-rank';
+    rank.textContent = String(index + 1).padStart(2, '0');
+
+    const rowName = document.createElement('span');
+    rowName.className = 'leaderboard-name';
+    rowName.textContent = entry.name;
+
+    const beats = document.createElement('span');
+    beats.className = 'leaderboard-metric';
+    beats.title = 'Heartbeats';
+    beats.textContent = `${entry.beats} B`;
+
+    const contracts = document.createElement('span');
+    contracts.className = 'leaderboard-metric';
+    contracts.title = 'Contracts';
+    contracts.textContent = `${entry.contracts} C`;
+
+    row.append(rank, rowName, beats, contracts);
+    item.appendChild(row);
+    list.appendChild(item);
+  });
+
+  leaderboardRoot.replaceChildren(header, list);
 }
 
 function setPanelPath(path) {
@@ -850,6 +943,7 @@ async function submitContract() {
     // Success - add to data, create 3D line, update HUD
     const normalized = addContract(data);
     addContractLine(normalized);
+    renderAgentLeaderboard();
     updateHUD();
 
     successEl.textContent = `CONTRACT ${data.id} TRANSMITTED. State: ${data.state}`;

--- a/tests/beacon_agent_leaderboard.test.mjs
+++ b/tests/beacon_agent_leaderboard.test.mjs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildAgentLeaderboard } from '../site/beacon/leaderboard.mjs';
+
+const agents = [
+  { id: 'bcn_beta', name: 'Beta', beat_count: 8 },
+  { id: 'bcn_alpha', name: 'Alpha', beat_count: 8 },
+  { id: 'bcn_gamma', name: 'Gamma', beat_count: 3 },
+  { id: 'bcn_idle', name: 'Idle', beat_count: 0 },
+];
+
+const contracts = [
+  { id: 'ctr-1', from: 'bcn_alpha', to: 'bcn_gamma' },
+  { id: 'ctr-2', from: 'bcn_gamma', to: 'bcn_beta' },
+  { id: 'ctr-3', from: 'bcn_gamma', to: 'bcn_gamma' },
+];
+
+test('beat mode ranks by heartbeats, then contracts, then name', () => {
+  const ranked = buildAgentLeaderboard(agents, contracts, {}, 'beats');
+
+  assert.deepEqual(ranked.map(entry => entry.id), [
+    'bcn_alpha',
+    'bcn_beta',
+    'bcn_gamma',
+  ]);
+  assert.deepEqual(ranked.map(entry => entry.beats), [8, 8, 3]);
+});
+
+test('contract mode combines visible relationships with reputation history', () => {
+  const ranked = buildAgentLeaderboard(
+    agents,
+    contracts,
+    { bcn_beta: { contracts_completed: 7 } },
+    'contracts',
+  );
+
+  assert.equal(ranked[0].id, 'bcn_beta');
+  assert.equal(ranked[0].contracts, 7);
+  assert.equal(ranked.find(entry => entry.id === 'bcn_gamma').contracts, 3);
+});
+
+test('duplicate contract ids and self-contracts count once per agent', () => {
+  const ranked = buildAgentLeaderboard(
+    [{ id: 'bcn_one', name: 'One', beat_count: 1 }],
+    [
+      { id: 'same', from: 'bcn_one', to: 'bcn_one' },
+      { id: 'same', from: 'bcn_one', to: 'bcn_other' },
+    ],
+    {},
+    'contracts',
+  );
+
+  assert.equal(ranked[0].contracts, 1);
+});
+
+test('malformed counts fail closed and source arrays are not mutated', () => {
+  const sourceAgents = [
+    { id: 'bcn_bad', name: 'Bad', beat_count: '<script>' },
+    { id: 'bcn_good', name: 'Good', beat_count: 2.9 },
+    { id: 'bcn_good', name: 'Duplicate', beat_count: 99 },
+    null,
+  ];
+  const snapshot = structuredClone(sourceAgents);
+
+  const ranked = buildAgentLeaderboard(
+    sourceAgents,
+    [],
+    { bcn_bad: { contracts_completed: Number.POSITIVE_INFINITY } },
+    'unknown-mode',
+  );
+
+  assert.deepEqual(ranked, [{ id: 'bcn_good', name: 'Good', beats: 2, contracts: 0 }]);
+  assert.deepEqual(sourceAgents, snapshot);
+});
+
+test('limit is bounded and invalid input returns an empty leaderboard', () => {
+  assert.deepEqual(buildAgentLeaderboard(null, null), []);
+  assert.equal(buildAgentLeaderboard(agents, contracts, {}, 'beats', 2).length, 2);
+});

--- a/tests/test_beacon_agent_leaderboard_ui.py
+++ b/tests/test_beacon_agent_leaderboard_ui.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BEACON = ROOT / "site" / "beacon"
+
+
+class BeaconAgentLeaderboardIntegrationTests(unittest.TestCase):
+    def test_atlas_exposes_an_accessible_leaderboard_sidebar(self):
+        html = (BEACON / "index.html").read_text(encoding="utf-8")
+
+        self.assertIn('class="agent-leaderboard"', html)
+        self.assertIn('aria-label="Top Beacon agents"', html)
+
+    def test_ui_renders_safe_selectable_rows_and_both_modes(self):
+        source = (BEACON / "ui.js").read_text(encoding="utf-8")
+
+        self.assertIn(
+            "import { buildAgentLeaderboard } from './leaderboard.mjs';",
+            source,
+        )
+        self.assertIn("buildAgentLeaderboard(", source)
+        self.assertIn("modeButton.setAttribute('aria-pressed'", source)
+        self.assertIn("rowName.textContent = entry.name", source)
+        self.assertIn("row.addEventListener('click', () => selectAgent(entry.id))", source)
+        self.assertIn("leaderboardRoot.replaceChildren", source)
+
+    def test_sidebar_is_interactive_scrollable_and_responsive(self):
+        css = (BEACON / "styles.css").read_text(encoding="utf-8")
+
+        for fragment in (
+            ".agent-leaderboard {",
+            "pointer-events: auto",
+            ".leaderboard-list {",
+            "overflow-y: auto",
+            ".leaderboard-row:focus-visible",
+            "@media (max-width: 768px)",
+        ):
+            self.assertIn(fragment, css)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Maintainer rebase of #8221 by @SageHaven onto current main; authorship preserved. Conflicts were add/add against search, teleport and sound work (ui.js imports/state/init, styles.css); resolved as a union. node 5/5, pytest 24/24. Bounty credit to @SageHaven (rustchain-bounties#1524). Supersedes #8221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RDgENXHE8sjiekfdvw3jn