### PR TITLE
Harden RTC money path: remove legacy transfer route, guard /pending/void, unify admin key

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -280,7 +280,6 @@ _ADMIN_RATE_LIMIT_PATHS = {
     "/wallet/ledger",
     "/wallet/link-coinbase",
     "/wallet/transfer",
-    "/wallet/transfer_OLD_DISABLED",
     "/withdraw/register",
 }
 
@@ -12304,8 +12303,17 @@ def void_pending():
         c.execute("""
             UPDATE pending_ledger 
             SET status = 'voided', voided_by = ?, voided_reason = ?
-            WHERE id = ?
+            WHERE id = ? AND status = 'pending'
         """, (voided_by, reason, pid))
+        # TOCTOU guard: only void if STILL pending. If confirm_pending claimed
+        # this row between the SELECT above and here, rowcount is 0 -> do not
+        # report a false "voided" success for funds that actually moved.
+        if c.rowcount != 1:
+            conn.rollback()
+            return jsonify({
+                "error": "Cannot void - transfer is no longer pending (raced with confirm)",
+                "code": "VOID_RACE",
+            }), 409
         
         conn.commit()
         
@@ -12720,67 +12728,6 @@ def check_integrity():
     })
 
 
-# OLD FUNCTION DISABLED - Kept for reference
-@app.route('/wallet/transfer_OLD_DISABLED', methods=['POST'])
-def wallet_transfer_OLD():
-    # SECURITY FIX: Require admin key for internal transfers
-    admin_key_env = os.environ.get("RC_ADMIN_KEY", "")
-    if not admin_key_env:
-        return jsonify({"error": "RC_ADMIN_KEY not configured on server", "code": "ADMIN_KEY_UNSET"}), 503
-    admin_key = request.headers.get("X-Admin-Key", "")
-    if not hmac.compare_digest(admin_key, admin_key_env):
-        return jsonify({"error": "Unauthorized - admin key required", "hint": "Use /wallet/transfer/signed for user transfers"}), 401
-    """Transfer RTC between miner wallets"""
-    data = request.get_json(silent=True)
-    if not isinstance(data, dict):
-        return jsonify({"error": "Invalid JSON body"}), 400
-
-    # Extract client IP (handle nginx proxy)
-    client_ip = get_client_ip()
-    from_miner = data.get('from_miner')
-    to_miner = data.get('to_miner')
-    amount_rtc = float(data.get('amount_rtc', 0))
-
-    if not all([from_miner, to_miner]):
-        return jsonify({"error": "Missing from_miner or to_miner"}), 400
-
-    if amount_rtc <= 0:
-        return jsonify({"error": "Amount must be positive"}), 400
-
-    amount_i64 = int(amount_rtc * 1000000)
-
-    conn = sqlite3.connect(DB_PATH)
-    try:
-        c = conn.cursor()
-        row = c.execute("SELECT amount_i64 FROM balances WHERE miner_id = ?", (from_miner,)).fetchone()
-        sender_balance = row[0] if row else 0
-
-        if sender_balance < amount_i64:
-            return jsonify({
-                "error": "Insufficient balance",
-                "balance_rtc": sender_balance / 1000000,
-                "requested_rtc": amount_rtc
-            }), 400
-
-        c.execute("INSERT OR IGNORE INTO balances (miner_id, amount_i64) VALUES (?, 0)", (to_miner,))
-        c.execute("UPDATE balances SET amount_i64 = amount_i64 - ? WHERE miner_id = ?", (amount_i64, from_miner))
-        c.execute("UPDATE balances SET amount_i64 = amount_i64 + ?, balance_rtc = (amount_i64 + ?) / 1000000.0 WHERE miner_id = ?", (amount_i64, amount_i64, to_miner))
-
-        sender_new = c.execute("SELECT amount_i64 FROM balances WHERE miner_id = ?", (from_miner,)).fetchone()[0]
-        recipient_new = c.execute("SELECT amount_i64 FROM balances WHERE miner_id = ?", (to_miner,)).fetchone()[0]
-
-        conn.commit()
-
-        return jsonify({
-            "ok": True,
-            "from_miner": from_miner,
-            "to_miner": to_miner,
-            "amount_rtc": amount_rtc,
-            "sender_balance_rtc": sender_new / 1000000,
-            "recipient_balance_rtc": recipient_new / 1000000
-        })
-    finally:
-        conn.close()
 @app.route('/wallet/ledger', methods=['GET'])
 def api_wallet_ledger():
     """Get transaction ledger (optionally filtered by miner)"""


### PR DESCRIPTION
## Summary

Defensive hardening of the RTC transfer + admin-auth path, from a source-verified audit (GPT-6 Astra + Fable 5.1, cross-checked against source and reviewed by the tri-brain loop / Codex).

### Changes
1. **Remove the live `/wallet/transfer_OLD_DISABLED` route** (+ its rate-limit allowlist entry). Despite the `_DISABLED` name it was a **registered, admin-authenticated, reachable** endpoint that did a direct `UPDATE balances` with no idempotency, `float()` amount parsing, and a sender/recipient `balance_rtc` drift. It duplicated `/wallet/transfer`.
2. **`/pending/void`: guard the UPDATE** with `AND status='pending'` + rowcount check → returns `409 VOID_RACE`. Previously an unconditional `UPDATE ... WHERE id=?` could overwrite a row `confirm_pending` had just claimed → a **false "voided" success for funds that actually moved**.
3. **`_configured_admin_key()`: read `RC_ADMIN_KEY` live** each call (drop the import-time `ADMIN_KEY` global snapshot) and route **all** inline admin-key reads (~12), the module global, `/miner/headerkey`, and `/withdraw/status` through it. Removes a strip/no-strip divergence and a boot-time-pinning footgun.

### Reviewer notes (raised by tri-brain / Codex — flagged, not hidden)
- **Breaking removal (intentional):** deleting `/wallet/transfer_OLD_DISABLED` returns 404 to any caller still hitting that path. This is a deliberate security retirement — the canonical admin path is `/wallet/transfer`, and user transfers use `/wallet/transfer/signed`. Please confirm no internal caller depends on the old path before merge.
- **`.strip()` semantics:** admin-key comparison now trims whitespace consistently. This **aligns the money endpoints with `is_admin()`**, which already stripped — it removes a divergence rather than adding one. A deployment that intentionally embedded leading/trailing whitespace in `RC_ADMIN_KEY` (unusual) would need to trim it; documented here for visibility.

### Verification
- `ast.parse` clean; no `transfer_OLD_DISABLED` refs remain; 0 raw inline `os.environ.get("RC_ADMIN_KEY","")` reads remain; `VOID_RACE` present.
- Findings #1/#2 (this diff) and the UTXO double-spend suspicion were each **verified against source** before action; the UTXO concern was confirmed **already defended** and is not touched here.
- No auth-surface change: each endpoint keeps its `503`-on-unset, `hmac.compare_digest`, and header semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbyXP4eiiRYEa8GsQtQPhR