### PR TITLE
fix(utxo): require admin key for rollback_genesis (bounty #2819)

### DIFF
--- a/node/test_genesis_race.py
+++ b/node/test_genesis_race.py
@@ -20,6 +20,10 @@ import threading
 import time
 import sqlite3
 
+# rollback_genesis() is a destructive state mutation and now requires an
+# admin key (bounty #2819). This demo script configures a test key.
+os.environ["RC_ADMIN_KEY"] = "demo-rollback-admin-key-2819"
+
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
@@ -144,7 +148,7 @@ def test_genesis_migration_rollback():
         migrate(db_path, dry_run=False)
         
         # Rollback
-        deleted = rollback_genesis(db_path)
+        deleted = rollback_genesis(db_path, admin_key="demo-rollback-admin-key-2819")
         
         # Verify rollback
         conn = sqlite3.connect(db_path)

--- a/node/test_rollback_atomicity.py
+++ b/node/test_rollback_atomicity.py
@@ -33,9 +33,14 @@ class TestRollbackAtomicity(unittest.TestCase):
     """Test rollback atomicity and re-run safety."""
 
     def setUp(self):
-        """Create a temporary database with test balances."""
+        """Create a temporary database with test data."""
         self.tmpdir = tempfile.mkdtemp()
         self.db_path = os.path.join(self.tmpdir, "test_rollback.db")
+
+        # rollback_genesis() is a destructive state mutation and now requires
+        # an admin key (bounty #2819). Configure a test key for this suite.
+        self.admin_key = "test-rollback-admin-key-2819"
+        os.environ["RC_ADMIN_KEY"] = self.admin_key
 
         # Create balances table with test data
         conn = sqlite3.connect(self.db_path)
@@ -60,6 +65,7 @@ class TestRollbackAtomicity(unittest.TestCase):
 
     def tearDown(self):
         """Clean up temporary database."""
+        os.environ.pop("RC_ADMIN_KEY", None)
         if os.path.exists(self.db_path):
             os.unlink(self.db_path)
         # Remove WAL and SHM files
@@ -138,7 +144,7 @@ class TestRollbackAtomicity(unittest.TestCase):
         migrate(self.db_path, dry_run=False)
 
         # Then rollback
-        deleted = rollback_genesis(self.db_path)
+        deleted = rollback_genesis(self.db_path, admin_key=self.admin_key)
         self.assertEqual(deleted, 3)
 
         # Verify no genesis boxes remain
@@ -161,11 +167,11 @@ class TestRollbackAtomicity(unittest.TestCase):
         UtxoDB(self.db_path).init_tables()
 
         # Rollback on empty DB should not raise
-        deleted = rollback_genesis(self.db_path)
+        deleted = rollback_genesis(self.db_path, admin_key=self.admin_key)
         self.assertEqual(deleted, 0)
 
         # Second rollback should also be safe
-        deleted = rollback_genesis(self.db_path)
+        deleted = rollback_genesis(self.db_path, admin_key=self.admin_key)
         self.assertEqual(deleted, 0)
 
     def test_04_rerun_after_rollback(self):
@@ -175,7 +181,7 @@ class TestRollbackAtomicity(unittest.TestCase):
         self.assertEqual(result1['boxes_created'], 3)
 
         # Rollback
-        rollback_genesis(self.db_path)
+        rollback_genesis(self.db_path, admin_key=self.admin_key)
 
         # Re-migrate should succeed (not fail due to partial state)
         result2 = migrate(self.db_path, dry_run=False)
@@ -209,7 +215,7 @@ class TestRollbackAtomicity(unittest.TestCase):
             self.assertEqual(tx_count, 3)
 
             # Perform rollback
-            rollback_genesis(self.db_path)
+            rollback_genesis(self.db_path, admin_key=self.admin_key)
 
             # Verify BOTH boxes and transactions are gone (atomic)
             box_count_after = conn.execute(
@@ -233,7 +239,7 @@ class TestRollbackAtomicity(unittest.TestCase):
         # - PRAGMA foreign_keys=ON
         # We verify by checking the DB state after rollback
         migrate(self.db_path, dry_run=False)
-        rollback_genesis(self.db_path)
+        rollback_genesis(self.db_path, admin_key=self.admin_key)
 
         # Verify WAL mode is active
         conn = sqlite3.connect(self.db_path)
@@ -249,7 +255,7 @@ class TestRollbackAtomicity(unittest.TestCase):
 
         self.assertFalse(check_existing_genesis(UtxoDB(self.db_path)))
 
-        deleted = rollback_genesis(self.db_path)
+        deleted = rollback_genesis(self.db_path, admin_key=self.admin_key)
         self.assertEqual(deleted, 0)
 
         conn = UtxoDB(self.db_path)._conn()
@@ -414,7 +420,7 @@ class TestRollbackAtomicity(unittest.TestCase):
             conn.close()
 
         with self.assertRaisesRegex(RuntimeError, "non-genesis UTXO state"):
-            rollback_genesis(self.db_path)
+            rollback_genesis(self.db_path, admin_key=self.admin_key)
 
         conn = UtxoDB(self.db_path)._conn()
         try:

--- a/node/test_utxo_2819_rollback_mempool_and_bounded_select.py
+++ b/node/test_utxo_2819_rollback_mempool_and_bounded_select.py
@@ -40,6 +40,10 @@ class TestRollbackEvictsMempoolClaims(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
         self.db_path = os.path.join(self.tmpdir, "rollback_mempool.db")
+        # rollback_genesis() is a destructive state mutation and now requires
+        # an admin key (bounty #2819). Configure a test key for this suite.
+        self.admin_key = "test-rollback-admin-key-2819"
+        os.environ["RC_ADMIN_KEY"] = self.admin_key
         conn = sqlite3.connect(self.db_path)
         conn.execute(
             """CREATE TABLE IF NOT EXISTS balances (
@@ -56,6 +60,7 @@ class TestRollbackEvictsMempoolClaims(unittest.TestCase):
         self.db = UtxoDB(self.db_path)
 
     def tearDown(self):
+        os.environ.pop("RC_ADMIN_KEY", None)
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def _genesis_box_id(self):
@@ -83,7 +88,7 @@ class TestRollbackEvictsMempoolClaims(unittest.TestCase):
             "precondition: the box is claimed while the tx is pending",
         )
 
-        rollback_genesis(self.db_path)
+        rollback_genesis(self.db_path, admin_key=self.admin_key)
 
         self.assertFalse(
             self.db.mempool_check_double_spend(box_id),
@@ -142,8 +147,9 @@ class TestRollbackEvictsMempoolClaims(unittest.TestCase):
         )
 
         # Non-genesis UTXO state exists, so rollback is expected to refuse.
+        # Auth is satisfied first; the refusal is the non-genesis guard.
         with self.assertRaises(RuntimeError):
-            rollback_genesis(self.db_path)
+            rollback_genesis(self.db_path, admin_key=self.admin_key)
 
         # And having refused, it must not have evicted anything.
         self.assertTrue(self.db.mempool_check_double_spend(genesis_box))

--- a/node/utxo_genesis_migration.py
+++ b/node/utxo_genesis_migration.py
@@ -19,15 +19,65 @@ Rules:
 import argparse
 from decimal import Decimal, InvalidOperation
 import hashlib
+import hmac
 import json
+import os
 import sqlite3
 import sys
 import time
 from pathlib import Path
+from typing import Optional
 
 from utxo_db import (
     UtxoDB, address_to_proposition, compute_box_id, UNIT,
 )
+
+# ---------------------------------------------------------------------------
+# Rollback authorization (bounty #2819)
+# ---------------------------------------------------------------------------
+
+# rollback_genesis() is a destructive state mutation: it deletes every genesis
+# box and transaction and evicts mempool entries that depend on them. It was
+# reachable with no authorization at all -- a CLI flag or any code path that
+# imported it could wipe the UTXO genesis set and its pending spends.
+#
+# Fail closed: an unset admin key means the operator did not intend rollback to
+# be possible at all, so the call refuses instead of defaulting to open.
+_ROLLBACK_ADMIN_KEY_ENV = "RC_ADMIN_KEY"
+
+
+def _required_rollback_admin_key() -> str:
+    """Return the configured rollback admin key, or '' when none is set."""
+    return os.environ.get(_ROLLBACK_ADMIN_KEY_ENV, "").strip()
+
+
+def _constant_time_key_match(provided: str, required: str) -> bool:
+    try:
+        return hmac.compare_digest(
+            provided.encode("utf-8"),
+            required.encode("utf-8"),
+        )
+    except UnicodeError:
+        return False
+
+
+def _require_rollback_authorization(admin_key: Optional[str]) -> None:
+    """Raise RuntimeError unless *admin_key* matches the configured key.
+
+    - No key configured  -> refuse (fail closed, never default to open).
+    - Missing key arg  -> refuse.
+    - Wrong key         -> refuse (constant-time compare).
+    """
+    required = _required_rollback_admin_key()
+    if not required:
+        raise RuntimeError(
+            "rollback admin key is not configured; refusing unauthenticated "
+            "genesis rollback. Set RC_ADMIN_KEY to enable it."
+        )
+    if not admin_key or not isinstance(admin_key, str):
+        raise RuntimeError("admin_key is required for genesis rollback")
+    if not _constant_time_key_match(admin_key.strip(), required):
+        raise RuntimeError("genesis rollback unauthorized: invalid admin key")
 
 GENESIS_TX_PREFIX = "rustchain_genesis:"
 GENESIS_HEIGHT = 0
@@ -407,7 +457,7 @@ def migrate(db_path: str, dry_run: bool = False) -> dict:
     return result
 
 
-def rollback_genesis(db_path: str) -> int:
+def rollback_genesis(db_path: str, admin_key: Optional[str] = None) -> int:
     """Remove all genesis boxes and their transactions atomically.
 
     Wrapped in a single BEGIN IMMEDIATE transaction so no partial
@@ -422,7 +472,13 @@ def rollback_genesis(db_path: str) -> int:
     from before the rollback, blocking fresh spends and leaving the old
     transaction eligible for inclusion. Rolling back has to clear pending
     intent as well as state, or it is not a rollback.
+
+    Authorization (bounty #2819): rollback is a destructive state mutation
+    that deletes every genesis box/transaction and evicts pending mempool
+    claims. It was previously reachable unauthenticated, so it now requires
+    an admin key matching RC_ADMIN_KEY. Fail closed: an unset key refuses.
     """
+    _require_rollback_authorization(admin_key)
     utxo_db = UtxoDB(db_path)
     conn = utxo_db._conn()
     try:
@@ -489,10 +545,16 @@ if __name__ == '__main__':
                         help='Preview migration without writing')
     parser.add_argument('--rollback', action='store_true',
                         help='Remove genesis boxes (rollback)')
+    parser.add_argument('--admin-key', default=None,
+                        help='Admin key for rollback (or set RC_ADMIN_KEY)')
     args = parser.parse_args()
 
     if args.rollback:
-        rollback_genesis(args.db)
+        try:
+            rollback_genesis(args.db, admin_key=args.admin_key)
+        except RuntimeError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            sys.exit(1)
     else:
         result = migrate(args.db, dry_run=args.dry_run)
         if 'error' in result:

--- a/tests/test_utxo_security_audit.py
+++ b/tests/test_utxo_security_audit.py
@@ -25,6 +25,10 @@ import unittest
 # Allow importing from node/
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'node'))
 
+# rollback_genesis() is a destructive state mutation and now requires an
+# admin key (bounty #2819). Configure a test key for this suite.
+os.environ["RC_ADMIN_KEY"] = "test-rollback-admin-key-2819"
+
 from utxo_db import (
     UtxoDB, coin_select, compute_box_id, address_to_proposition,
     proposition_to_address, UNIT, DUST_THRESHOLD, MAX_COINBASE_OUTPUT_NRTC,
@@ -600,7 +604,7 @@ class TestGenesisMigrationSafety(unittest.TestCase):
             self.assertEqual(db.get_balance('bob'), 50 * UNIT)
 
             # Rollback
-            deleted = rollback_genesis(tmp.name)
+            deleted = rollback_genesis(tmp.name, admin_key="test-rollback-admin-key-2819")
             self.assertEqual(deleted, 2)
             self.assertEqual(db.get_balance('alice'), 0)
             self.assertEqual(db.get_balance('bob'), 0)
@@ -641,6 +645,86 @@ class TestGenesisMigrationSafety(unittest.TestCase):
 
         finally:
             os.unlink(tmp.name)
+
+
+class TestRollbackAuthorization(unittest.TestCase):
+    """Bounty #2819: rollback_genesis() was an unauthenticated destructive
+    state mutation. It must require an admin key and fail closed."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        self.db = UtxoDB(self.tmp.name)
+        self.db.init_tables()
+        # Pre-create a genesis box so rollback has something to delete.
+        from utxo_genesis_migration import (
+            compute_genesis_tx_id, GENESIS_HEIGHT,
+        )
+        import json
+        conn = self.db._conn()
+        now = int(time.time())
+        tx_id = compute_genesis_tx_id('auth_wallet')
+        prop = address_to_proposition('auth_wallet')
+        box_id = compute_box_id(10 * UNIT, prop, GENESIS_HEIGHT, tx_id, 0)
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            """INSERT INTO utxo_boxes
+               (box_id, value_nrtc, proposition, owner_address,
+                creation_height, transaction_id, output_index,
+                tokens_json, registers_json, created_at)
+               VALUES (?,?,?,?,?,?,?,?,?,?)""",
+            (box_id, 10 * UNIT, prop, 'auth_wallet', GENESIS_HEIGHT,
+             tx_id, 0, '[]', json.dumps({'R4': 'genesis'}), now),
+        )
+        conn.execute(
+            """INSERT INTO utxo_transactions
+               (tx_id, tx_type, inputs_json, outputs_json,
+                data_inputs_json, fee_nrtc, timestamp,
+                block_height, status)
+               VALUES (?,?,?,?,?,?,?,?,?)""",
+            (tx_id, 'genesis', '[]',
+             json.dumps([{'box_id': box_id, 'value_nrtc': 10 * UNIT,
+                          'owner': 'auth_wallet'}]),
+             '[]', 0, now, GENESIS_HEIGHT, 'confirmed'),
+        )
+        conn.execute("COMMIT")
+        conn.close()
+        self.box_id = box_id
+
+    def tearDown(self):
+        os.unlink(self.tmp.name)
+
+    def test_rollback_refuses_when_no_key_configured(self):
+        """Fail closed: an unset RC_ADMIN_KEY must refuse rollback."""
+        from utxo_genesis_migration import rollback_genesis
+        old = os.environ.pop('RC_ADMIN_KEY', None)
+        try:
+            with self.assertRaisesRegex(RuntimeError, "not configured"):
+                rollback_genesis(self.tmp.name, admin_key=None)
+        finally:
+            if old is not None:
+                os.environ['RC_ADMIN_KEY'] = old
+
+    def test_rollback_refuses_wrong_key(self):
+        """A wrong admin key must be rejected (constant-time compare)."""
+        from utxo_genesis_migration import rollback_genesis
+        with self.assertRaisesRegex(RuntimeError, "unauthorized"):
+            rollback_genesis(self.tmp.name, admin_key="wrong-key")
+
+    def test_rollback_refuses_missing_key_arg(self):
+        """An explicit None key must be rejected even when one is configured."""
+        from utxo_genesis_migration import rollback_genesis
+        with self.assertRaisesRegex(RuntimeError, "admin_key is required"):
+            rollback_genesis(self.tmp.name, admin_key=None)
+
+    def test_rollback_succeeds_with_correct_key(self):
+        """The happy path still works once authorized."""
+        from utxo_genesis_migration import rollback_genesis
+        deleted = rollback_genesis(
+            self.tmp.name, admin_key="test-rollback-admin-key-2819"
+        )
+        self.assertEqual(deleted, 1)
+        self.assertIsNone(self.db.get_box(self.box_id))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

ollback_genesis() in \
ode/utxo_genesis_migration.py\ was a destructive state mutation reachable with no authorization. It deletes every genesis box and transaction and evicts pending mempool claims that depend on them. Any code path importing the module, or the \--rollback\ CLI flag, could wipe the UTXO genesis set and its pending spends.

### Fix
- Added \_require_rollback_authorization(admin_key)\ gate keyed on \RC_ADMIN_KEY\:
  - **Fail closed**: an unset key refuses (operator never intended rollback to be possible)
  - Missing key arg refused
  - Wrong key refused via constant-time \hmac.compare_digest\
- \ollback_genesis(db_path, admin_key=None)\ now calls the gate first, before any state mutation
- CLI gained \--admin-key\; unauthenticated rollback exits 1 with a clear error
- Mirrors the existing \gent_relationships.py\ admin-key pattern

### Tests
- Updated \
ode/test_rollback_atomicity.py\, \
ode/test_utxo_2819_rollback_mempool_and_bounded_select.py\, \
ode/test_genesis_race.py\, and \	ests/test_utxo_security_audit.py\ to pass the key
- Added \TestRollbackAuthorization\ (4 cases: no-key refuses, wrong-key refuses, missing-arg refuses, correct-key succeeds)

### Verification
- \	est_rollback_atomicity.py\: 10/10 passed
- \	est_utxo_2819_rollback_mempool_and_bounded_select.py\: 7/7 passed (8 subtests)
- \	ests/test_utxo_security_audit.py\: 28/28 passed (incl. 4 new auth tests)
- \
ode/test_genesis_race.py\: both scenarios pass
- \
ode/test_utxo_db.py\: 107 passed

This finding is distinct from the three existing open #2819 PRs (#8388 receiver-side mirror provenance, #8332 red-team audit report, #8302 fee/output/conservation invariants) — none of them cover the rollback authorization gap.

Co-authored-by: Thamsanqa Skenjana <tahmiix@gmail.com>