### PR TITLE
fix(miner): mask hardware serial in startup banner (#8368)

### DIFF
--- a/miners/linux/rustchain_linux_miner.py
+++ b/miners/linux/rustchain_linux_miner.py
@@ -300,7 +300,8 @@ class LocalMiner:
         print("="*70)
         print(f"Node: {self.node_url}")
         print(f"Wallet: {self.wallet}")
-        print(f"Serial: {self.serial}")
+        serial_display = f"***{self.serial[-4:]}" if self.serial and len(self.serial) >= 4 else "***(hidden)"
+        print(f"Serial: {serial_display}")
         platform_warning = _linux_miner_platform_warning(platform.system())
         if platform_warning:
             print(f"[WARN] {platform_warning}")


### PR DESCRIPTION
## Summary

`miners/linux/rustchain_linux_miner.py` printed the machine's **full hardware serial** to stdout in the `LocalMiner` startup banner (incl. `--dry-run`), leaking a persistent device identifier into otherwise-shareable diagnostic output (RustChain #8368).

## Root cause

`LocalMiner.__init__` does `print(f"Serial: {self.serial}")` unconditionally. The serial is still required internally for RIP-PoA hardware binding, so the fix masks only the console output, not the collection.

## Fix

- Banner now prints a masked serial: `***<last 4 chars>` (or `***(hidden)` when unavailable).
- `self.serial` is untouched — binding payloads at the existing call sites still use the real value.
- Privacy/data-minimization win; no behavior change to mining or binding.

## Verification

- Single-line print change; `self.serial = get_hardware_serial()` and all binding payloads preserved.
- No fund-safety impact (issue confirms this is privacy, not fund-safety).