### PR TITLE
fix(mcp): exclude non-bounty issues from discovery

### DIFF
--- a/rustchain-bounties-mcp/rustchain_bounties_mcp/client.py
+++ b/rustchain-bounties-mcp/rustchain_bounties_mcp/client.py
@@ -278,7 +278,10 @@ class RustChainClient:
         await self._ensure_session()
         state = status if status in ("open", "closed", "all") else "open"
         url = f"{GITHUB_API_BASE}/repos/{GITHUB_BOUNTIES_OWNER}/{GITHUB_BOUNTIES_REPO}/issues"
-        params = {"state": state, "per_page": min(limit, 100)}
+        # Filter at the source so administrative issues (wallet registrations,
+        # payout claims, retired notices, etc.) do not consume the result limit
+        # before real bounties are considered.
+        params = {"state": state, "labels": "bounty", "per_page": min(limit, 100)}
         headers = {"Accept": "application/vnd.github.v3+json", "User-Agent": "RustChain-Bounties-MCP/0.1"}
 
         try:
@@ -307,6 +310,9 @@ class RustChainClient:
     @staticmethod
     def _parse_github_issue(issue: dict[str, Any]) -> Optional[BountyInfo]:
         """Parse a GitHub issue into a BountyInfo, or None if not a bounty."""
+        if "pull_request" in issue:
+            return None
+
         title = issue.get("title", "")
         number = issue.get("number", 0)
         html_url = issue.get("html_url", "")
@@ -344,9 +350,10 @@ class RustChainClient:
             reward_rtc = float(title_match.group(1))
 
         # If no reward found in labels or title, skip non-bounty issues
-        if reward_rtc == 0 and not any("bounty" in (lbl.get("name", "") or "").lower() for lbl in labels):
-            # Still include it but with 0 reward — better than nothing for discovery
-            pass
+        if reward_rtc == 0 and not any(
+            "bounty" in (lbl.get("name", "") or "").lower() for lbl in labels
+        ):
+            return None
 
         return BountyInfo(
             issue_number=number,

--- a/rustchain-bounties-mcp/tests/test_client_bounties.py
+++ b/rustchain-bounties-mcp/tests/test_client_bounties.py
@@ -1,0 +1,90 @@
+"""Tests for GitHub-backed bounty discovery."""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from rustchain_bounties_mcp.client import RustChainClient
+
+
+class AsyncContextManager:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *args):
+        return None
+
+
+class MockResponse:
+    def __init__(self, data, status=200):
+        self._data = data
+        self.status = status
+
+    async def json(self):
+        return self._data
+
+    async def text(self):
+        return ""
+
+
+def github_issue(number, title, labels):
+    return {
+        "number": number,
+        "title": title,
+        "html_url": f"https://github.com/Scottcjn/rustchain-bounties/issues/{number}",
+        "state": "open",
+        "labels": [{"name": label} for label in labels],
+        "body": "test issue",
+    }
+
+
+def test_parser_rejects_non_bounty_administrative_issue():
+    issue = github_issue(16884, "[WALLET] Register payout identity", [])
+
+    assert RustChainClient._parse_github_issue(issue) is None
+
+
+def test_parser_keeps_labeled_bounty_without_numeric_reward():
+    issue = github_issue(121, "[BOUNTY] SEO audit fix pack", ["bounty", "open"])
+
+    result = RustChainClient._parse_github_issue(issue)
+
+    assert result is not None
+    assert result.issue_number == 121
+    assert result.reward_rtc == 0
+
+
+def test_parser_keeps_title_reward_when_label_is_missing():
+    issue = github_issue(42, "Fix the widget — 7 RTC", [])
+
+    result = RustChainClient._parse_github_issue(issue)
+
+    assert result is not None
+    assert result.reward_rtc == 7
+
+
+@pytest.mark.asyncio
+async def test_fetch_filters_github_query_and_defensively_skips_non_bounties():
+    response = MockResponse([
+        github_issue(16884, "[WALLET] Register payout identity", []),
+        github_issue(520, "[Achievement] Bug Hunter — 3 RTC", ["bounty"]),
+    ])
+    session = MagicMock()
+    session.get = MagicMock(return_value=AsyncContextManager(response))
+    client = RustChainClient(session=session)
+
+    results = await client._fetch_bounties_from_github(limit=20)
+
+    assert [result.issue_number for result in results] == [520]
+    assert session.get.call_args.kwargs["params"] == {
+        "state": "open",
+        "labels": "bounty",
+        "per_page": 20,
+    }

--- a/rustchain-bounties-mcp/tests/test_schemas.py
+++ b/rustchain-bounties-mcp/tests/test_schemas.py
@@ -247,11 +247,8 @@ class TestGitHubBountyParsing:
             "body": "",
             "pull_request": {"merged_at": None},
         }
-        # The client filters these out before calling _parse_github_issue,
-        # but the parser itself doesn't skip — the caller does.
         b = self._parse(issue)
-        assert b is not None  # parser doesn't check pull_request
-        assert b.issue_number == 99
+        assert b is None
 
     def test_parse_no_reward(self):
         issue = {
@@ -263,6 +260,4 @@ class TestGitHubBountyParsing:
             "body": "Just a discussion thread.",
         }
         b = self._parse(issue)
-        assert b is not None
-        assert b.reward_rtc == 0.0
-        assert b.difficulty is None
+        assert b is None


### PR DESCRIPTION
## Summary

- request only issues carrying the registered `bounty` label from the GitHub Issues API
- defensively reject pull requests and ordinary administrative issues in the parser
- add regressions for wallet-registration issues, unlabeled discussions, PR payloads, title-only RTC rewards, and labeled bounties without a numeric reward

Closes #8372.

## Reproduction before the fix

The same first page used by the MCP client currently contains wallet registrations, payout claims, and retired notices. Passing issue #16884 (`[WALLET] Register AKASH80047 payout identity`, no labels) to `_parse_github_issue()` returned:

```text
BountyInfo 16884 0.0 []
```

That made administrative issues appear as zero-reward bounties and allowed them to consume the caller's result limit.

## Verification

- `python -m pytest -q rustchain-bounties-mcp/tests` → **46 passed**
- live read-only `client.bounties(limit=20)` smoke test → **20 registered bounty-labelled results**, with no wallet/claim/retired issues
- `git diff --check` → passed

Environment: macOS 26.0.1 arm64, Python 3.14.0.

AI assistance was used for source inspection, duplicate checking, reproduction, implementation, testing, and PR formatting. No security testing or production write was performed.
