### PR TITLE
Add POCO F6 Termux miner to Green Tracker

### DIFF
--- a/community/machines/zaguzovmaksim0-hue-poco-f6.json
+++ b/community/machines/zaguzovmaksim0-hue-poco-f6.json
@@ -1,0 +1,21 @@
+{
+  "machine_name": "zaguzovmaksim0-hue POCO F6",
+  "model": "POCO F6 (2024)",
+  "model_identifier": "24069PC21G / peridot",
+  "year_manufactured": 2024,
+  "architecture": "ARM64 / aarch64 (Qualcomm SM8635)",
+  "cpu_cores": "8 (Cortex-A520 detected by RustChain miner)",
+  "memory_gb": 11,
+  "power_draw_watts": 8,
+  "usage": [
+    "RustChain miner on Android/Termux",
+    "PPA hardware fingerprint testing",
+    "AI coding and bounty automation",
+    "local development"
+  ],
+  "description": "POCO F6 Android phone kept in active compute use for RustChain mining, PPA fingerprint testing, AI coding, and bounty automation through Termux. The RustChain miner detects ARM/aarch64 and Cortex-A520, the current six fingerprint checks pass, and the live node accepted its attestation under the native RTC wallet. The 8 W power figure is a rough active-phone estimate rather than a wall-meter measurement.",
+  "wallet_name": "zaguzovmaksim0-hue",
+  "wallet_address": "RTC9190307a061e45c69134f4cabd55704599337161",
+  "contributor": "zaguzovmaksim0-hue",
+  "added_date": "2026-09-11"
+}


### PR DESCRIPTION
Refs Scottcjn/rustchain-bounties#2218.

Adds one community machine record for my physical POCO F6 (`24069PC21G` / `peridot`, ARM64 / SM8635) that is now running the RustChain miner under a native RTC wallet.

Evidence checked before submission:
- Android reports market name `POCO F6`, device `peridot`, SoC `SM8635`
- miner detects Cortex-A520 / aarch64, 8 cores, 11 GB memory
- current six PPA fingerprint checks pass
- live RustChain `/api/miners` accepted the same native wallet/ARM attestation

The 8 W field is explicitly described as a rough active-phone estimate, not a wall-meter measurement. No photo bonus is claimed.

Validation: JSON parse/schema-presence check and `git diff --check`. AI assistance disclosed; the hardware and live-miner observations were taken from the actual phone.