### PR TITLE
security(utxo): require canonical RTC recipient on /utxo/transfer (#2819, by @antoleod)

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -126,9 +126,9 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertEqual(r.get_json()['utxo_count'], 1)
 
     def test_boxes_endpoint(self):
-        self._seed_coinbase('bob', 50 * UNIT, height=1)
-        self._seed_coinbase('bob', 30 * UNIT, height=2)
-        r = self.client.get('/utxo/boxes/bob')
+        self._seed_coinbase(('RTC' + 'b' * 40), 50 * UNIT, height=1)
+        self._seed_coinbase(('RTC' + 'b' * 40), 30 * UNIT, height=2)
+        r = self.client.get('/utxo/boxes/RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
         data = r.get_json()
         self.assertEqual(data['count'], 2)
         self.assertEqual(len(data['boxes']), 2)
@@ -136,11 +136,11 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertEqual(values, [30 * UNIT, 50 * UNIT])
 
     def test_boxes_endpoint_is_paginated(self):
-        self._seed_coinbase('bob', 10 * UNIT, height=1)
-        self._seed_coinbase('bob', 20 * UNIT, height=2)
-        self._seed_coinbase('bob', 30 * UNIT, height=3)
+        self._seed_coinbase(('RTC' + 'b' * 40), 10 * UNIT, height=1)
+        self._seed_coinbase(('RTC' + 'b' * 40), 20 * UNIT, height=2)
+        self._seed_coinbase(('RTC' + 'b' * 40), 30 * UNIT, height=3)
 
-        first = self.client.get('/utxo/boxes/bob?limit=2').get_json()
+        first = self.client.get('/utxo/boxes/RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb?limit=2').get_json()
         self.assertEqual(first['count'], 2)
         self.assertTrue(first['has_more'])
         self.assertEqual([box['value_nrtc'] for box in first['boxes']],
@@ -148,7 +148,7 @@ class TestUtxoEndpoints(unittest.TestCase):
 
         cursor = first['next_cursor']
         second = self.client.get(
-            '/utxo/boxes/bob?limit=2&after_value_nrtc={}&after_box_id={}'.format(
+            '/utxo/boxes/RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb?limit=2&after_value_nrtc={}&after_box_id={}'.format(
                 cursor['after_value_nrtc'], cursor['after_box_id']))
         second = second.get_json()
         self.assertEqual(second['count'], 1)
@@ -157,37 +157,37 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertEqual(second['boxes'][0]['value_nrtc'], 30 * UNIT)
 
     def test_boxes_cursor_handles_equal_values(self):
-        self._seed_coinbase('bob', 10 * UNIT, height=1)
-        self._seed_coinbase('bob', 10 * UNIT, height=2)
-        self._seed_coinbase('bob', 10 * UNIT, height=3)
+        self._seed_coinbase(('RTC' + 'b' * 40), 10 * UNIT, height=1)
+        self._seed_coinbase(('RTC' + 'b' * 40), 10 * UNIT, height=2)
+        self._seed_coinbase(('RTC' + 'b' * 40), 10 * UNIT, height=3)
 
-        first = self.client.get('/utxo/boxes/bob?limit=2').get_json()
+        first = self.client.get('/utxo/boxes/RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb?limit=2').get_json()
         cursor = first['next_cursor']
         second = self.client.get(
-            '/utxo/boxes/bob?limit=2&after_value_nrtc={}&after_box_id={}'.format(
+            '/utxo/boxes/RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb?limit=2&after_value_nrtc={}&after_box_id={}'.format(
                 cursor['after_value_nrtc'], cursor['after_box_id'])).get_json()
         ids = [box['box_id'] for box in first['boxes'] + second['boxes']]
         self.assertEqual(len(ids), 3)
         self.assertEqual(len(set(ids)), 3)
 
     def test_boxes_endpoint_rejects_invalid_pagination(self):
-        self.assertEqual(self.client.get('/utxo/boxes/bob?limit=0').status_code, 400)
-        self.assertEqual(self.client.get('/utxo/boxes/bob?limit=501').status_code, 400)
-        self.assertEqual(self.client.get('/utxo/boxes/bob?after_value_nrtc=1').status_code, 400)
-        self.assertEqual(self.client.get('/utxo/boxes/bob?after_box_id=x').status_code, 400)
-        self.assertEqual(self.client.get('/utxo/boxes/bob?limit=nope').status_code, 400)
+        self.assertEqual(self.client.get('/utxo/boxes/RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb?limit=0').status_code, 400)
+        self.assertEqual(self.client.get('/utxo/boxes/RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb?limit=501').status_code, 400)
+        self.assertEqual(self.client.get('/utxo/boxes/RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb?after_value_nrtc=1').status_code, 400)
+        self.assertEqual(self.client.get('/utxo/boxes/RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb?after_box_id=x').status_code, 400)
+        self.assertEqual(self.client.get('/utxo/boxes/RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb?limit=nope').status_code, 400)
 
     def test_boxes_endpoint_rejects_out_of_range_cursor(self):
         # after_value_nrtc past SQLite's signed 64-bit range must be a clean 400,
         # not an OverflowError 500 at parameter binding.
         over = (1 << 63)
         self.assertEqual(
-            self.client.get(f'/utxo/boxes/bob?after_value_nrtc={over}&after_box_id=x').status_code,
+            self.client.get(f'/utxo/boxes/RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb?after_value_nrtc={over}&after_box_id=x').status_code,
             400,
         )
         # The boundary value itself is in range and forms a valid (empty-result) cursor.
         self.assertEqual(
-            self.client.get(f'/utxo/boxes/bob?after_value_nrtc={over - 1}&after_box_id=x').status_code,
+            self.client.get(f'/utxo/boxes/RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb?after_value_nrtc={over - 1}&after_box_id=x').status_code,
             200,
         )
 
@@ -241,7 +241,7 @@ class TestUtxoEndpoints(unittest.TestCase):
                 'box_id': box['box_id'],
                 'spending_proof': 'ab' * 64,
             }],
-            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'outputs': [{'address': ('RTC' + 'b' * 40), 'value_nrtc': 100 * UNIT}],
             'fee_nrtc': 0,
             'timestamp': int(time.time()),
             '_allow_minting': True,
@@ -271,7 +271,7 @@ class TestUtxoEndpoints(unittest.TestCase):
 
         r = self.client.post('/utxo/transfer', json={
             'from_address': 'RTC_test_aabbccdd',
-            'to_address': 'bob',
+            'to_address': ('RTC' + 'b' * 40),
             'amount_rtc': 60.0,
             'public_key': 'aabbccdd' * 8,
             'signature': 'sig' * 22,
@@ -286,7 +286,7 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertGreaterEqual(data['outputs_created'], 1)
 
         # Check balances
-        self.assertEqual(self.utxo_db.get_balance('bob'), 60 * UNIT)
+        self.assertEqual(self.utxo_db.get_balance(('RTC' + 'b' * 40)), 60 * UNIT)
         sender_bal = self.utxo_db.get_balance('RTC_test_aabbccdd')
         self.assertEqual(sender_bal, 40 * UNIT)
 
@@ -313,7 +313,7 @@ class TestUtxoEndpoints(unittest.TestCase):
 
         r = self.client.post('/utxo/transfer', json={
             'from_address': sender,
-            'to_address': 'bob',
+            'to_address': ('RTC' + 'b' * 40),
             'amount_rtc': 10.0,
             'public_key': 'aabbccdd' * 8,
             'signature': 'sig' * 22,
@@ -322,7 +322,7 @@ class TestUtxoEndpoints(unittest.TestCase):
 
         self.assertEqual(r.status_code, 200, r.get_json())
         self.assertEqual(r.get_json()['inputs_consumed'], 1)
-        self.assertEqual(self.utxo_db.get_balance('bob'), 10 * UNIT)
+        self.assertEqual(self.utxo_db.get_balance(('RTC' + 'b' * 40)), 10 * UNIT)
         self.assertEqual(self.utxo_db.get_balance(sender), 41 * UNIT)
         self.assertTrue(self.utxo_db.mempool_check_double_spend(claimed_box['box_id']))
 
@@ -341,7 +341,7 @@ class TestUtxoEndpoints(unittest.TestCase):
 
         r = self.client.post('/utxo/transfer', json={
             'from_address': 'RTC_test_aabbccdd',
-            'to_address': 'bob',
+            'to_address': ('RTC' + 'b' * 40),
             'amount_rtc': 100.0,
             'public_key': 'aabbccdd' * 8,
             'signature': 'sig' * 22,
@@ -354,7 +354,7 @@ class TestUtxoEndpoints(unittest.TestCase):
     def test_transfer_missing_fields(self):
         r = self.client.post('/utxo/transfer', json={
             'from_address': 'alice',
-            'to_address': 'bob',
+            'to_address': ('RTC' + 'b' * 40),
         })
         self.assertEqual(r.status_code, 400)
 
@@ -367,7 +367,7 @@ class TestUtxoEndpoints(unittest.TestCase):
     def test_transfer_zero_amount(self):
         r = self.client.post('/utxo/transfer', json={
             'from_address': 'RTC_test_aabbccdd',
-            'to_address': 'bob',
+            'to_address': ('RTC' + 'b' * 40),
             'amount_rtc': 0,
             'public_key': 'aabbccdd' * 8,
             'signature': 'sig' * 22,
@@ -378,7 +378,7 @@ class TestUtxoEndpoints(unittest.TestCase):
     def test_transfer_pubkey_mismatch(self):
         r = self.client.post('/utxo/transfer', json={
             'from_address': 'wrong_address',
-            'to_address': 'bob',
+            'to_address': ('RTC' + 'b' * 40),
             'amount_rtc': 10.0,
             'public_key': 'aabbccdd' * 8,
             'signature': 'sig' * 22,
@@ -396,7 +396,7 @@ class TestUtxoEndpoints(unittest.TestCase):
             with self.subTest(nonce=bad_nonce):
                 r = self.client.post('/utxo/transfer', json={
                     'from_address': sender,
-                    'to_address': 'bob',
+                    'to_address': ('RTC' + 'b' * 40),
                     'amount_rtc': 10.0,
                     'public_key': 'aabbccdd' * 8,
                     'signature': 'sig' * 22,
@@ -412,7 +412,7 @@ class TestUtxoEndpoints(unittest.TestCase):
 
     def test_transfer_rejects_stale_nonce_after_newer_nonce(self):
         sender = 'RTC_test_aabbccdd'
-        recipient = 'bob'
+        recipient = ('RTC' + 'b' * 40)
         self._seed_coinbase(sender, 100 * UNIT)
 
         first = self.client.post('/utxo/transfer', json={
@@ -462,7 +462,7 @@ class TestUtxoEndpoints(unittest.TestCase):
 
         r = client.post('/utxo/transfer', json={
             'from_address': sender,
-            'to_address': 'bob',
+            'to_address': ('RTC' + 'b' * 40),
             'amount_rtc': 10.0,
             'public_key': 'aabbccdd' * 8,
             'signature': 'sig' * 22,
@@ -475,7 +475,7 @@ class TestUtxoEndpoints(unittest.TestCase):
 
         r = self.client.post('/utxo/transfer', json={
             'from_address': 'RTC_test_aabbccdd',
-            'to_address': 'bob',
+            'to_address': ('RTC' + 'b' * 40),
             'amount_rtc': 90.0,
             'fee_rtc': 1.0,
             'public_key': 'aabbccdd' * 8,
@@ -494,7 +494,7 @@ class TestUtxoEndpoints(unittest.TestCase):
 
         r = self.client.post('/utxo/transfer', json={
             'from_address': sender,
-            'to_address': 'bob',
+            'to_address': ('RTC' + 'b' * 40),
             'amount_rtc': 100.0,
             'public_key': 'aabbccdd' * 8,
             'signature': 'sig' * 22,
@@ -511,7 +511,7 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertEqual(data['absorbed_fee_nrtc'], 500)
         self.assertEqual(data['absorbed_fee_rtc'], self._rtc_float(500))
         self.assertEqual(self.utxo_db.get_balance(sender), 0)
-        self.assertEqual(self.utxo_db.get_balance('bob'), 100 * UNIT)
+        self.assertEqual(self.utxo_db.get_balance(('RTC' + 'b' * 40)), 100 * UNIT)
 
         conn = self.utxo_db._conn()
         try:
@@ -530,7 +530,7 @@ class TestUtxoEndpoints(unittest.TestCase):
 
         r = self.client.post('/utxo/transfer', json={
             'from_address': sender,
-            'to_address': 'bob',
+            'to_address': ('RTC' + 'b' * 40),
             'amount_rtc': 100.0,
             'fee_rtc': self._rtc_float(requested_fee_nrtc),
             'public_key': 'aabbccdd' * 8,
@@ -559,7 +559,7 @@ class TestUtxoEndpoints(unittest.TestCase):
 
         r = self.client.post('/utxo/transfer', json={
             'from_address': 'RTC_test_aabbccdd',
-            'to_address': 'bob',
+            'to_address': ('RTC' + 'b' * 40),
             'amount_rtc': 0.1,
             'public_key': 'aabbccdd' * 8,
             'signature': 'sig' * 22,
@@ -570,7 +570,7 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertTrue(data['ok'])
 
         # Bob must have exactly 0.1 RTC = 10_000_000 nanoRTC
-        bob_bal = self.utxo_db.get_balance('bob')
+        bob_bal = self.utxo_db.get_balance(('RTC' + 'b' * 40))
         self.assertEqual(bob_bal, 10_000_000,
                          f"Expected 10_000_000 nanoRTC, got {bob_bal} "
                          f"(float truncation bug)")
@@ -578,7 +578,7 @@ class TestUtxoEndpoints(unittest.TestCase):
     def test_transfer_rejects_below_dust_amount(self):
         """Recipient outputs below DUST_THRESHOLD must be rejected cleanly."""
         sender = 'RTC_test_aabbccdd'
-        recipient = 'bob'
+        recipient = ('RTC' + 'b' * 40)
         self._seed_coinbase(sender, UNIT)
 
         r = self.client.post('/utxo/transfer', json={
@@ -600,7 +600,7 @@ class TestUtxoEndpoints(unittest.TestCase):
 
     def test_transfer_allows_exact_dust_threshold_amount(self):
         sender = 'RTC_test_aabbccdd'
-        recipient = 'bob'
+        recipient = ('RTC' + 'b' * 40)
         self._seed_coinbase(sender, UNIT)
 
         r = self.client.post('/utxo/transfer', json={
@@ -619,7 +619,7 @@ class TestUtxoEndpoints(unittest.TestCase):
 
     def test_transfer_preserves_nano_precision_above_dust_threshold(self):
         sender = 'RTC_test_aabbccdd'
-        recipient = 'bob'
+        recipient = ('RTC' + 'b' * 40)
         amount_nrtc = DUST_THRESHOLD + 3
         self._seed_coinbase(sender, UNIT)
 
@@ -649,7 +649,7 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertEqual(float(base_amount), float(mutated_amount))
 
         sender = 'RTC_test_aabbccdd'
-        recipient = 'bob'
+        recipient = ('RTC' + 'b' * 40)
         self._seed_existing_box(sender, int(mutated_amount * UNIT))
 
         signed_message = json.dumps({
@@ -693,7 +693,7 @@ class TestUtxoEndpoints(unittest.TestCase):
         before any fee handling, and balances stay untouched.
         """
         sender = 'RTC_test_aabbccdd'
-        recipient = 'bob'
+        recipient = ('RTC' + 'b' * 40)
         self._seed_coinbase(sender, 100 * UNIT)
 
         signed_message = json.dumps({
@@ -736,7 +736,7 @@ class TestUtxoEndpoints(unittest.TestCase):
         import sqlite3
 
         sender = 'RTC_test_aabbccdd'
-        recipient = 'bob'
+        recipient = ('RTC' + 'b' * 40)
         self._seed_coinbase(sender, 100 * UNIT)
 
         conn = sqlite3.connect(self.db_path)
@@ -893,7 +893,7 @@ class TestUtxoDualWrite(unittest.TestCase):
         balance was 9 RTC, letting the legacy model retain spendable value.
         """
         sender = 'RTC_test_aabbccdd'
-        recipient = 'bob'
+        recipient = ('RTC' + 'b' * 40)
         self._seed_sender(sender, rtc_amount=100)
 
         r = self.client.post('/utxo/transfer', json={
@@ -921,7 +921,7 @@ class TestUtxoDualWrite(unittest.TestCase):
     def test_dual_write_debits_absorbed_dust_fee_from_shadow_balance(self):
         """dual_write must mirror dust absorbed into the effective UTXO fee."""
         sender = 'RTC_test_aabbccdd'
-        recipient = 'bob'
+        recipient = ('RTC' + 'b' * 40)
         absorbed_fee_nrtc = 500
         self._seed_sender_nrtc(sender, 10 * UNIT + absorbed_fee_nrtc)
 
@@ -959,7 +959,7 @@ class TestUtxoDualWrite(unittest.TestCase):
 
         r = self.client.post('/utxo/transfer', json={
             'from_address': sender,
-            'to_address': 'bob',
+            'to_address': ('RTC' + 'b' * 40),
             'amount_rtc': '0.00000001',
             'fee_rtc': 0,
             'public_key': 'aabbccdd' * 8,
@@ -969,7 +969,7 @@ class TestUtxoDualWrite(unittest.TestCase):
 
         self.assertEqual(r.status_code, 400)
         self.assertIn('dual-write', r.get_json()['error'])
-        self.assertEqual(self.utxo_db.get_balance('bob'), 0)
+        self.assertEqual(self.utxo_db.get_balance(('RTC' + 'b' * 40)), 0)
         self.assertEqual(
             self._account_balance(sender),
             100 * utxo_endpoints.ACCOUNT_UNIT,
@@ -983,7 +983,7 @@ class TestUtxoDualWrite(unittest.TestCase):
         ok=True with /utxo/integrity permanently diverged.
         """
         sender = 'RTC_test_aabbccdd'
-        recipient = 'bob'
+        recipient = ('RTC' + 'b' * 40)
         self.utxo_db.apply_transaction({
             'tx_type': 'mining_reward',
             'inputs': [],

--- a/node/tests/test_dual_write_shadow_balance.py
+++ b/node/tests/test_dual_write_shadow_balance.py
@@ -109,7 +109,7 @@ class TestDualWriteShadowBalanceGuard(unittest.TestCase):
         """If sender shadow balance < transfer amount, dual-write must be
         skipped (not drive amount_i64 negative)."""
         sender = 'RTC_test_aabbccdd'
-        recipient = 'RTC_test_eeffgghh'
+        recipient = 'RTC' + 'e' * 40  # canonical form; recipients are format-checked since #2819
 
         # Seed UTXO with 100 RTC
         self._seed_coinbase(sender, 100 * UNIT)
@@ -148,7 +148,7 @@ class TestDualWriteShadowBalanceGuard(unittest.TestCase):
         """If sender has no row in balances at all, dual-write must be
         skipped (shadow_balance = 0 < amount)."""
         sender = 'RTC_test_aabbccdd'
-        recipient = 'RTC_test_eeffgghh'
+        recipient = 'RTC' + 'e' * 40  # canonical form; recipients are format-checked since #2819
 
         self._seed_coinbase(sender, 100 * UNIT)
 
@@ -177,7 +177,7 @@ class TestDualWriteShadowBalanceGuard(unittest.TestCase):
     def test_dual_write_succeeds_when_shadow_sufficient(self):
         """Normal dual-write path still works when shadow balance is enough."""
         sender = 'RTC_test_aabbccdd'
-        recipient = 'RTC_test_eeffgghh'
+        recipient = 'RTC' + 'e' * 40  # canonical form; recipients are format-checked since #2819
 
         self._seed_coinbase(sender, 100 * UNIT)
 
@@ -211,7 +211,7 @@ class TestDualWriteShadowBalanceGuard(unittest.TestCase):
     def test_dual_write_exact_balance_goes_to_zero(self):
         """Transferring exactly the shadow balance should succeed (goes to 0)."""
         sender = 'RTC_test_aabbccdd'
-        recipient = 'RTC_test_eeffgghh'
+        recipient = 'RTC' + 'e' * 40  # canonical form; recipients are format-checked since #2819
 
         self._seed_coinbase(sender, 100 * UNIT)
 
@@ -241,7 +241,7 @@ class TestDualWriteShadowBalanceGuard(unittest.TestCase):
         """When dual-write is skipped due to insufficient shadow balance,
         no ledger entries should be created."""
         sender = 'RTC_test_aabbccdd'
-        recipient = 'RTC_test_eeffgghh'
+        recipient = 'RTC' + 'e' * 40  # canonical form; recipients are format-checked since #2819
 
         self._seed_coinbase(sender, 100 * UNIT)
 
@@ -326,7 +326,7 @@ class TestDualWriteShadowBalanceGuardDisabled(unittest.TestCase):
         """UTXO transfer succeeds regardless of shadow balance when
         dual_write=False."""
         sender = 'RTC_test_aabbccdd'
-        recipient = 'RTC_test_eeffgghh'
+        recipient = 'RTC' + 'e' * 40  # canonical form; recipients are format-checked since #2819
         self._seed_coinbase(sender, 100 * UNIT)
 
         r = self.client.post('/utxo/transfer', json={
@@ -348,3 +348,48 @@ class TestDualWriteShadowBalanceGuardDisabled(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestTransferRecipientFormat(unittest.TestCase):
+    """#2819 (reported by @antoleod): a non-canonical to_address must be rejected
+    before signature verification or any state mutation, or the RTC lands in a
+    box no wallet key can ever spend."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        self.db_path = self.tmp.name
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("CREATE TABLE IF NOT EXISTS balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER DEFAULT 0, balance_rtc REAL DEFAULT 0)")
+        conn.execute("CREATE TABLE IF NOT EXISTS ledger (ts INTEGER, epoch INTEGER, miner_id TEXT, delta_i64 INTEGER, reason TEXT)")
+        conn.commit(); conn.close()
+        self.utxo_db = UtxoDB(self.db_path); self.utxo_db.init_tables()
+        self.app = Flask(__name__); self.app.config['TESTING'] = True
+        register_utxo_blueprint(self.app, self.utxo_db, self.db_path,
+                                verify_sig_fn=mock_verify_sig, addr_from_pk_fn=mock_addr_from_pk,
+                                current_slot_fn=mock_current_slot, dual_write=False)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        try: os.unlink(self.db_path)
+        except OSError: pass
+
+    def _post(self, to_address):
+        pk = 'aa' * 32
+        return self.client.post('/utxo/transfer', json={
+            'from_address': mock_addr_from_pk(pk), 'to_address': to_address,
+            'amount_rtc': '0.1', 'fee_rtc': '0', 'nonce': 1,
+            'public_key': pk, 'signature': 'bb' * 64,
+        })
+
+    def test_rejects_arbitrary_string_recipient(self):
+        for bad in ('not-a-wallet', 'RTC' + 'g' * 40, 'RTC' + 'a' * 39, 'rtc' + 'a' * 40, 'bcn_something'):
+            resp = self._post(bad)
+            self.assertEqual(resp.status_code, 400, bad)
+            self.assertEqual(resp.get_json()['error'], 'invalid_to_address_format', bad)
+        self.assertEqual(self.utxo_db.get_balance('not-a-wallet') if hasattr(self.utxo_db, 'get_balance') else 0, 0)
+
+    def test_canonical_recipient_passes_format_check(self):
+        resp = self._post('RTC' + 'c' * 40)
+        # Anything but the format error: the request proceeds to the normal path.
+        self.assertNotEqual((resp.get_json() or {}).get('error'), 'invalid_to_address_format')

--- a/node/tests/test_dual_write_unit_mismatch.py
+++ b/node/tests/test_dual_write_unit_mismatch.py
@@ -82,7 +82,7 @@ class TestUtxoSignatureDomain(unittest.TestCase):
     def _payload(self, nonce=123):
         return {
             'from_address': 'RTC_test_aabbccdd',
-            'to_address': 'RTC_test_eeffgghh',
+            'to_address': ('RTC' + 'e' * 40),
             'amount_rtc': 10.0,
             'public_key': 'aabbccdd' * 8,
             'signature': 'sig' * 22,
@@ -98,7 +98,7 @@ class TestUtxoSignatureDomain(unittest.TestCase):
             signed = json.loads(message.decode())
             return (
                 signed.get('from') == sender
-                and signed.get('to') == 'RTC_test_eeffgghh'
+                and signed.get('to') == ('RTC' + 'e' * 40)
                 and signed.get('amount') == 10.0
                 and signed.get('memo') == ''
                 and signed.get('nonce') == 123
@@ -117,7 +117,7 @@ class TestUtxoSignatureDomain(unittest.TestCase):
 
     def test_utxo_domain_signature_still_authorizes_transfer(self):
         sender = 'RTC_test_aabbccdd'
-        recipient = 'RTC_test_eeffgghh'
+        recipient = 'RTC' + 'e' * 40  # canonical form; recipients are format-checked since #2819
         self._seed_coinbase(sender, 100 * UNIT)
 
         def utxo_domain_verifier(pubkey_hex, message, sig_hex):
@@ -207,7 +207,7 @@ class TestDualWriteUnitCorrectness(unittest.TestCase):
     def test_dual_write_10_rtc_equals_10_million_uRTC(self):
         """Transferring 10 RTC should write 10_000_000 uRTC, not 10_000_000_000."""
         sender = 'RTC_test_aabbccdd'
-        recipient = 'RTC_test_eeffgghh'
+        recipient = 'RTC' + 'e' * 40  # canonical form; recipients are format-checked since #2819
         self._seed_coinbase(sender, 100 * UNIT)
 
         # Seed shadow balance so dual-write can proceed (security guard requires it)
@@ -246,7 +246,7 @@ class TestDualWriteUnitCorrectness(unittest.TestCase):
     def test_dual_write_debit_matches_credit(self):
         """Sender debit and recipient credit must use the same unit."""
         sender = 'RTC_test_aabbccdd'
-        recipient = 'RTC_test_eeffgghh'
+        recipient = 'RTC' + 'e' * 40  # canonical form; recipients are format-checked since #2819
         self._seed_coinbase(sender, 100 * UNIT)
 
         # Pre-seed sender in balances table with sufficient shadow balance
@@ -278,7 +278,7 @@ class TestDualWriteUnitCorrectness(unittest.TestCase):
     def test_dual_write_fractional_rtc(self):
         """Transferring 0.001 RTC should write 1000 uRTC, not 1_000_000."""
         sender = 'RTC_test_aabbccdd'
-        recipient = 'RTC_test_eeffgghh'
+        recipient = 'RTC' + 'e' * 40  # canonical form; recipients are format-checked since #2819
         self._seed_coinbase(sender, 10 * UNIT)
 
         # Seed shadow balance so dual-write can proceed
@@ -321,7 +321,7 @@ class TestDualWriteUnitCorrectness(unittest.TestCase):
         ceiling.
         """
         sender = 'RTC_test_aabbccdd'
-        recipient = 'RTC_test_eeffgghh'
+        recipient = 'RTC' + 'e' * 40  # canonical form; recipients are format-checked since #2819
         self._seed_coinbase(sender, 20_000 * UNIT)
 
         # Seed shadow balance so dual-write can proceed
@@ -368,7 +368,7 @@ class TestDualWriteUnitCorrectness(unittest.TestCase):
         """After a dual-write, /utxo/integrity should report models_agree=true
         when UTXO and account totals match (after unit conversion)."""
         sender = 'RTC_test_aabbccdd'
-        recipient = 'RTC_test_eeffgghh'
+        recipient = 'RTC' + 'e' * 40  # canonical form; recipients are format-checked since #2819
         self._seed_coinbase(sender, 100 * UNIT)
 
         # Seed shadow balance so dual-write can proceed
@@ -424,7 +424,7 @@ class TestDualWriteUnitCorrectness(unittest.TestCase):
     def test_ledger_entries_use_correct_unit(self):
         """Ledger delta_i64 should match ACCOUNT_UNIT, not 1000x larger."""
         sender = 'RTC_test_aabbccdd'
-        recipient = 'RTC_test_eeffgghh'
+        recipient = 'RTC' + 'e' * 40  # canonical form; recipients are format-checked since #2819
         self._seed_coinbase(sender, 100 * UNIT)
 
         # Seed shadow balance so dual-write can proceed
@@ -517,7 +517,7 @@ class TestDualWriteDisabled(unittest.TestCase):
     def test_no_account_write_when_dual_write_false(self):
         """When dual_write=False, balances table should remain untouched."""
         sender = 'RTC_test_aabbccdd'
-        recipient = 'RTC_test_eeffgghh'
+        recipient = 'RTC' + 'e' * 40  # canonical form; recipients are format-checked since #2819
         self._seed_coinbase(sender, 100 * UNIT)
 
         self.client.post('/utxo/transfer', json={

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -17,6 +17,7 @@ Endpoints:
 """
 
 import json
+import re
 import sqlite3
 import time
 from decimal import Decimal, InvalidOperation
@@ -42,6 +43,9 @@ _BOXES_MAX_LIMIT = 500
 # would raise OverflowError at parameter binding (a 500) instead of a clean 400.
 _INT64_MAX = (1 << 63) - 1
 _NONCE_MAX_DIGITS = len(str(_INT64_MAX))
+
+_CANONICAL_RTC_ADDRESS_RE = re.compile(r"RTC[0-9a-fA-F]{40}")
+
 
 
 def _parse_rtc_amount(raw) -> Decimal:
@@ -576,6 +580,16 @@ def utxo_transfer():
     to_address, error_response = _transfer_string_field(data, 'to_address')
     if error_response:
         return error_response
+    # SECURITY (#2819, reported by @antoleod): the sender is bound to its public
+    # key below, but the recipient was accepted as any non-empty string. A typo
+    # or hostile value such as "not-a-wallet" became a persisted box owner that
+    # no wallet key can ever spend, permanently locking the RTC. Require the
+    # canonical RTC + 40 hex form before signature checks or state mutation.
+    if not _CANONICAL_RTC_ADDRESS_RE.fullmatch(to_address):
+        return jsonify({
+            'error': 'invalid_to_address_format',
+            'message': 'to_address must be a canonical RustChain address: RTC followed by 40 hex characters',
+        }), 400
     public_key, error_response = _transfer_string_field(data, 'public_key')
     if error_response:
         return error_response

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -580,16 +580,6 @@ def utxo_transfer():
     to_address, error_response = _transfer_string_field(data, 'to_address')
     if error_response:
         return error_response
-    # SECURITY (#2819, reported by @antoleod): the sender is bound to its public
-    # key below, but the recipient was accepted as any non-empty string. A typo
-    # or hostile value such as "not-a-wallet" became a persisted box owner that
-    # no wallet key can ever spend, permanently locking the RTC. Require the
-    # canonical RTC + 40 hex form before signature checks or state mutation.
-    if not _CANONICAL_RTC_ADDRESS_RE.fullmatch(to_address):
-        return jsonify({
-            'error': 'invalid_to_address_format',
-            'message': 'to_address must be a canonical RustChain address: RTC followed by 40 hex characters',
-        }), 400
     public_key, error_response = _transfer_string_field(data, 'public_key')
     if error_response:
         return error_response
@@ -619,6 +609,17 @@ def utxo_transfer():
             'error': 'Missing required fields',
             'required': ['from_address', 'to_address', 'public_key',
                          'signature', 'nonce']
+        }), 400
+
+    # SECURITY (#2819, reported by @antoleod): the sender is bound to its public
+    # key below, but the recipient was accepted as any non-empty string. A typo
+    # or hostile value such as "not-a-wallet" became a persisted box owner that
+    # no wallet key can ever spend, permanently locking the RTC. Require the
+    # canonical RTC + 40 hex form before signature checks or state mutation.
+    if not _CANONICAL_RTC_ADDRESS_RE.fullmatch(to_address):
+        return jsonify({
+            'error': 'invalid_to_address_format',
+            'message': 'to_address must be a canonical RustChain address: RTC followed by 40 hex characters',
         }), 400
 
     if amount_rtc <= 0:

--- a/tests/test_utxo_dual_write_double_spend.py
+++ b/tests/test_utxo_dual_write_double_spend.py
@@ -47,7 +47,7 @@ from utxo_endpoints import register_utxo_blueprint
 NRTC_PER_ACCOUNT_UNIT = UNIT // 1_000_000  # 100
 
 ALICE = "RTC_test_aabbccdd"
-RECEIVER = "RTC_test_receiver0"
+RECEIVER = "RTC" + "f" * 40  # canonical recipient; format-checked since #2819
 PUBKEY = "aabbccdd" * 8
 GENESIS_HEIGHT = 0
 

--- a/tests/test_utxo_legacy_signature_deadline.py
+++ b/tests/test_utxo_legacy_signature_deadline.py
@@ -74,7 +74,7 @@ def seed_coinbase(utxo_db, address, value_nrtc):
 def transfer_payload(signature, fee_rtc=1.0):
     return {
         "from_address": "RTC_test_aabbccdd",
-        "to_address": "bob",
+        "to_address": "RTC" + "b" * 40,
         "amount_rtc": 10.0,
         "fee_rtc": fee_rtc,
         "public_key": "aabbccdd" * 8,
@@ -92,7 +92,7 @@ def test_account_style_signature_is_rejected_on_utxo_endpoint(tmp_path):
     assert response.status_code == 401
     assert response.get_json()["code"] == "UTXO_SIGNATURE_DOMAIN_REQUIRED"
     assert utxo_db.get_balance("RTC_test_aabbccdd") == 100 * UNIT
-    assert utxo_db.get_balance("bob") == 0
+    assert utxo_db.get_balance(("RTC" + "b" * 40)) == 0
 
 
 def test_account_style_signature_with_fee_is_rejected_for_domain(tmp_path):
@@ -103,7 +103,7 @@ def test_account_style_signature_with_fee_is_rejected_for_domain(tmp_path):
     assert response.status_code == 401
     assert response.get_json()["code"] == "UTXO_SIGNATURE_DOMAIN_REQUIRED"
     assert utxo_db.get_balance("RTC_test_aabbccdd") == 100 * UNIT
-    assert utxo_db.get_balance("bob") == 0
+    assert utxo_db.get_balance(("RTC" + "b" * 40)) == 0
 
 
 def test_utxo_domain_signature_still_accepts_fee(tmp_path):
@@ -113,4 +113,4 @@ def test_utxo_domain_signature_still_accepts_fee(tmp_path):
 
     assert response.status_code == 200
     assert response.get_json()["ok"] is True
-    assert utxo_db.get_balance("bob") == 10 * UNIT
+    assert utxo_db.get_balance(("RTC" + "b" * 40)) == 10 * UNIT

--- a/tests/test_utxo_malformed_pubkey_6114.py
+++ b/tests/test_utxo_malformed_pubkey_6114.py
@@ -43,7 +43,7 @@ def test_malformed_public_key_returns_400(client):
     """Non-hex public_key should return 400, not 500."""
     resp = client.post("/utxo/transfer", json={
         "from_address": "RTC1aaaa",
-        "to_address": "RTC1bbbb",
+        "to_address": "RTC" + "b" * 40,
         "public_key": "not-hex-at-all!!",
         "signature": "abcd1234",
         "nonce": "n1",
@@ -58,7 +58,7 @@ def test_short_public_key_returns_400(client):
     """Too-short hex public_key should return 400."""
     resp = client.post("/utxo/transfer", json={
         "from_address": "RTC1aaaa",
-        "to_address": "RTC1bbbb",
+        "to_address": "RTC" + "b" * 40,
         "public_key": "abcd",
         "signature": "abcd1234",
         "nonce": "n1",
@@ -72,7 +72,7 @@ def test_valid_hex_length_passes_hex_check(client):
     valid_pk = "a" * 64
     resp = client.post("/utxo/transfer", json={
         "from_address": "RTC1aaaa",
-        "to_address": "RTC1bbbb",
+        "to_address": "RTC" + "b" * 40,
         "public_key": valid_pk,
         "signature": "b" * 128,
         "nonce": "n1",

--- a/tests/test_utxo_transfer_nonce_required.py
+++ b/tests/test_utxo_transfer_nonce_required.py
@@ -74,7 +74,7 @@ def seed_coinbase(utxo_db, address, value_nrtc, height=1):
 def payload(nonce=1733420000000, amount_rtc=10.0):
     return {
         "from_address": "RTC_test_aabbccdd",
-        "to_address": "bob",
+        "to_address": "RTC" + "b" * 40,
         "amount_rtc": amount_rtc,
         "public_key": "aabbccdd" * 8,
         "signature": "sig" * 22,

--- a/tests/test_utxo_transfer_replay.py
+++ b/tests/test_utxo_transfer_replay.py
@@ -73,7 +73,7 @@ def seed_coinbase(utxo_db, address, value_nrtc, height=1):
 def payload(nonce=1733420000000, amount_rtc=10.0):
     return {
         "from_address": "RTC_test_aabbccdd",
-        "to_address": "bob",
+        "to_address": "RTC" + "b" * 40,
         "amount_rtc": amount_rtc,
         "public_key": "aabbccdd" * 8,
         "signature": "sig" * 22,
@@ -105,7 +105,7 @@ def test_utxo_transfer_rejects_duplicate_nonce():
         assert body["code"] == "REPLAY_DETECTED"
         assert "Nonce already used" in body["error"]
 
-        assert utxo_db.get_balance("bob") == 10 * UNIT
+        assert utxo_db.get_balance(("RTC" + "b" * 40)) == 10 * UNIT
 
         assert nonce_count(db_path) == 1
     finally:
@@ -130,6 +130,6 @@ def test_utxo_transfer_failed_attempt_does_not_burn_nonce():
         assert accepted.get_json()["ok"] is True
 
         assert nonce_count(db_path) == 1
-        assert utxo_db.get_balance("bob") == 10 * UNIT
+        assert utxo_db.get_balance(("RTC" + "b" * 40)) == 10 * UNIT
     finally:
         os.unlink(db_path)

--- a/tests/test_utxo_transfer_spends_account_mirror.py
+++ b/tests/test_utxo_transfer_spends_account_mirror.py
@@ -36,6 +36,7 @@ from utxo_db import UtxoDB, UNIT
 from utxo_endpoints import register_utxo_blueprint
 
 ALICE = "RTC_test_aabbccdd"
+RECIPIENT = "RTC" + "c" * 40  # canonical recipient; format-checked since #2819
 PUBKEY = "aabbccdd" * 8
 GENESIS_HEIGHT = 0
 
@@ -111,7 +112,7 @@ def rig():
     return app.test_client(), utxo_db, db_path
 
 
-def _transfer(client, to_address=ALICE, amount_rtc=99.0, nonce=1733420000000):
+def _transfer(client, to_address=RECIPIENT, amount_rtc=99.0, nonce=1733420000000):
     return client.post("/utxo/transfer", json={
         "from_address": ALICE,
         "to_address": to_address,
@@ -180,7 +181,7 @@ def test_independently_earned_boxes_are_unaffected(rig):
 
     resp = client.post("/utxo/transfer", json={
         "from_address": mock_addr_from_pk("deadbeef" * 8),
-        "to_address": ALICE,
+        "to_address": RECIPIENT,
         "amount_rtc": 10.0,
         "public_key": "deadbeef" * 8,
         "signature": "bb" * 64,
@@ -227,7 +228,7 @@ def test_non_mirror_box_spends_when_same_wallet_also_has_small_mirror(rig):
 
     resp = _transfer(
         client,
-        to_address="RTC_test_receiver",
+        to_address="RTC" + "d" * 40,
         amount_rtc=10.0,
         nonce=1733420000002,
     )
@@ -235,6 +236,6 @@ def test_non_mirror_box_spends_when_same_wallet_also_has_small_mirror(rig):
     assert resp.status_code == 200, resp.get_json()
     data = resp.get_json()
     assert data["inputs_consumed"] == 1
-    assert data["to_address"] == "RTC_test_receiver"
-    assert utxo_db.get_balance("RTC_test_receiver") == 10 * UNIT
+    assert data["to_address"] == "RTC" + "d" * 40
+    assert utxo_db.get_balance("RTC" + "d" * 40) == 10 * UNIT
     assert _unspent_mirror_value(db_path, ALICE) == 1 * UNIT


### PR DESCRIPTION
Finding by @antoleod (rustchain-bounties#2819 Low, 25 RTC paid): `/utxo/transfer` binds `from_address` to the public key but accepted **any non-empty string** as `to_address`, so `"not-a-wallet"` became a persisted box owner no key can ever spend.

Fix: `to_address` must fullmatch `RTC[0-9a-fA-F]{40}`, checked before signature verification or any state mutation; `400 invalid_to_address_format` otherwise. Two regression tests (rejects arbitrary string, wrong length, non-hex, lowercase prefix, `bcn_`; canonical passes the format gate).

Test note: the dual-write fixtures sent the mock recipient `RTC_test_eeffgghh`; they now use a canonical address. **Three failures in `test_dual_write_shadow_balance.py` (409 on shadow-balance paths) pre-exist on main** — verified by running the file with this change stashed — and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RDgENXHE8sjiekfdvw3jn