### PR TITLE
Harden withdrawal off-ramp: nonce replay, review-hold race, fee semantics, worker ledger

### DIFF
--- a/node/payout_worker.py
+++ b/node/payout_worker.py
@@ -20,6 +20,7 @@ BATCH_SIZE = 10
 POLL_INTERVAL = 30  # seconds
 MAX_RETRIES = 3
 MOCK_MODE = os.environ.get("RUSTCHAIN_MOCK_MODE", "0") == "1"  # Default: production (False)
+ACCOUNT_UNIT = 1_000_000  # balances.amount_i64 is micro-RTC — must match the node.
 
 
 class ProductionWithdrawalNotConfigured(RuntimeError):
@@ -58,6 +59,55 @@ class PayoutWorker:
                 })
 
             return withdrawals
+
+    @staticmethod
+    def _micro(rtc) -> int:
+        """RTC (float) -> micro-RTC (int), matching the node's int(round(x*UNIT))."""
+        return int(round(float(rtc) * ACCOUNT_UNIT))
+
+    @staticmethod
+    def _balance_columns(conn) -> set:
+        return {row[1] for row in conn.execute("PRAGMA table_info(balances)").fetchall()}
+
+    def _credit_balance_micro(self, conn, wallet_id: str, delta_i64: int) -> None:
+        """Credit ``delta_i64`` micro-RTC to the canonical `balances` ledger, schema-
+        tolerant — mirrors the node's _ensure_wallet_balance_row + _apply_wallet_balance_delta
+        so the worker's refund lands in the SAME ledger the node debited at request time
+        (the old code used a non-existent `accounts` table). Must run inside the caller's
+        BEGIN IMMEDIATE transaction.
+        """
+        cols = self._balance_columns(conn)
+        if {"miner_id", "amount_i64"}.issubset(cols):
+            if "balance_rtc" in cols:
+                conn.execute(
+                    "INSERT OR IGNORE INTO balances (miner_id, amount_i64, balance_rtc) VALUES (?, 0, 0)",
+                    (wallet_id,),
+                )
+                conn.execute(
+                    "UPDATE balances SET amount_i64 = amount_i64 + ?, "
+                    "balance_rtc = (amount_i64 + ?) / 1000000.0 WHERE miner_id = ?",
+                    (delta_i64, delta_i64, wallet_id),
+                )
+            else:
+                conn.execute(
+                    "INSERT OR IGNORE INTO balances (miner_id, amount_i64) VALUES (?, 0)",
+                    (wallet_id,),
+                )
+                conn.execute(
+                    "UPDATE balances SET amount_i64 = amount_i64 + ? WHERE miner_id = ?",
+                    (delta_i64, wallet_id),
+                )
+            return
+        delta_rtc = delta_i64 / ACCOUNT_UNIT
+        if {"miner_pk", "balance_rtc"}.issubset(cols):
+            conn.execute("INSERT OR IGNORE INTO balances (miner_pk, balance_rtc) VALUES (?, 0)", (wallet_id,))
+            conn.execute("UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk = ?", (delta_rtc, wallet_id))
+            return
+        if {"miner_id", "balance_rtc"}.issubset(cols):
+            conn.execute("INSERT OR IGNORE INTO balances (miner_id, balance_rtc) VALUES (?, 0)", (wallet_id,))
+            conn.execute("UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_id = ?", (delta_rtc, wallet_id))
+            return
+        raise RuntimeError("unsupported balances schema for withdrawal refund")
 
     def _record_broadcast_reconciliation_needed(
         self,
@@ -164,10 +214,21 @@ class PayoutWorker:
             )
 
     def process_withdrawal(self, withdrawal: Dict) -> bool:
-        """Process a single withdrawal with balance deduction before execution."""
+        """Claim an already-debited withdrawal, broadcast it, and complete it —
+        or refund the request-time debit on pre-broadcast failure.
+
+        LEDGER CORRECTNESS (#2): the RTC balance was ALREADY debited (amount + fee)
+        from the canonical `balances` ledger at REQUEST time by the node's /withdraw
+        endpoint (see _debit_wallet_atomic there). This worker must therefore NOT
+        debit again. The old code debited a second time here against a NON-EXISTENT
+        `accounts` table — a latent double-debit against a phantom ledger (masked
+        only because production broadcast is stubbed). The worker's sole money
+        responsibility is to refund the request-time debit back to `balances` if the
+        payout fails before it is broadcast.
+        """
         withdrawal_id = withdrawal['withdrawal_id']
         tx_hash = None
