### PR TITLE
fix(sdk): align python sdk rtc address derivation with node specification

### DIFF
--- a/sdk/python/rustchain_sdk/wallet.py
+++ b/sdk/python/rustchain_sdk/wallet.py
@@ -329,12 +329,8 @@ class RustChainWallet:
         # Derive public key (always real Ed25519; raises if cryptography missing)
         pubkey = cls._derive_public_key(private_key)
 
-        # Hash public key to get address
-        addr_hash = _sha256d(b"address" + pubkey)
-        addr_bytes = addr_hash[:20]
-
-        # Format as RTC + hex
-        return cls.ADDRESS_PREFIX + addr_bytes.hex()
+        # Hash public key to get address: RTC + SHA256(pubkey).hexdigest()[:40]
+        return cls.ADDRESS_PREFIX + hashlib.sha256(pubkey).hexdigest()[:40]
 
     @classmethod
     def from_seed_phrase(cls, words: List[str]) -> "RustChainWallet":

--- a/tests/test_wallet_address.py
+++ b/tests/test_wallet_address.py
@@ -1,0 +1,35 @@
+"""
+Tests for RustChain Python SDK Wallet address generation and signing.
+"""
+
+import hashlib
+import unittest
+from rustchain_sdk.wallet import RustChainWallet
+
+
+class TestWalletAddressDerivation(unittest.TestCase):
+    def test_address_matches_node_derivation(self):
+        """
+        Verify that Python SDK wallet address matches node address_from_pubkey derivation:
+        Node derivation rule: "RTC" + SHA256(pubkey).hexdigest()[:40]
+        """
+        wallet = RustChainWallet.create()
+        pubkey_bytes = bytes.fromhex(wallet.public_key_hex)
+        expected_node_address = "RTC" + hashlib.sha256(pubkey_bytes).hexdigest()[:40]
+
+        self.assertEqual(
+            wallet.address,
+            expected_node_address,
+            f"SDK address {wallet.address} does not match node expected derivation {expected_node_address}"
+        )
+        self.assertEqual(len(wallet.address), 43)  # 'RTC' (3) + 40 hex chars = 43 chars
+        self.assertTrue(wallet.address.startswith("RTC"))
+
+    def test_rfc8032_known_vector_address(self):
+        pubkey = bytes.fromhex("d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a")
+        expected_address = "RTC" + hashlib.sha256(pubkey).hexdigest()[:40]
+        self.assertEqual(expected_address, "RTC21fe31dfa154a261626bf854046fd2271b7bed4b")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary
Fixes #8379. Aligns the Python SDK wallet address derivation logic with the RustChain node specification (`RTC` + `SHA256(pubkey)[:40]`).

### Changes Made
- Updated `RustChainWallet._generate_address` in `sdk/python/rustchain_sdk/wallet.py` to use single SHA-256 hash formatting instead of the legacy double-SHA256 prefix method.
- Added comprehensive unit tests in `tests/test_wallet_address.py` covering node rule consistency and RFC 8032 test vectors.

### Verification & Testing
- Ran unit tests:
  ```bash
  PYTHONPATH=sdk/python python3 tests/test_wallet_address.py
  ```
  Result: `Ran 2 tests in 0.022s ... OK`