### PR TITLE
docs: stop hard-coding the RTC reference rate (welcome.yml + registry submissions), reported by @prins1bap-ui

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -27,7 +27,7 @@ jobs:
 
             **Earn RTC tokens** by contributing code, docs, or security fixes. Every merged PR gets paid\!
 
-            1 RTC = $0.10 USD | `pip install clawrtc` to start mining
+            Reference rate: see the [Tokenomics table](https://github.com/Scottcjn/Rustchain#tokenomics) (holder-count schedule; no fiat off-ramp) | `pip install clawrtc` to start mining
           pr_message: |
             Welcome to RustChain\! Thanks for your first pull request.
 

--- a/registry-submissions/SUBMISSION_STATUS.md
+++ b/registry-submissions/SUBMISSION_STATUS.md
@@ -83,7 +83,7 @@ Hi DePINHub team! I'd like to submit RustChain for your project listing.
 - MIT licensed, open source
 
 **Token**: RTC (RustChain Token)
-- Reference rate: $0.10 USD
+- Reference rate: see [README → Tokenomics](https://github.com/Scottcjn/Rustchain#tokenomics) (holder-count schedule, currently the $0.15 tier; internal reference only, no fiat off-ramp)
 - 31,710+ RTC distributed
 - 248+ contributors
 

--- a/registry-submissions/depinhub_submission.md
+++ b/registry-submissions/depinhub_submission.md
@@ -36,7 +36,7 @@ Hi DePINHub team! I'd like to submit RustChain for your project listing.
 - MIT licensed, open source
 
 **Token**: RTC (RustChain Token)
-- Reference rate: $0.10 USD
+- Reference rate: see [README → Tokenomics](https://github.com/Scottcjn/Rustchain#tokenomics) (holder-count schedule, currently the $0.15 tier; internal reference only, no fiat off-ramp)
 - 31,710+ RTC distributed
 - 248+ contributors
 


### PR DESCRIPTION
Two rustchain-bounties#254 reports by @prins1bap-ui (email fallback), both verified against main: `.github/workflows/welcome.yml` greets every new contributor with `1 RTC = $0.10 USD`, and `registry-submissions/SUBMISSION_STATUS.md` + `depinhub_submission.md` still say `Reference rate: $0.10 USD`, while README's tokenomics table marks the $0.15 tier as current.

Fix: replace the hard-coded number in all three with a pointer to the canonical README table (holder-count schedule, no fiat off-ramp), so the rate cannot drift again. Docs/workflow text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RDgENXHE8sjiekfdvw3jn