### PR TITLE
fix(utxo): exclude account-mirror boxes before candidate bounding (closes #8395)

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -802,6 +802,96 @@ class TestUtxoEndpoints(unittest.TestCase):
                 self.assertNotIn(recipient, balances)
                 self.assertEqual(ledger_count, 0)
 
+    def test_coin_select_candidates_exclude_mirror_boxes_before_bounding(self):
+        """Fix #8395 regression test:
+        1 mirror box (1,000,000 nRTC) + 20 independent boxes (100,000...99,981) + 21 small boxes (1,000...1,020).
+        Transfer target: 1,999,810 nRTC.
+        Mirror box must be filtered out at candidate SQL level so the 20 independent boxes
+        fill the bounded dearest slice and successfully fund the transfer without false 409.
+        """
+        sender = 'RTC_test_aabbccdd'
+        recipient = ('RTC' + 'c' * 40)
+
+        # 1 mirror box
+        mirror_box = {
+            'box_id': 'mirror_box_1',
+            'value_nrtc': 1_000_000,
+            'owner_address': sender,
+            'proposition': address_to_proposition(sender),
+            'creation_height': 1,
+            'transaction_id': 'tx_mirror',
+            'output_index': 0,
+        }
+        self.utxo_db.add_box(mirror_box)
+
+        # Create account_mirror_boxes table and record mirror box
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS account_mirror_boxes (
+                    box_id TEXT PRIMARY KEY, account_wallet TEXT NOT NULL,
+                    value_nrtc INTEGER NOT NULL, created_epoch INTEGER NOT NULL)"""
+            )
+            conn.execute(
+                "INSERT INTO account_mirror_boxes (box_id, account_wallet, value_nrtc, created_epoch) "
+                "VALUES (?, ?, ?, 0)",
+                ('mirror_box_1', sender, 1_000_000),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # 20 independent boxes of 100,000 ... 99,981 (sum = 1,999,810)
+        for i, val in enumerate(range(100_000, 99_980, -1)):
+            self.utxo_db.add_box({
+                'box_id': f'indep_box_{i}',
+                'value_nrtc': val,
+                'owner_address': sender,
+                'proposition': address_to_proposition(sender),
+                'creation_height': 1,
+                'transaction_id': f'tx_indep_{i}',
+                'output_index': 0,
+            })
+
+        # 21 small boxes of 1,000 ... 1,020
+        for i, val in enumerate(range(1_000, 1_021)):
+            self.utxo_db.add_box({
+                'box_id': f'small_box_{i}',
+                'value_nrtc': val,
+                'owner_address': sender,
+                'proposition': address_to_proposition(sender),
+                'creation_height': 1,
+                'transaction_id': f'tx_small_{i}',
+                'output_index': 0,
+            })
+
+        # Verify candidate selection directly: mirror must NOT be present
+        candidates = self.utxo_db.get_coin_select_candidates(sender)
+        candidate_ids = {c['box_id'] for c in candidates}
+        self.assertNotIn('mirror_box_1', candidate_ids)
+
+        # Perform transfer requesting exactly 1,999,810 nRTC
+        target_rtc = 1_999_810 / Decimal(UNIT)
+        r = self.client.post('/utxo/transfer', json={
+            'from_address': sender,
+            'to_address': recipient,
+            'amount_rtc': str(target_rtc),
+            'fee_rtc': 0,
+            'public_key': 'aabbccdd' * 8,
+            'signature': 'sig' * 22,
+            'nonce': int(time.time() * 1000) + 12345,
+        })
+        self.assertEqual(r.status_code, 200, r.get_json())
+        data = r.get_json()
+        self.assertEqual(data['inputs_consumed'], 20)
+
+        # Verify mirror box is untouched
+        with sqlite3.connect(self.db_path) as c:
+            spent = c.execute(
+                "SELECT spent_at FROM utxo_boxes WHERE box_id = 'mirror_box_1'"
+            ).fetchone()[0]
+            self.assertIsNone(spent, "Mirror box must remain unspent")
+
 
 class TestUtxoDualWrite(unittest.TestCase):
 

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -500,6 +500,21 @@ class UtxoDB:
         self.mempool_clear_expired()
         conn = self._conn()
         try:
+            # FIX(#8395): Exclude account-mirror boxes before bounding cheapest
+            # and dearest candidates. When a mirror box occupies a slice slot it
+            # hides the next eligible box outside the slice, causing coin_select
+            # to fail on a wallet with sufficient spendable boxes.
+            has_mirror_table = bool(
+                conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='account_mirror_boxes'"
+                ).fetchone()
+            )
+            if has_mirror_table:
+                base += """ AND NOT EXISTS (
+                        SELECT 1 FROM account_mirror_boxes amb
+                        WHERE amb.box_id = utxo_boxes.box_id
+                    )"""
+
             # Smallest-first needs one extra row: it is the row that proves the
             # selection would have exceeded the cap, sending coin_select() down
             # its largest-first path.

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -747,20 +747,18 @@ def utxo_transfer():
     # slice of a wallet, so loading every unspent box let a third party inflate
     # the cost of this call by sending dust to the sender's address.
     utxos = _utxo_db.get_coin_select_candidates(from_address)
-    all_candidate_total_nrtc = sum(u['value_nrtc'] for u in utxos)
-    # SECURITY(danaher-j / #2819 residual): exclude account-mirror boxes from
-    # UTXO coin selection in BOTH dual-write states. Under UTXO_DUAL_WRITE=1 the
-    # /utxo/transfer path mints receiver+change outputs with NO
-    # account_mirror_boxes provenance; a later rollback to dual_write=0 then
-    # leaves that migrated value spendable through BOTH the UTXO and account
-    # models (double spend). Migrated funds must always move via the account
-    # path, so the mirror-box exclusion cannot be gated on dual-write.
+    # SECURITY(danaher-j / #2819 residual, #8395): account-mirror boxes are
+    # excluded inside get_coin_select_candidates() before candidate bounding.
+    # We keep _spendable_utxo_candidates() as defense-in-depth and compute
+    # total spendable candidates post-filter so mirror boxes cannot cause a
+    # false 409 ACCOUNT_MIRROR_BOX_NOT_SPENDABLE.
     mirror_candidate_ids = []
     conn = sqlite3.connect(_db_path)
     try:
         utxos, mirror_candidate_ids = _spendable_utxo_candidates(conn, utxos)
     finally:
         conn.close()
+    all_candidate_total_nrtc = sum(u['value_nrtc'] for u in utxos)
     selected, change_nrtc = coin_select(utxos, target_nrtc)
 
     if not selected:


### PR DESCRIPTION
Closes #8395

### Problem
`UtxoDB.get_coin_select_candidates(from_address)` bounded candidates into cheapest (`max_inputs + 1`) and dearest (`max_inputs`) slices before `_spendable_utxo_candidates()` in `/utxo/transfer` stripped account-mirror boxes. When an account-mirror box occupied a slice slot, it pushed eligible spendable boxes outside the bounded window. Furthermore, `all_candidate_total_nrtc` was summed before filtering out mirror boxes, triggering a false `409 ACCOUNT_MIRROR_BOX_NOT_SPENDABLE` when spendable boxes could have funded the transaction.

### Solution
- Exclude boxes recorded in `account_mirror_boxes` directly inside `UtxoDB.get_coin_select_candidates()` before taking the `ORDER BY ... LIMIT` slices (with graceful check for table existence).
- Keep `_spendable_utxo_candidates()` in `utxo_endpoints.py` as defense-in-depth and compute `all_candidate_total_nrtc` on the filtered spendable set.
- Retain the existing in-transaction recheck under `BEGIN IMMEDIATE` against concurrent migrations.
- Add deterministic regression test reproducing the 42-box scenario in `node/test_utxo_endpoints.py`.