### PR TITLE
security(beacon): refuse anonymous first registration of a pre-funded noncanonical bcn_ id

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -96,6 +96,18 @@ def _coinbase_addresses_match(left, right):
     return (left or '').strip().casefold() == (right or '').strip().casefold()
 
 
+def _prefunded_balance_i64(db, wallet_id):
+    """RTC (i64 micro-units) already credited to `wallet_id` in the shared
+    balances table, or 0 when the table is absent (standalone Beacon DB)."""
+    try:
+        row = db.execute(
+            "SELECT amount_i64 FROM balances WHERE miner_id = ?", (wallet_id,)
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return 0
+    return int(row[0] or 0) if row else 0
+
+
 def get_db():
     """Get database connection for current request context."""
     if 'db' not in g:
@@ -654,6 +666,21 @@ def beacon_join():
                 WHERE agent_id = ?
             """, (name, new_status, now, agent_id))
         else:
+            # SECURITY (#398 Step 3, reported privately 2026-08-29): a
+            # noncanonical bcn_ id skips the pubkey->id binding above, so the
+            # first caller to register such a name installs their own key. If
+            # RTC was already credited to that name (legacy payouts, hosted
+            # handles), the signed-transfer path would then treat the squatter's
+            # key as the spending authority for a balance they never owned.
+            # Fail closed: a pre-funded noncanonical id needs operator-assisted
+            # migration, never anonymous first registration.
+            if not _is_canonical_agent_id(agent_id) and _prefunded_balance_i64(db, agent_id) > 0:
+                return jsonify({
+                    'error': 'This bcn_ id already holds RTC but has no registered key; '
+                             'anonymous first registration is refused. Contact the '
+                             'operators for an ownership migration.',
+                    'code': 'PREFUNDED_ID_REQUIRES_MIGRATION',
+                }), 409
             # New agent — insert with pubkey_hex
             new_status = 'active'
             db.execute("""

--- a/node/tests/test_beacon_api_join.py
+++ b/node/tests/test_beacon_api_join.py
@@ -116,3 +116,52 @@ def test_beacon_join_reactivates_inactive_agent(tmp_path, monkeypatch):
 
     assert response.get_json()["status"] == "active"
     assert _db_status("idle-agent") == "active"
+
+
+def _fund(agent_id, amount_i64):
+    conn = sqlite3.connect(beacon_api.DB_PATH)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+            (agent_id, amount_i64),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_beacon_join_refuses_first_registration_of_prefunded_noncanonical_id(tmp_path, monkeypatch):
+    """#398 Step 3: RTC credited to an unregistered legacy bcn_ name must not be
+    claimable by whoever registers that name first."""
+    client = _client(tmp_path, monkeypatch)
+    _fund("bcn_legacy_demo", 35_000_000)
+    response = client.post(
+        "/beacon/join",
+        json={"agent_id": "bcn_legacy_demo", "pubkey_hex": "11" * 32},
+    )
+    assert response.status_code == 409
+    assert response.get_json()["code"] == "PREFUNDED_ID_REQUIRES_MIGRATION"
+    assert _db_status("bcn_legacy_demo") is None
+
+
+def test_beacon_join_still_accepts_unfunded_noncanonical_id(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    _fund("bcn_other_name", 5_000_000)  # balances table exists, but not for this id
+    response = client.post(
+        "/beacon/join",
+        json={"agent_id": "bcn_legacy_fresh", "pubkey_hex": "22" * 32},
+    )
+    assert response.status_code in (200, 201)
+    assert _db_status("bcn_legacy_fresh") == "active"
+
+
+def test_beacon_join_without_balances_table_is_unaffected(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    response = client.post(
+        "/beacon/join",
+        json={"agent_id": "bcn_legacy_nodb", "pubkey_hex": "33" * 32},
+    )
+    assert response.status_code in (200, 201)


### PR DESCRIPTION
Fixes a cross-component issue reported privately by @prins1bap-ui under rustchain-bounties#398 Step 3 (details withheld until merge).

**Problem.** Noncanonical `bcn_` ids skip the pubkey→id binding in `/beacon/join`, so the first caller to register such a name installs their own key. `/wallet/transfer/signed` then treats that key as the spending authority for any RTC already credited to the string, and payout preflight accepts unregistered `bcn_` destinations, so pre-funded-but-unregistered names can exist.

**Fix.** A NEW noncanonical id that already holds RTC in the shared `balances` table gets `409 PREFUNDED_ID_REQUIRES_MIGRATION` instead of an insert. Standalone Beacon DBs without a `balances` table are unaffected. Three regression tests; `test_beacon_api_join.py` + `test_beacon_identity.py` 42 pass.

**Deployment note.** No deployed node currently routes `/beacon/join` (nginx 405/404 on all four), so this is a main-branch hardening, not a live hotfix. Follow-up: require `bcn_` transfer destinations to resolve to a registered Atlas identity in `payout_preflight.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RDgENXHE8sjiekfdvw3jn