### PR TITLE
fix(signed-transfer): require chain_id binding to close cross-network replay

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -13515,6 +13515,35 @@ def wallet_transfer_signed():
             "got_chain_id": chain_id,
         }), 400
 
+    # SECURITY (cross-network replay): when chain_id is provided it is bound into
+    # the signed message (see _wallet_transfer_signed_messages) and matched above.
+    # But it was OPTIONAL: a client that OMITS chain_id signs a chain-less message
+    # with NO network binding, so the SAME signature is valid on every RustChain
+    # network (testnet <-> mainnet, forks). With cross-network key reuse (the norm),
+    # a low-value transfer signed on one network replays on another to move real
+    # funds. Require chain binding by default; the destination is in the signed
+    # message so this is the last gap. RC_ALLOW_CHAINLESS_SIGNED_TRANSFER=1 is an
+    # explicit, logged transition escape hatch for operators mid client-migration
+    # (clients that do not yet include chain_id) — flip it back off once clients
+    # sign with chain_id.
+    _allow_chainless = os.environ.get("RC_ALLOW_CHAINLESS_SIGNED_TRANSFER", "0") == "1"
+    if not chain_id:
+        if not _allow_chainless:
+            return jsonify({
+                "error": "chain_id required",
+                "code": "CHAIN_ID_REQUIRED",
+                "message": "Signed transfers must bind the active chain_id to prevent "
+                           "cross-network replay. Include chain_id in the signed "
+                           "transaction and request.",
+                "expected_chain_id": CHAIN_ID,
+            }), 400
+        logging.warning(
+            "signed transfer accepted WITHOUT chain_id binding (from=%s nonce=%s) — "
+            "RC_ALLOW_CHAINLESS_SIGNED_TRANSFER is set; this is cross-network "
+            "replayable. Migrate clients to include chain_id and disable the flag.",
+            from_address, nonce_int,
+        )
+
     # Verify public key matches from_address
     # Support bcn_ beacon addresses: resolve pubkey from Beacon Atlas
     if is_bcn_address(from_address):

