### PR TITLE
security(bcos): escape badge SVG label and restrict tier to L0/L1/L2

### DIFF
--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -11,8 +11,7 @@ Adds /bcos/* routes to the RustChain Flask application:
   GET  /bcos/directory         List all certified repos
 
 Usage in main node file:
-    from bcos_routes import
-import register_bcos_routes
+    from bcos_routes import register_bcos_routes
     register_bcos_routes(app, DB_PATH)
 """
 

--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -11,7 +11,8 @@ Adds /bcos/* routes to the RustChain Flask application:
   GET  /bcos/directory         List all certified repos
 
 Usage in main node file:
-    from bcos_routes import register_bcos_routes
+    from bcos_routes import
+import register_bcos_routes
     register_bcos_routes(app, DB_PATH)
 """
 
@@ -20,6 +21,7 @@ from __future__ import annotations
 import io
 import json
 import hmac
+import html
 import os
 import sqlite3
 import time
@@ -240,7 +242,12 @@ def _generate_badge_svg(tier: str, score: int) -> str:
     else:
         color = colors.get(tier, "#08c")
 
-    label = f"{tier} {score}/100"
+    # SECURITY: tier/score come from stored attestation data and are interpolated
+    # into XML served as image/svg+xml on this origin. Escape every dynamic
+    # value so a crafted tier cannot break out of <text> and inject active SVG
+    # content (stored same-origin script execution). Reported privately
+    # 2026-09-08 under rustchain-bounties#398 Step 3.
+    label = html.escape(f"{tier} {score}/100", quote=True)
     right_width = max(70, len(label) * 7 + 10)
     width = 50 + right_width
     text_x = 50 + right_width // 2
@@ -286,6 +293,9 @@ def bcos_attest():
             repo = _string_report_field(report, "repo")
         commit_sha = _string_report_field(report, "commit_sha")
         tier = _string_report_field(report, "tier", "L1")
+        # SECURITY: tier is rendered into the badge SVG; restrict to the enum.
+        if tier not in ("L0", "L1", "L2"):
+            return jsonify({"error": "Invalid tier: must be one of L0, L1, L2"}), 400
         reviewer = _string_report_field(report, "reviewer")
         signature = _string_report_field(data, "signature") if "signature" in data else _string_report_field(report, "signature")
         signer_pubkey = (

--- a/node/tests/test_bcos_reattest_preserves_anchor.py
+++ b/node/tests/test_bcos_reattest_preserves_anchor.py
@@ -90,7 +90,7 @@ def test_reattest_duplicate_cert_id_is_rejected_and_preserves_anchor(tmp_path, m
         "cert_id": "BCOS-anchored",
         "repo": "attacker/evil",
         "commit_sha": "0000000000000000",
-        "tier": "L4",
+        "tier": "L0",  # valid enum value, still different from the original L2
         "trust_score": 100,
         "reviewer": "attacker",
     })

--- a/node/tests/test_bcos_routes.py
+++ b/node/tests/test_bcos_routes.py
@@ -234,3 +234,31 @@ def test_bcos_verify_tolerates_corrupt_stored_report(tmp_path):
     assert body["commitment_valid"] is False
     assert body["score_breakdown"] == {}
     assert body["checks"] == {}
+
+
+def test_bcos_badge_svg_escapes_stored_tier(tmp_path, monkeypatch):
+    """A crafted tier must not break out of <text> into active SVG content."""
+    from bcos_routes import _generate_badge_svg
+    svg = _generate_badge_svg('L1</text><script>alert(1)</script><text>', 42)
+    assert "<script>" not in svg
+    assert "&lt;script&gt;" in svg
+
+
+def test_bcos_attest_rejects_tier_outside_enum(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin")
+    app = Flask(__name__)
+    register_bcos_routes(app, str(tmp_path / "bcos.db"))
+    app.config["TESTING"] = True
+    report = _with_commitment({
+        "cert_id": "cert-tier-enum",
+        "repo": "Scottcjn/example",
+        "tier": 'L1</text><script>alert(1)</script><text>',
+        "trust_score": 42,
+    })
+    response = app.test_client().post(
+        "/bcos/attest",
+        headers={"X-Admin-Key": "test-admin"},
+        json={"report": report},
+    )
+    assert response.status_code == 400
+    assert "tier" in response.get_json()["error"].lower()


### PR DESCRIPTION
Private disclosure by @stratumpraxis (rustchain-bounties#398 Step 3, 2026-09-08). `_generate_badge_svg()` interpolated the stored `tier` unescaped into XML served as `image/svg+xml` on this origin, and `bcos_attest()` accepted any string as tier, so an attestation signer (admin key or valid Ed25519 signature) could store active SVG content: stored same-origin script execution when the badge is opened directly. `GET /bcos/badge/<id>.svg` is live on rustchain.org.

Fix: `html.escape()` on the label; tier restricted to `L0/L1/L2` at attest time; two regression tests. BCOS test files: all pass.

Deploy note: prod runs its own node copy; splice the two hunks surgically after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RDgENXHE8sjiekfdvw3jn