### PR TITLE
anti-VM: require explicit True in _fingerprint_check_passed (close score forge)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2582,7 +2582,12 @@ def _fingerprint_check_passed(check_entry) -> bool:
     if isinstance(check_entry, bool):
         return check_entry
     if isinstance(check_entry, dict):
-        return bool(check_entry.get("passed", True))
+        # SECURITY (anti-VM): require an EXPLICIT boolean True. The old
+        # bool(check_entry.get("passed", True)) let an empty {} default to pass and a
+        # truthy string ("false") pass -- so a VM could forge a perfect score by
+        # submitting {name: {} for name in active_checks}. A missing / non-True
+        # "passed" now fails. (Legit clients always send an explicit bool.)
+        return check_entry.get("passed") is True
     return False
 
 


### PR DESCRIPTION
## Summary
GPT-6 Astra audit (source-verified) found the RIP-PoA anti-VM fingerprinting **spoofable end-to-end** — every gate scores attacker-controlled self-reported JSON. This PR closes the **laziest** hole.

`_fingerprint_check_passed` was `bool(check_entry.get("passed", True))`:
- `{}` → `True` (missing key defaulted to pass)
- `{"passed":"false"}` → `True` (truthy string)

So a VM forges a perfect score with `{name: {} for name in active_checks}` → `fingerprint_passed=True` → full/vintage weight.

**Fix:** require `check_entry.get("passed") is True`. Verified: `{}` and `"false"` now fail; legit `{"passed": true/false}` and bare-bool are correct; **full suite (3,964) green** — inert for honest clients (they always send an explicit bool).

## Scope (honest)
This is a **bar-raiser**, not a sound fix — a VM can still send `{"passed": true}`, and arch is still derived from self-reported brand strings. The **sound fix** (vetted enrollment + capped vintage rewards; thermal probe as a soft confidence signal) is a separate design change, in progress. See the anti-VM spoofability finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbyXP4eiiRYEa8GsQtQPhR