### PR TITLE
fix(miner): keep hardware serial out of startup output

### DIFF
--- a/miners/linux/rustchain_linux_miner.py
+++ b/miners/linux/rustchain_linux_miner.py
@@ -300,7 +300,7 @@ class LocalMiner:
         print("="*70)
         print(f"Node: {self.node_url}")
         print(f"Wallet: {self.wallet}")
-        print(f"Serial: {self.serial}")
+        print(f"Serial present: {'yes' if self.serial else 'no'}")
         platform_warning = _linux_miner_platform_warning(platform.system())
         if platform_warning:
             print(f"[WARN] {platform_warning}")

--- a/tests/test_linux_miner_identity.py
+++ b/tests/test_linux_miner_identity.py
@@ -85,6 +85,22 @@ def test_local_miner_can_use_ephemeral_keypair_without_persisting(monkeypatch):
     assert calls == {"ephemeral": 1, "persisted": 0}
 
 
+def test_local_miner_keeps_serial_internal_without_printing_it(monkeypatch, capsys):
+    miner = load_miner_module()
+    raw_serial = "C02-PRIVATE-HARDWARE-SERIAL"
+
+    monkeypatch.setattr(miner, "CRYPTO_AVAILABLE", False)
+    monkeypatch.setattr(miner, "FINGERPRINT_AVAILABLE", False)
+    monkeypatch.setattr(miner, "get_hardware_serial", lambda: raw_serial)
+
+    instance = miner.LocalMiner(wallet="RTC-test-wallet", persist_key=False)
+    output = capsys.readouterr().out
+
+    assert instance.serial == raw_serial
+    assert raw_serial not in output
+    assert "Serial present: yes" in output
+
+
 def test_default_wallet_is_controlled_by_signing_key(monkeypatch):
     miner = load_miner_module()
     public_key = "11" * 32


### PR DESCRIPTION
## Summary

- Keep the raw hardware serial available internally for attestation and binding.
- Replace the unconditional startup-banner serial dump with a privacy-safe `Serial present: yes/no` status.
- Add a regression test proving a raw serial is retained but never printed by `LocalMiner` initialization.

Fixes #8368.
Related bounty: Scottcjn/rustchain-bounties#71

## Verification

- `python -m pytest -q tests/test_linux_miner_identity.py` — 9 passed
- `python -m py_compile miners/linux/rustchain_linux_miner.py tests/test_linux_miner_identity.py`
- `git diff --check`