### PR TITLE
fix(mcp): preserve decimal bounty rewards

### DIFF
--- a/rustchain-bounties-mcp/rustchain_bounties_mcp/client.py
+++ b/rustchain-bounties-mcp/rustchain_bounties_mcp/client.py
@@ -339,7 +339,7 @@ class RustChainClient:
             tags.append(label.get("name", ""))
 
         # Try to extract reward from title (e.g. "Bounty: MCP Server (500 RTC)")
-        title_match = re.search(r"(\d+)\s*RTC", title, re.IGNORECASE)
+        title_match = re.search(r"(\d+(?:\.\d+)?)\s*RTC", title, re.IGNORECASE)
         if title_match and reward_rtc == 0:
             reward_rtc = float(title_match.group(1))
 

--- a/rustchain-bounties-mcp/tests/test_schemas.py
+++ b/rustchain-bounties-mcp/tests/test_schemas.py
@@ -237,6 +237,21 @@ class TestGitHubBountyParsing:
         assert b.reward_rtc == 50.0
         assert b.difficulty == "easy"
 
+    def test_parse_decimal_rtc_reward_in_title(self):
+        issue = {
+            "number": 16863,
+            "title": "[MICRO-BOUNTY: 0.1 RTC] Share your contributor motivation",
+            "html_url": "https://github.com/Scottcjn/rustchain-bounties/issues/16863",
+            "state": "open",
+            "labels": [{"name": "bounty"}, {"name": "micro"}],
+            "body": "",
+        }
+
+        b = self._parse(issue)
+
+        assert b is not None
+        assert b.reward_rtc == 0.1
+
     def test_parse_pr_is_skipped(self):
         issue = {
             "number": 99,


### PR DESCRIPTION
## Summary

- parse decimal RTC values in bounty issue titles without dropping the integer portion
- retain the existing behavior for integer rewards
- add a regression for the live `0.1 RTC` micro-bounty title

Closes #8374.

## Reproduction before the fix

Parsing the current registered bounty title from `rustchain-bounties#16863`:

```text
[MICRO-BOUNTY: 0.1 RTC] Why did you choose to work on an Elyan Labs repo?
```

returned `reward_rtc == 1.0`. The integer-only regex began its match after `0.` and treated the fractional digit as a whole RTC amount.

## Verification

- `python -m pytest -q rustchain-bounties-mcp/tests` → **43 passed**
- exact-title parser smoke test → **0.1 RTC**
- `git diff --check` → passed

Environment: macOS 26.0.1 arm64, Python 3.14.0.

AI assistance was used for source inspection, duplicate checking, reproduction, implementation, testing, and PR formatting. This is a non-security parsing fix; no production mutation was performed.