-        funds_debited = False
+        claimed = False
 
         try:
             logger.info(f"Processing withdrawal {withdrawal_id}")
@@ -188,10 +249,11 @@ class PayoutWorker:
                 logger.error(f"✗ Withdrawal {withdrawal_id}: {message}")
                 return False
 
-            # ── Atomic balance check + deduction + status update ─────────
-            # All three operations MUST happen in a single transaction so
-            # that a crash between them cannot leave funds deducted without
-            # a matching withdrawal, or vice-versa.
+            # ── Atomically CLAIM the row (exactly-once) ──────────────────
+            # The request-time debit already reserved the funds, so the only state
+            # this transaction changes is pending -> processing. The rowcount==1
+            # guard makes the claim exactly-once across concurrent workers. No debit
+            # happens here (funds already left `balances` at request time).
             with sqlite3.connect(self.db_path) as conn:
                 conn.execute("BEGIN IMMEDIATE")
                 try:
@@ -214,38 +276,12 @@ class PayoutWorker:
                             current_status,
                         )
                         return False
-
-                    # Check sender has sufficient balance
-                    row = conn.execute(
-                        "SELECT balance FROM accounts WHERE public_key = ?",
-                        (withdrawal['miner_pk'],)
-                    ).fetchone()
-                    current_balance = row[0] if row else 0
-
-                    total_deduction = withdrawal['amount'] + withdrawal.get('fee', 0)
-                    if current_balance < total_deduction:
-                        conn.execute(
-                            "UPDATE withdrawals SET status = 'failed', error_msg = ? "
-                            "WHERE withdrawal_id = ?",
-                            (f"Insufficient balance: have {current_balance}, need {total_deduction}",
-                             withdrawal_id)
-                        )
-                        conn.execute("COMMIT")
-                        logger.error(f"✗ Withdrawal {withdrawal_id}: insufficient balance")
-                        self.stats['failed'] += 1
-                        return False
-
-                    # Deduct balance BEFORE broadcasting transaction
-                    conn.execute(
-                        "UPDATE accounts SET balance = balance - ? WHERE public_key = ?",
-                        (total_deduction, withdrawal['miner_pk'])
-                    )
                     conn.execute("COMMIT")
-                    # The debit is durable only now; the outer handler must not
-                    # refund unless this flag is set, or a COMMIT that raises
-                    # (e.g. SQLITE_BUSY) — which rolls the debit back below —
-                    # would trigger a phantom refund that creates money.
-                    funds_debited = True
+                    # Claim is durable only now. If the COMMIT raised (e.g.
+                    # SQLITE_BUSY) the row was rolled back to 'pending' and claimed
+                    # stays False, so the failure handler leaves it for retry rather
+                    # than refunding funds that were never re-reserved by us.
+                    claimed = True
                 except Exception:
                     conn.execute("ROLLBACK")
                     raise
@@ -283,25 +319,40 @@ class PayoutWorker:
                 self.stats['failed'] += 1
                 return False
 
-            # Mark as failed. Only refund if the debit actually committed:
-            # if the debit transaction was rolled back (funds_debited is False)
-            # the funds never left the account, so crediting them here would
-            # fabricate balance out of thin air.
+            # Pre-broadcast failure (tx_hash is None). Refund the request-time debit
+            # (amount + fee) back to the canonical `balances` ledger and mark the row
+            # failed — atomically and exactly-once. The refund is gated on the
+            # processing -> failed transition succeeding (rowcount == 1), which can
+            # only fire on the row THIS worker claimed, so it cannot double-refund.
+            # If we never claimed the row (claimed is False, e.g. the claim COMMIT
+            # raised), the row is still 'pending' and the funds are still reserved:
+            # leave it untouched for the next poll rather than fabricate a refund.
+            if not claimed:
+                logger.warning(
+                    "Withdrawal %s failed before it was claimed; leaving pending for retry",
+                    withdrawal_id,
+                )
+                self.stats['failed'] += 1
+                return False
+
             with sqlite3.connect(self.db_path) as conn:
                 conn.execute("BEGIN IMMEDIATE")
