### PR TITLE
fix(utxo): genesis dry-run preview root uses big-endian count (matches compute_state_root)

### DIFF
--- a/node/utxo_genesis_migration.py
+++ b/node/utxo_genesis_migration.py
@@ -182,7 +182,7 @@ def _state_root_from_boxes(boxes: list[dict]) -> str:
     rows = sorted(boxes, key=lambda box: box["box_id"])
     if not rows:
         return hashlib.sha256(b"empty").hexdigest()
-    count_bytes = len(rows).to_bytes(8, "little")
+    count_bytes = len(rows).to_bytes(8, "big")  # must match UtxoDB.compute_state_root (big-endian)
     hashes = []
     for row in rows:
         leaf = {


### PR DESCRIPTION
One-line fix for the finding by @stratumpraxis under rustchain-bounties#2819 (Low, 25 RTC paid): `_state_root_from_boxes()` encoded the row count little-endian while `UtxoDB.compute_state_root()` encodes big-endian, so the dry-run preview root never matched the real migration root for nonzero box counts. `test_utxo_genesis_dry_run_side_effects.py` 2 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RDgENXHE8sjiekfdvw3jn