### PR TITLE
fix(nginx): proxy /ready and /api/nodes to node backend (closes #8389)

### DIFF
--- a/site/nginx-rustchain-org.conf
+++ b/site/nginx-rustchain-org.conf
@@ -28,6 +28,12 @@ server {
         add_header Access-Control-Allow-Origin "*" always;
     }
 
+    location /ready {
+        proxy_pass http://127.0.0.1:8099/ready;
+        proxy_set_header Host $host;
+        add_header Access-Control-Allow-Origin "*" always;
+    }
+
     location /epoch {
         proxy_pass http://127.0.0.1:8099/epoch;
         proxy_set_header Host $host;
@@ -42,6 +48,12 @@ server {
 
     location /api/stats {
         proxy_pass http://127.0.0.1:8099/api/stats;
+        proxy_set_header Host $host;
+        add_header Access-Control-Allow-Origin "*" always;
+    }
+
+    location /api/nodes {
+        proxy_pass http://127.0.0.1:8099/api/nodes;
         proxy_set_header Host $host;
         add_header Access-Control-Allow-Origin "*" always;
     }
@@ -357,6 +369,12 @@ server {
         add_header Access-Control-Allow-Origin "*" always;
     }
 
+    location /ready {
+        proxy_pass http://127.0.0.1:8099/ready;
+        proxy_set_header Host $host;
+        add_header Access-Control-Allow-Origin "*" always;
+    }
+
     location /epoch {
         proxy_pass http://127.0.0.1:8099/epoch;
         proxy_set_header Host $host;
@@ -371,6 +389,12 @@ server {
 
     location /api/stats {
         proxy_pass http://127.0.0.1:8099/api/stats;
+        proxy_set_header Host $host;
+        add_header Access-Control-Allow-Origin "*" always;
+    }
+
+    location /api/nodes {
+        proxy_pass http://127.0.0.1:8099/api/nodes;
         proxy_set_header Host $host;
         add_header Access-Control-Allow-Origin "*" always;
     }

--- a/tests/test_rustchain_org_nginx_config.py
+++ b/tests/test_rustchain_org_nginx_config.py
@@ -14,3 +14,15 @@ def test_rustchain_org_nginx_proxies_api_stats_in_all_server_blocks():
     assert stats_locations == miners_locations
     assert config.count("proxy_pass http://127.0.0.1:8099/api/stats;") == stats_locations
     assert config.count('add_header Access-Control-Allow-Origin "*" always;') >= stats_locations
+
+
+def test_rustchain_org_nginx_proxies_ready_and_api_nodes():
+    config = (ROOT / "site" / "nginx-rustchain-org.conf").read_text(encoding="utf-8")
+
+    ready_locations = config.count("location /ready {")
+    api_nodes_locations = config.count("location /api/nodes {")
+
+    assert ready_locations == 2
+    assert api_nodes_locations == 2
+    assert config.count("proxy_pass http://127.0.0.1:8099/ready;") == 2
+    assert config.count("proxy_pass http://127.0.0.1:8099/api/nodes;") == 2


### PR DESCRIPTION
Closes #8389

### Problem
The API documentation in `docs/API_REFERENCE.md` documents `GET /ready` and `GET /api/nodes` on `https://rustchain.org`. While the node implementation defines these routes in Flask (`@app.route('/ready')` and `@app.route('/api/nodes')`), the production nginx reverse-proxy configuration in `site/nginx-rustchain-org.conf` was missing location proxy blocks for them, returning nginx 404 HTML responses to public callers.

### Solution
- Added `location /ready` and `location /api/nodes` proxy blocks forwarding to `http://127.0.0.1:8099` in both the port 8070 (testing) and `rustchain.org` (production) server blocks of `site/nginx-rustchain-org.conf`.
- Added test coverage in `tests/test_rustchain_org_nginx_config.py` verifying both location blocks and proxy destinations are present in all server blocks.

### Verification
- Tested locally with pytest:
  ```bash
  pytest tests/test_rustchain_org_nginx_config.py
  ```
  Result: `2 passed in 0.04s`