### PR TITLE
Fix Linux miner balance lookup to use reward wallet

### DIFF
--- a/miners/linux/rustchain_linux_miner.py
+++ b/miners/linux/rustchain_linux_miner.py
@@ -823,7 +823,7 @@ class LocalMiner:
             resp = self._get(
                 "/wallet/balance",
                 "checking wallet balance",
-                params={"miner_id": self._miner_id()},
+                params={"miner_id": self.wallet},
                 timeout=10,
                 verify=TLS_VERIFY,
             )

--- a/tests/test_miner_balance_endpoints.py
+++ b/tests/test_miner_balance_endpoints.py
@@ -48,7 +48,7 @@ def test_linux_miner_balance_uses_current_wallet_endpoint(monkeypatch):
     assert miner.check_balance() == 2.5
     assert calls[0][0] == "/wallet/balance"
     assert calls[0][1] == "checking wallet balance"
-    assert calls[0][2]["params"] == {"miner_id": "x86_64-test-host"}
+    assert calls[0][2]["params"] == {"miner_id": "RTC-test-wallet"}
 
 
 def test_power8_miner_balance_uses_current_wallet_endpoint(monkeypatch):


### PR DESCRIPTION
Fixes #8391.

The Linux miner displays balance after mining by calling `/wallet/balance` with the hardware-derived `_miner_id()` (for example `aarch64-localhost`) rather than the configured signed wallet that actually receives rewards. On my live physical ARM miner the wallet had 0.5 RTC while the hardware id had 0, and the CLI printed `Balance: 0.0 RTC`.

This changes only the balance lookup parameter to `self.wallet` and updates the focused regression test. Hardware miner_id remains unchanged for attestation/enrollment metadata.

Validation:
- `PYTHONPATH=miners/linux:. python3 -m pytest -q tests/test_miner_balance_endpoints.py tests/test_linux_miner_identity.py`
- `python3 -m py_compile miners/linux/rustchain_linux_miner.py tests/test_miner_balance_endpoints.py`
- `git diff --check`

AI assistance was used; the bug was reproduced against the live read-only balance endpoint and a real running miner before the patch.