--- a/node/tests/test_signed_transfer_chain_id_required.py
+++ b/node/tests/test_signed_transfer_chain_id_required.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: MIT
+"""Regression: /wallet/transfer/signed must bind chain_id to prevent cross-network
+replay.
+
+chain_id was OPTIONAL and only bound into the signed message `if chain_id:`. A
+client that OMITTED it signed a chain-less message with no network binding, so the
+same signature replays across networks (testnet <-> mainnet, forks) — real theft
+under the common case of cross-network key reuse. The fix requires chain binding by
+default, with RC_ALLOW_CHAINLESS_SIGNED_TRANSFER=1 as an explicit transition hatch.
+
+The chain_id gate runs BEFORE signature verification (right after the review gate),
+so these tests reach it with a dummy signature, like the blocked-wallet freeze test.
+"""
+import gc
+import importlib.util
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+SENDER = "RTC" + "c" * 40   # valid form, NOT under review -> passes the review gate
+DEST = "RTC" + "d" * 40
+
+
+class TestSignedTransferChainIdRequired(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.mkdtemp(prefix="chainid-")
+        cls._prev = {k: os.environ.get(k) for k in
+                     ("RUSTCHAIN_DB_PATH", "RC_ADMIN_KEY", "RC_ALLOW_CHAINLESS_SIGNED_TRANSFER")}
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._tmp, "import.db")
+        os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
+        os.environ.pop("RC_ALLOW_CHAINLESS_SIGNED_TRANSFER", None)
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+        spec = importlib.util.spec_from_file_location("rc_chainid_test", MODULE_PATH)
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+        cls.client = cls.mod.app.test_client()
+        # ensure review tables exist + empty (SENDER not blocked)
+        with sqlite3.connect(cls.mod.DB_PATH) as conn:
+            cls.mod.ensure_wallet_review_tables(conn)
+            conn.commit()
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.mod.app.do_teardown_appcontext()
+        except Exception:
+            pass
+        cls.client = None
+        cls.mod = None
+        for k, v in cls._prev.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        gc.collect()
+        shutil.rmtree(cls._tmp, ignore_errors=True)
+
+    def _post(self, chain_id=None, nonce=None):
+        body = {
+            "from_address": SENDER,
+            "to_address": DEST,
+            "amount_rtc": 1,
+            "nonce": nonce if nonce is not None else int(time.time() * 1000),
+            "signature": "00",           # dummy — the chain_id gate is reached first
+            "public_key": "00" * 32,
+        }
+        if chain_id is not None:
+            body["chain_id"] = chain_id
+        return self.client.post("/wallet/transfer/signed", json=body)
+
+    def test_chainless_rejected_by_default(self):
+        os.environ.pop("RC_ALLOW_CHAINLESS_SIGNED_TRANSFER", None)
+        resp = self._post(chain_id=None)
+        self.assertEqual(resp.status_code, 400, resp.get_json())
+        self.assertEqual(resp.get_json().get("code"), "CHAIN_ID_REQUIRED")
+
+    def test_wrong_chain_id_rejected(self):
+        resp = self._post(chain_id="rustchain-not-a-real-network")
+        self.assertEqual(resp.status_code, 400, resp.get_json())
+        self.assertIn("does not match", resp.get_json().get("error", ""))
+
+    def test_correct_chain_id_passes_gate(self):
+        """Correct chain_id must get PAST the chain gate (then fail downstream at
+        pubkey/signature, since the dummy key/sig don't match) — not CHAIN_ID_REQUIRED."""
+        resp = self._post(chain_id=self.mod.CHAIN_ID)
+        self.assertNotEqual(resp.get_json().get("code"), "CHAIN_ID_REQUIRED")
+        # downstream rejection (pubkey mismatch / invalid signature), gate passed
+        self.assertIn(resp.status_code, (400, 401))
+
+    def test_transition_flag_allows_chainless(self):
+        os.environ["RC_ALLOW_CHAINLESS_SIGNED_TRANSFER"] = "1"
+        try:
+            resp = self._post(chain_id=None)
+            self.assertNotEqual(resp.get_json().get("code"), "CHAIN_ID_REQUIRED",
+                                "flag set: chain-less must pass the gate")
+            self.assertIn(resp.status_code, (400, 401))  # fails later at sig, not the gate
+        finally:
+            os.environ.pop("RC_ALLOW_CHAINLESS_SIGNED_TRANSFER", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/node/tests/test_wallet_transfer_signed_no_pubkey_disclosure.py
+++ b/node/tests/test_wallet_transfer_signed_no_pubkey_disclosure.py
@@ -108,6 +108,11 @@ class TestWalletTransferSignedNoPubkeyDisclosure(unittest.TestCase):
         cls._tmp.cleanup()
 
     def _post(self, body):
+        # Signed transfers now require chain_id binding (cross-network replay fix).
+        # These tests exercise the DOWNSTREAM pubkey-mismatch non-disclosure path,
+        # so bind the active chain_id to get past the chain gate to their subject.
+        if "chain_id" not in body:
+            body = {**body, "chain_id": self.mod.CHAIN_ID}
         return self.client.post(
             "/wallet/transfer/signed",
             json=body,


### PR DESCRIPTION
Closes the cross-network replay gap in `/wallet/transfer/signed` (the #3 residual from the money-path sweep).

### The bug
`_wallet_transfer_signed_messages` bound `chain_id` into the signed message only `if chain_id:`, and `chain_id` was **optional** in the request. A client that **omitted** it signed a chain-less canonical message with **no network binding** — so the identical signature verifies on **every** RustChain network (testnet ↔ mainnet, any fork). With cross-network key reuse (the norm — same keypair on testnet and mainnet), a low-value transfer signed on one network **replays on another to move real funds**. The per-DB `(from_address, nonce)` replay guard doesn't span networks. When the client *did* send `chain_id` it was already bound and matched (existing check), so the gap was specifically the omit case.

### Fix
Require chain_id binding **by default**:
- A missing `chain_id` → `400 CHAIN_ID_REQUIRED`. The check runs right after the review gate, before signature verification.
- `RC_ALLOW_CHAINLESS_SIGNED_TRANSFER=1` is an explicit, **logged** transition escape hatch for operators mid client-migration; every chain-less acceptance under the flag logs a warning naming the exposure.

### Tests
- `node/tests/test_signed_transfer_chain_id_required.py`: chain-less rejected by default; wrong chain_id rejected; correct chain_id passes the gate; transition flag re-enables chain-less. The default-reject test **fails on `origin/main`** (bug present), passes here.
- Updated `test_wallet_transfer_signed_no_pubkey_disclosure.py` to bind chain_id in its shared `_post` helper so those tests still reach the downstream pubkey-mismatch path they cover (otherwise they'd trivially hit the new gate).
- All signed-endpoint suites pass (**25**), including preflight and blocked-wallet freeze.

### ⚠️ Client-coordinated rollout
This rejects chain-less signed transfers by default, so it needs a client cutoff. Operators whose wallet clients don't yet include `chain_id` must set `RC_ALLOW_CHAINLESS_SIGNED_TRANSFER=1` during migration, then disable it once clients sign with `chain_id`. **Not deployed — operator controls rollout.** (This is the "client-coordinated cutoff" the original finding called for.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbyXP4eiiRYEa8GsQtQPhR