-                if funds_debited:
-                    conn.execute(
-                        "UPDATE accounts SET balance = balance + ? WHERE public_key = ?",
-                        (withdrawal['amount'] + withdrawal.get('fee', 0),
-                         withdrawal['miner_pk'])
+                try:
+                    marked = conn.execute(
+                        "UPDATE withdrawals SET status = 'failed', error_msg = ? "
+                        "WHERE withdrawal_id = ? AND status = 'processing'",
+                        (str(e), withdrawal_id),
                     )
-                conn.execute("""
-                    UPDATE withdrawals
-                    SET status = 'failed',
-                        error_msg = ?
-                    WHERE withdrawal_id = ?
-                """, (str(e), withdrawal_id))
-                conn.execute("COMMIT")
+                    if marked.rowcount == 1:
+                        refund_micro = (
+                            self._micro(withdrawal['amount'])
+                            + self._micro(withdrawal.get('fee', 0))
+                        )
+                        self._credit_balance_micro(conn, withdrawal['miner_pk'], refund_micro)
+                    conn.execute("COMMIT")
+                except Exception:
+                    conn.execute("ROLLBACK")
+                    raise
 
             self.stats['failed'] += 1
             return False

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8503,6 +8503,20 @@ def request_withdrawal():
     if not all([miner_pk, destination, signature, nonce]):
         return jsonify({"error": "Missing required fields"}), 400
 
+    # SECURITY (nonce replay): the signed message below stringifies the nonce
+    # (f"...:{nonce}"), while the replay-dedup key is stored in withdrawal_nonces
+    # as TEXT. Those two representations must never diverge, or ONE signature can
+    # satisfy TWO distinct dedup keys and be replayed. Concretely JSON `true`
+    # (Python bool) and the string "True" both render to "True" in the signed
+    # message, but sqlite stores the bool as INTEGER 1 -> TEXT "1" and the string
+    # as "True" -> two rows, one replay. Reject booleans outright and canonicalize
+    # the nonce to exactly its signed string form so the dedup key IS the signed
+    # form. int/str nonces are accepted (backward compatible); str(nonce) is a
+    # no-op on the signed bytes because the f-string already stringifies.
+    if isinstance(nonce, bool) or not isinstance(nonce, (str, int)):
+        return jsonify({"error": "nonce must be a string or integer"}), 400
+    nonce = str(nonce)
+
     # SECURITY: a wallet under review / blocked (wallet_review_holds or the
     # legacy blocked_wallets table) must not be able to move funds out. The
     # same gate already guards /attest/submit, but the fund-EXIT paths never
@@ -8547,6 +8561,31 @@ def request_withdrawal():
             def rollback_json(payload, status):
                 c.rollback()
                 return jsonify(payload), status
+
+            # SECURITY (#3 review-hold TOCTOU): re-check the hold INSIDE the write
+            # transaction, on the reserved write connection, closing the race window
+            # between the pre-BEGIN gate (line ~8513) and the debit below. A flag
+            # applied during that window would otherwise let one last withdrawal
+            # through. The wallet_review_holds / blocked_wallets tables were already
+            # ensured by that pre-check, so this is a plain indexed read (NO DDL — a
+            # CREATE inside BEGIN IMMEDIATE would break the transaction) and uses `c`
+            # itself, so there is no separate-connection lock contention.
+            held = c.execute(
+                "SELECT 1 FROM wallet_review_holds WHERE wallet = ? "
+                "AND status IN ('needs_review','held','escalated','blocked') LIMIT 1",
+                (miner_pk,),
+            ).fetchone()
+            if not held:
+                held = c.execute(
+                    "SELECT 1 FROM blocked_wallets WHERE wallet = ? LIMIT 1",
+                    (miner_pk,),
+                ).fetchone()
+            if held:
+                withdrawal_failed.inc()
+                return rollback_json({
+                    "error": "wallet_under_review",
+                    "message": "This wallet is under review; withdrawal blocked.",
+                }, 409)
 
             # CRITICAL: Check nonce reuse FIRST (replay protection)
             nonce_row = c.execute(
@@ -8690,12 +8729,18 @@ def request_withdrawal():
         balance_gauge.labels(miner_pk=miner_pk).set(remaining_balance)
         withdrawal_queue_size.inc()
 
+    # Fee model (#5): the fee is charged ON TOP of the amount — the wallet is
+    # debited amount + fee (see total_needed_i64 above) and the destination
+    # receives `amount`. The old response reported net_amount = amount - fee,
+    # which contradicted the debit (fee-inclusive vs fee-on-top). Report what is
+    # actually true: total_debited = amount + fee, received = amount.
     return jsonify({
         "withdrawal_id": withdrawal_id,
         "status": "pending",
         "amount": amount,
         "fee": WITHDRAWAL_FEE,
-        "net_amount": amount - WITHDRAWAL_FEE
+        "total_debited": amount + WITHDRAWAL_FEE,
+        "net_amount": amount
     })
 
 

--- a/node/tests/test_payout_worker_ledger.py
+++ b/node/tests/test_payout_worker_ledger.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for the payout-worker ledger correctness fix (#2, 2026-09-10).
+
+The RTC balance is debited (amount + fee) at REQUEST time by the node against the
+canonical `balances` ledger. The worker must therefore:
+  * NOT debit again (the old code debited a phantom `accounts` table = latent
+    double-debit),
+  * on successful broadcast, leave `balances` untouched (already debited),
+  * on pre-broadcast failure, REFUND amount + fee back to `balances`, exactly once.
+"""
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+WORKER_PATH = os.path.join(NODE_DIR, "payout_worker.py")
+
+
+def _load_worker(db_path, mock=True):
+    os.environ["RUSTCHAIN_MOCK_MODE"] = "1" if mock else "0"
+    spec = importlib.util.spec_from_file_location(f"payout_worker_test_{id(db_path)}", WORKER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod.DB_PATH = db_path
+    return mod
+
+
+class TestPayoutWorkerLedger(unittest.TestCase):
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        with sqlite3.connect(self.db_path) as conn:
+            # canonical integer micro-RTC schema
+            conn.execute("CREATE TABLE balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER NOT NULL DEFAULT 0)")
+            conn.execute("""CREATE TABLE withdrawals (withdrawal_id TEXT PRIMARY KEY, miner_pk TEXT NOT NULL,
+                amount REAL NOT NULL, fee REAL NOT NULL, destination TEXT NOT NULL, signature TEXT DEFAULT '',
+                status TEXT DEFAULT 'pending', created_at INTEGER NOT NULL, processed_at INTEGER,
+                tx_hash TEXT, error_msg TEXT)""")
+            # request-time debit already happened: wallet had 100, requested 10 (+0.01 fee) -> 89.99 left
+            conn.execute("INSERT INTO balances VALUES ('minerA', ?)", (int(round(89.99 * 1_000_000)),))
+            conn.execute("""INSERT INTO withdrawals (withdrawal_id, miner_pk, amount, fee, destination, status, created_at)
+                VALUES ('w1', 'minerA', 10.0, 0.01, 'dest', 'pending', ?)""", (int(time.time()),))
+
+    def tearDown(self):
+        os.environ.pop("RUSTCHAIN_MOCK_MODE", None)
+        try:
+            os.unlink(self.db_path)
+        except (FileNotFoundError, PermissionError):
+            pass
+
+    def _balance_micro(self, miner_id="minerA"):
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute("SELECT amount_i64 FROM balances WHERE miner_id=?", (miner_id,)).fetchone()
+        return row[0] if row else None
+
+    def _status(self, wid="w1"):
+        with sqlite3.connect(self.db_path) as conn:
+            return conn.execute("SELECT status FROM withdrawals WHERE withdrawal_id=?", (wid,)).fetchone()[0]
+
+    def test_worker_does_not_have_accounts_table_reference(self):
+        """The phantom `accounts` table must not be queried anywhere in the worker."""
+        src = open(WORKER_PATH).read()
+        # allow the word only inside comments; assert no SQL touches it
+        for kw in ("FROM accounts", "UPDATE accounts", "INTO accounts"):
+            self.assertNotIn(kw, src, f"worker still references phantom table via {kw!r}")
+
+    def test_successful_payout_does_not_double_debit(self):
+        """On success the worker must leave `balances` exactly as the request-time
+        debit left it (89.99) — no second deduction."""
+        mod = _load_worker(self.db_path, mock=True)
+        worker = mod.PayoutWorker()
+        worker.execute_withdrawal = lambda w: "0xdeadbeef"  # force a successful broadcast
+        ok = worker.process_withdrawal({
+            "withdrawal_id": "w1", "miner_pk": "minerA", "amount": 10.0, "fee": 0.01, "destination": "dest",
+        })
+        self.assertTrue(ok)
+        self.assertEqual(self._status(), "completed")
+        self.assertEqual(self._balance_micro(), int(round(89.99 * 1_000_000)))  # unchanged by worker
+
+    def test_pre_broadcast_failure_refunds_to_balances(self):
+        """If broadcast fails before a tx hash, the request-time debit (amount+fee)
+        is refunded to `balances`, and the row is marked failed."""
+        mod = _load_worker(self.db_path, mock=True)
+        worker = mod.PayoutWorker()
+
+        def boom(_w):
+            raise RuntimeError("broadcast down")
+
+        worker.execute_withdrawal = boom
+        ok = worker.process_withdrawal({
+            "withdrawal_id": "w1", "miner_pk": "minerA", "amount": 10.0, "fee": 0.01, "destination": "dest",
+        })
+        self.assertFalse(ok)
+        self.assertEqual(self._status(), "failed")
+        # 89.99 + refund(10.01) == 100.00
+        self.assertEqual(self._balance_micro(), int(round(100.0 * 1_000_000)))
+
+    def test_refund_is_exactly_once(self):
+        """A second process attempt on an already-failed row must not refund again."""
+        mod = _load_worker(self.db_path, mock=True)
+        worker = mod.PayoutWorker()
+        worker.execute_withdrawal = lambda _w: (_ for _ in ()).throw(RuntimeError("down"))
+        worker.process_withdrawal({"withdrawal_id": "w1", "miner_pk": "minerA", "amount": 10.0, "fee": 0.01, "destination": "dest"})
+        after_first = self._balance_micro()
+        # row is now 'failed'; a re-attempt can't re-claim (WHERE status='pending') -> no refund
+        worker.process_withdrawal({"withdrawal_id": "w1", "miner_pk": "minerA", "amount": 10.0, "fee": 0.01, "destination": "dest"})
+        self.assertEqual(self._balance_micro(), after_first)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/node/tests/test_payout_worker_recovery.py
+++ b/node/tests/test_payout_worker_recovery.py
@@ -195,7 +195,11 @@ def test_reconcile_broadcast_withdrawals_preserves_unknown_tx_hash(tmp_path):
     assert error_msg == "manual reconciliation required"
 
 
-def test_process_withdrawal_claims_pending_row_once_before_debit(tmp_path, monkeypatch):
+def test_process_withdrawal_claims_pending_row_exactly_once_without_debiting(tmp_path, monkeypatch):
+    # The RTC balance is debited (amount + fee) at REQUEST time by the node against
+    # the `balances` ledger. The worker must NOT debit again here — the old worker
+    # debited a phantom `accounts` table (a latent double-debit). This test proves
+    # the exactly-once CLAIM still holds AND that the worker leaves balances alone.
     db_path = tmp_path / "payout.db"
     with sqlite3.connect(db_path) as conn:
         _create_schema(conn)
@@ -240,6 +244,6 @@ def test_process_withdrawal_claims_pending_row_once_before_debit(tmp_path, monke
         ).fetchone()
 
     assert broadcasts == ["wd-1"]
-    assert balance == 89.0
+    assert balance == 100.0  # worker does NOT debit — request-time debit is authoritative
     assert status == "completed"
     assert tx_hash == "tx-1"

--- a/node/tests/test_withdrawal_nonce_replay_and_fee.py
+++ b/node/tests/test_withdrawal_nonce_replay_and_fee.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for the withdrawal off-ramp audit (2026-09-10):
+
+  #1  nonce type-encoding replay — a signature is verified over the STRINGIFIED
+      nonce (f"...:{nonce}") while the dedup key is stored TEXT. JSON bool `true`
+      and the string "True" render identically in the signed message but stored as
+      distinct dedup keys, so one signature could be replayed. Fix: reject bool
+      nonces and canonicalize the nonce to its signed string form, so int 5 and
+      str "5" collapse to the same dedup key.
+
+  #5  fee semantics — the wallet is debited amount + fee (fee on top) and the
+      destination receives `amount`; the response must report that, not the old
+      contradictory net_amount = amount - fee.
+"""
+import base64
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+class TestWithdrawalNonceReplayAndFee(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_db = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_admin = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._tmp.name, "import.db")
+        os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+        spec = importlib.util.spec_from_file_location("rc_nonce_fee_test", MODULE_PATH)
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+
+    @classmethod
+    def tearDownClass(cls):
+        for k, v in (("RUSTCHAIN_DB_PATH", cls._prev_db), ("RC_ADMIN_KEY", cls._prev_admin)):
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        try:
+            cls._tmp.cleanup()
+        except OSError:
+            pass
+
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.mod.DB_PATH = self.db_path
+        self._orig_verify = self.mod.verify_sr25519_signature
+        self.mod.verify_sr25519_signature = lambda *_a, **_k: True
+        self._create_schema()
+
+    def tearDown(self):
+        self.mod.verify_sr25519_signature = self._orig_verify
+        try:
+            os.unlink(self.db_path)
+        except (FileNotFoundError, PermissionError):
+            pass
+
+    def _create_schema(self):
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("CREATE TABLE balances (miner_pk TEXT PRIMARY KEY, balance_rtc REAL NOT NULL DEFAULT 0)")
+            conn.execute("CREATE TABLE withdrawal_nonces (miner_pk TEXT NOT NULL, nonce TEXT NOT NULL, used_at INTEGER NOT NULL, PRIMARY KEY (miner_pk, nonce))")
+            conn.execute("CREATE TABLE withdrawal_limits (miner_pk TEXT NOT NULL, date TEXT NOT NULL, total_withdrawn REAL DEFAULT 0, PRIMARY KEY (miner_pk, date))")
+            conn.execute("CREATE TABLE miner_keys (miner_pk TEXT PRIMARY KEY, pubkey_sr25519 TEXT NOT NULL, registered_at INTEGER NOT NULL)")
+            conn.execute("""CREATE TABLE withdrawals (withdrawal_id TEXT PRIMARY KEY, miner_pk TEXT NOT NULL,
+                amount REAL NOT NULL, fee REAL NOT NULL, destination TEXT NOT NULL, signature TEXT NOT NULL,
+                status TEXT DEFAULT 'pending', created_at INTEGER NOT NULL)""")
+            conn.execute("""CREATE TABLE fee_events (id INTEGER PRIMARY KEY AUTOINCREMENT, source TEXT NOT NULL,
+                source_id TEXT, miner_pk TEXT, fee_rtc REAL NOT NULL, fee_urtc INTEGER NOT NULL,
+                destination TEXT NOT NULL, created_at INTEGER NOT NULL)""")
+            conn.execute("INSERT INTO balances VALUES ('miner-test', 100.0)")
+            conn.execute("INSERT INTO balances VALUES ('founder_community', 0)")
+            conn.execute("INSERT INTO miner_keys VALUES ('miner-test', ?, ?)", ("00" * 32, int(time.time())))
+
+    def _payload(self, nonce, amount=1.0):
+        return {
+            "miner_pk": "miner-test",
+            "amount": amount,
+            "destination": "rtc-destination",
+            "signature": base64.b64encode(b"\x00" * 64).decode("ascii"),
+            "nonce": nonce,
+        }
+
+    def _withdrawals(self):
+        with sqlite3.connect(self.db_path) as conn:
+            return conn.execute("SELECT COUNT(*) FROM withdrawals").fetchone()[0]
+
+    # ---- #1 -------------------------------------------------------------
+    def test_bool_nonce_rejected(self):
+        """A JSON boolean nonce is the replay vector — must be rejected outright."""
+        with self.mod.app.test_client() as client:
+            resp = client.post("/withdraw/request", json=self._payload(True))
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("nonce", resp.get_json().get("error", "").lower())
+        self.assertEqual(self._withdrawals(), 0)
+
+    def test_int_and_str_nonce_share_dedup_key(self):
+        """int 5 and str "5" render to the same signed form; the second must be a
+        replay, not a second payout (canonicalization closes the divergence)."""
+        with self.mod.app.test_client() as client:
+            first = client.post("/withdraw/request", json=self._payload("5"))
+            self.assertEqual(first.status_code, 200)
+            second = client.post("/withdraw/request", json=self._payload(5))  # int, same signed form
+        self.assertEqual(second.status_code, 400)
+        self.assertIn("replay", second.get_json().get("error", "").lower())
+        self.assertEqual(self._withdrawals(), 1)  # exactly one payout queued
+
+    # ---- #5 -------------------------------------------------------------
+    def test_fee_semantics_response_matches_debit(self):
+        """Fee is charged on top: debit = amount + fee, destination receives amount.
+        Response must report net_amount = amount (not the old amount - fee)."""
+        with self.mod.app.test_client() as client:
+            resp = client.post("/withdraw/request", json=self._payload("n-fee", amount=10.0))
+        self.assertEqual(resp.status_code, 200)
+        body = resp.get_json()
+        fee = self.mod.WITHDRAWAL_FEE
+        self.assertAlmostEqual(body["net_amount"], 10.0, places=6)
+        self.assertAlmostEqual(body["total_debited"], 10.0 + fee, places=6)
+        with sqlite3.connect(self.db_path) as conn:
+            bal = conn.execute("SELECT balance_rtc FROM balances WHERE miner_pk='miner-test'").fetchone()[0]
+        self.assertAlmostEqual(bal, 100.0 - (10.0 + fee), places=6)  # debited amount + fee
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
GPT-6 Astra audit of the RTC **withdrawal off-ramp** (funds *leaving* the chain), every finding source-verified against `origin/main`. The visible request-time debit path was already sound (`BEGIN IMMEDIATE`, guarded atomic debit, finite/positive/precision checks, bool amount rejected) — these close the seams around it.

### #1 — Nonce type-encoding replay (`request_withdrawal`)
The signature is verified over the **stringified** nonce (`f"...:{nonce}"`) while the replay-dedup key is stored `TEXT` in `withdrawal_nonces`. JSON `true` (Python `bool`) and the string `"True"` render identically in the signed message, but SQLite stores the bool as `INTEGER 1 → TEXT "1"` and the string as `"True"` → **two distinct dedup keys, one signature replayable once**. Bounded (destination is inside the signed message, so no redirection — griefing / double-*process*, not theft). **Fix:** reject `bool` nonces and canonicalize to the signed string form, so `int 5` and `"5"` collapse to a single dedup key.

### #2 — Payout worker ledger mismatch + latent double-debit (`payout_worker.py`)
The node debits the canonical `balances` ledger (amount + fee) at **request** time; the worker debited a **non-existent `accounts` table** again at **send** time — a latent double-debit against a phantom ledger, masked only because production broadcast is stubbed to refuse. **Fix:** removed the send-time debit (claim-only, exactly-once via the `pending→processing` rowcount gate); refund-on-pre-broadcast-failure now credits `balances` (schema-tolerant, mirroring the node's `_apply_wallet_balance_delta`) exactly once, gated on the `processing→failed` transition; a failure before the claim leaves the row `pending` for retry rather than fabricating a refund.

### #3 — Review-hold TOCTOU (`request_withdrawal`)
The pre-`BEGIN` review gate left a race window before the debit. **Fix:** added an in-transaction re-check on the reserved write connection (plain indexed read on `wallet_review_holds`/`blocked_wallets`, **no DDL** — tables already ensured by the pre-check), closing the window with no separate-connection lock contention.

### #5 — Fee semantics
Fee is charged **on top** (debit = amount + fee; destination receives `amount`), but the response reported `net_amount = amount - fee`, contradicting the debit. **Fix:** report `net_amount = amount` and add `total_debited = amount + fee`.

### Tests
- New `test_withdrawal_nonce_replay_and_fee.py` (bool rejected; int/str share dedup key; fee response matches debit).
- New `test_payout_worker_ledger.py` (no `accounts` reference; success doesn't double-debit; pre-broadcast failure refunds to `balances`; refund exactly-once).
- Updated `test_payout_worker_recovery.py` — its last case asserted the old phantom-`accounts` double-debit (100→89); now asserts the worker leaves `balances` untouched, keeping the exactly-once-claim coverage.

Targeted withdrawal + payout suite: **39 passed**. The wider node suite has 102 pre-existing isolation/ordering failures **identical on `origin/main`** (each passes in isolation), unrelated to this change.

⚠️ **Not deployed** — live money-movement consensus code; holding for review + explicit deploy approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbyXP4eiiRYEa8GsQtQPhR