### PR TITLE
security(wallet): refuse signed transfers to unregistered bcn_ destinations (follow-up to #8357)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -13526,6 +13526,22 @@ def wallet_transfer_signed():
     if review_gate is not None:
         return review_gate
 
+    # SECURITY (#398 Step 3 follow-up to #8357): a bcn_ destination must already
+    # resolve to a registered Beacon Atlas identity. Crediting RTC to an
+    # unregistered name creates a balance with no key owner, which is exactly
+    # the pre-funded-id condition #8357 had to guard against at /beacon/join.
+    # Close it at the source too: refuse the transfer instead of minting an
+    # orphan balance. Admin/operator migration paths use /wallet/transfer.
+    if to_address.startswith("bcn_"):
+        _dest = resolve_bcn_wallet(to_address)
+        if not _dest.get("found"):
+            return jsonify({
+                "error": "unregistered_bcn_destination",
+                "message": "Destination bcn_ id is not registered in Beacon Atlas; "
+                           "register it via /beacon/join before receiving RTC.",
+                "to_address": to_address,
+            }), 400
+
     # SECURITY (#6127): Validate signature/public_key types before str() coercion
     _raw_sig = data.get("signature")
     _raw_pubkey = data.get("public_key")


### PR DESCRIPTION
Second half of the fix for @prins1bap-ui's #398 Step 3 finding. #8357 stopped a squatter from claiming a pre-funded noncanonical `bcn_` id at `/beacon/join`; this stops the orphan balances from being created in the first place.

`/wallet/transfer/signed` now returns `400 unregistered_bcn_destination` when `to_address` is a `bcn_` id that `resolve_bcn_wallet()` cannot find. Placed right after the sender review gate, before any state mutation. Operator migrations continue to use the admin `/wallet/transfer` path.

`test_wallet_transfer_signed_no_pubkey_disclosure.py` + `test_beacon_api_join.py`: 12 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RDgENXHE8sjiekfdvw3jn